### PR TITLE
Empty repo for tests

### DIFF
--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -15,14 +15,15 @@ def check_content_repo_exists(destination):
         return True
 
 
-def create_content_repo(remote_repo, destination):
+def create_content_repo(remote_repo, destination, work_with_remote):
     if os.path.isdir(destination):
         raise RepoAlreadyExists('Repo already exists at {}'.format(destination))
     else:
         os.mkdir(destination)
         repo = git.Repo.init(destination)
-        origin = repo.create_remote('origin', remote_repo)
-        origin.fetch()
+        if work_with_remote:
+            origin = repo.create_remote('origin', remote_repo)
+            origin.fetch()
 
 
 def check_branch_checked_out(repo_directory, branch):
@@ -60,9 +61,9 @@ def check_out_branch(repo_directory, branch):
         raise BranchNotFound('Branch {} does not exist locally or in remote'.format(branch))
 
 
-def get_or_create_content_repo(remote_repo, destination):
+def get_or_create_content_repo(remote_repo, destination, work_with_remote):
     if not check_content_repo_exists(destination):
-        create_content_repo(remote_repo, destination)
+        create_content_repo(remote_repo, destination, work_with_remote)
 
 
 def clear_content_repo(repo_dir):

--- a/application/config.py
+++ b/application/config.py
@@ -32,8 +32,9 @@ class Config:
                                                                   '/'.join((GITHUB_URL,
                                                                             CONTENT_REPO)))
 
-    PUSH_ENABLED = os.environ.get('PUSH_ENABLED', True)
-    FETCH_ENABLED = os.environ.get('FETCH_ENABLED', True)
+    PUSH_ENABLED = bool(os.environ.get('PUSH_ENABLED', True))
+    FETCH_ENABLED = bool(os.environ.get('FETCH_ENABLED', True))
+    WORK_WITH_REMOTE = bool(os.environ.get('WORK_WITH_REMOTE', True))
 
     ENVIRONMENT = os.environ['ENVIRONMENT']
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
@@ -54,7 +55,6 @@ class DevConfig(Config):
         LOGIN_DISABLED = json.loads(os.environ.get("LOGIN_DISABLED", "true").lower())
     except KeyError:
         LOGIN_DISABLED = True
-    print(LOGIN_DISABLED, type(LOGIN_DISABLED))
 
 
 class TestConfig(DevConfig):
@@ -63,3 +63,4 @@ class TestConfig(DevConfig):
     else:
         SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', 'postgresql://localhost/rdcms_test')
     LOGIN_DISABLED = False
+    WORK_WITH_REMOTE = False

--- a/application/factory.py
+++ b/application/factory.py
@@ -51,8 +51,10 @@ def create_app(config_object):
 
     if app.config['ENVIRONMENT'] == 'HEROKU':
         clear_content_repo(app.config['REPO_DIR'])
+
     get_or_create_content_repo(app.config['GITHUB_REMOTE_REPO'],
-                               app.config['REPO_DIR'])
+                               app.config['REPO_DIR'],
+                               app.config['WORK_WITH_REMOTE'])
 
     page_service.init_app(app)
     db.init_app(app)


### PR DESCRIPTION
When test config is used the app only initializes an empty local repository which is not configured with any remotes. 

This allows tests to setup test data without any requirement for access to any remote data.

@thomasridd one for you.