### PR TITLE
Empty repo on startup for tests.

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -32,8 +32,9 @@ class Config:
                                                                   '/'.join((GITHUB_URL,
                                                                             CONTENT_REPO)))
 
-    PUSH_ENABLED = os.environ.get('PUSH_ENABLED', True)
-    FETCH_ENABLED = os.environ.get('FETCH_ENABLED', True)
+    PUSH_ENABLED = bool(os.environ.get('PUSH_ENABLED', True))
+    FETCH_ENABLED = bool(os.environ.get('FETCH_ENABLED', True))
+    WORK_WITH_REMOTE = bool(os.environ.get('WORK_WITH_REMOTE', True))
 
     ENVIRONMENT = os.environ['ENVIRONMENT']
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
@@ -54,7 +55,6 @@ class DevConfig(Config):
         LOGIN_DISABLED = json.loads(os.environ.get("LOGIN_DISABLED", "true").lower())
     except KeyError:
         LOGIN_DISABLED = True
-    print(LOGIN_DISABLED, type(LOGIN_DISABLED))
 
 
 class TestConfig(DevConfig):
@@ -63,3 +63,4 @@ class TestConfig(DevConfig):
     else:
         SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', 'postgresql://localhost/rdcms_test')
     LOGIN_DISABLED = False
+    WORK_WITH_REMOTE = False

--- a/application/factory.py
+++ b/application/factory.py
@@ -51,8 +51,10 @@ def create_app(config_object):
 
     if app.config['ENVIRONMENT'] == 'HEROKU':
         clear_content_repo(app.config['REPO_DIR'])
+
     get_or_create_content_repo(app.config['GITHUB_REMOTE_REPO'],
-                               app.config['REPO_DIR'])
+                               app.config['REPO_DIR'],
+                               app.config['WORK_WITH_REMOTE'])
 
     page_service.init_app(app)
     db.init_app(app)

--- a/tests/test_user_audit.py
+++ b/tests/test_user_audit.py
@@ -4,7 +4,7 @@ from flask import url_for
 
 from application.audit.models import Audit
 
-pytestmark = pytest.mark.usefixtures('mock_user', 'db_session')
+pytestmark = pytest.mark.usefixtures('mock_user', 'db_session', 'mock_page_service_get_pages')
 
 
 def test_user_login_and_logout_recorded(client):


### PR DESCRIPTION
When test config is used the app only initializes a local empty repository which is not configured with any remotes.

This allows tests to setup test data without any requirement for access
to any remote data.

Refactored git utils a bit as well.

@thomasridd let's try again :)