### PR TITLE
Use topic and subtopic guid passed in url for get_page

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -57,9 +57,9 @@ class PageService:
     def get_pages(self):
         return self.store.get_pages()
 
-    def get_page(self, guid):
+    def get_page(self, guid, path=None):
         try:
-            return self.store.get(guid)
+            return self.store.get(guid, path)
         except FileNotFoundError:
             raise PageNotFoundException
 

--- a/application/cms/stores.py
+++ b/application/cms/stores.py
@@ -169,8 +169,11 @@ class GitStore:
     # TODO lets change this to take a path and guid as caller knows path then
     # we don't need to search for page where meta.guid == guid or
     # at least we know the dir to search instead of walking directories from root
-    def get(self, guid):
-        page_dir = '%s/%s' % (self.repo_dir, self.content_dir)
+    def get(self, guid, path=None):
+        if path is not None:
+            page_dir = '%s/%s/%s' % (self.repo_dir, self.content_dir, path)
+        else:
+            page_dir = '%s/%s' % (self.repo_dir, self.content_dir)
         for root, dirs, files in os.walk(page_dir):
             if "meta.json" in files:
                 meta_file = "/".join((root, "meta.json"))

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -33,7 +33,6 @@ def index():
 @internal_user_required
 @login_required
 def create_topic_page():
-
     form = PageForm()
     if request.method == 'POST':
         form = PageForm(request.form)
@@ -49,19 +48,17 @@ def create_topic_page():
 @internal_user_required
 @login_required
 def create_measure_page(topic, subtopic):
-    topic_page = page_service.get_page(topic)
-    subtopic_page = page_service.get_page(subtopic)
     form = MeasurePageForm()
     if request.method == 'POST':
         form = MeasurePageForm(request.form)
         try:
             if form.validate():
-                page = page_service.create_page(page_type='measure', parent=subtopic_page.meta.guid, data=form.data)
+                page = page_service.create_page(page_type='measure', parent=subtopic, data=form.data)
                 message = 'Created page {}'.format(page.title)
                 flash(message, 'info')
                 return redirect(url_for("cms.edit_measure_page",
-                                        topic=topic_page.meta.guid,
-                                        subtopic=subtopic_page.meta.guid,
+                                        topic=topic,
+                                        subtopic=subtopic,
                                         measure=page.meta.guid))
             else:
                 flash(form.errors, 'error')
@@ -73,8 +70,8 @@ def create_measure_page(topic, subtopic):
 
     return render_template("cms/new_measure_page.html",
                            form=form,
-                           topic=topic_page,
-                           subtopic=subtopic_page)
+                           topic=topic,
+                           subtopic=subtopic)
 
 
 @cms_blueprint.route('/<topic>/edit', methods=['GET', 'POST'])
@@ -116,9 +113,8 @@ def edit_topic_page(topic):
 @login_required
 def edit_measure_page(topic, subtopic, measure):
     try:
-        subtopic_page = page_service.get_page(subtopic)
-        topic_page = page_service.get_page(topic)
-        page = page_service.get_page(measure)
+        measure_path = '%s/%s' % (topic, subtopic)
+        page = page_service.get_page(measure, path=measure_path)
 
     except PageNotFoundException:
         abort(404)
@@ -142,8 +138,8 @@ def edit_measure_page(topic, subtopic, measure):
 
     context = {
         'form': form,
-        'topic': topic_page,
-        'subtopic': subtopic_page,
+        'topic': topic,
+        'subtopic': subtopic,
         'measure': page,
         'status': current_status,
         'available_actions': available_actions,
@@ -176,7 +172,7 @@ def topic_overview(topic):
 @login_required
 def subtopic_overview(topic, subtopic):
     try:
-        page = page_service.get_page(subtopic)
+        page = page_service.get_page(subtopic, path=topic)
     except PageNotFoundException:
         abort(404)
 
@@ -204,7 +200,8 @@ def upload_file(topic, subtopic, measure):
     if file.filename == '':
         return json.dumps({'status': 'BAD REQUEST'}), 400
     else:
-        page = page_service.get_page(measure)
+        path = '%s/%s' % (topic, subtopic)
+        page = page_service.get_page(measure, path=path)
         page_service.upload_data(page, file)
         return json.dumps({'status': 'OK', 'file': file.filename}), 200
 
@@ -236,8 +233,9 @@ def reject_page(topic, subtopic, measure):
 def create_dimension(topic, subtopic, measure):
     try:
         topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        measure_page = page_service.get_page(measure)
+        subtopic_page = page_service.get_page(subtopic, path=topic)
+        measure_path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=measure_path)
     except PageNotFoundException:
         abort(404)
 
@@ -282,9 +280,10 @@ def create_dimension(topic, subtopic, measure):
 @login_required
 def edit_dimension(topic, subtopic, measure, dimension):
     try:
-        measure_page = page_service.get_page(measure)
         topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        subtopic_page = page_service.get_page(subtopic, path=topic)
+        measure_path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=measure_path)
         dimension = page_service.get_dimension(measure_page, dimension)
     except PageNotFoundException:
         abort(404)
@@ -312,9 +311,10 @@ def edit_dimension(topic, subtopic, measure, dimension):
 @login_required
 def create_chart(topic, subtopic, measure, dimension):
     try:
-        measure_page = page_service.get_page(measure)
         topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        subtopic_page = page_service.get_page(subtopic, path=topic)
+        measure_path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=measure_path)
         dimension_object = page_service.get_dimension(measure_page, dimension)
     except PageNotFoundException:
         abort(404)
@@ -335,9 +335,10 @@ def create_chart(topic, subtopic, measure, dimension):
 @login_required
 def create_table(topic, subtopic, measure, dimension):
     try:
-        measure_page = page_service.get_page(measure)
         topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        subtopic_page = page_service.get_page(subtopic, path=topic)
+        measure_path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=measure_path)
         dimension_object = page_service.get_dimension(measure_page, dimension)
     except PageNotFoundException:
         abort(404)
@@ -358,9 +359,8 @@ def create_table(topic, subtopic, measure, dimension):
 @login_required
 def save_chart_to_page(topic, subtopic, measure, dimension):
     try:
-        measure_page = page_service.get_page(measure)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=path)
         dimension = page_service.get_dimension(measure_page, dimension)
     except PageNotFoundException:
         abort(404)
@@ -389,9 +389,8 @@ def save_chart_to_page(topic, subtopic, measure, dimension):
 @login_required
 def save_table_to_page(topic, subtopic, measure, dimension):
     try:
-        measure_page = page_service.get_page(measure)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        path = '%s/%s' % (topic, subtopic)
+        measure_page = page_service.get_page(measure, path=path)
         dimension = page_service.get_dimension(measure_page, dimension)
     except PageNotFoundException:
         abort(404)
@@ -420,7 +419,8 @@ def save_table_to_page(topic, subtopic, measure, dimension):
 @login_required
 def get_measure_page(topic, subtopic, measure):
     try:
-        page = page_service.get_page(measure)
+        path = '%s/%s' % (topic, subtopic)
+        page = page_service.get_page(measure, path=path)
         return page.to_json(), 200
     except(PageNotFoundException):
         return json.dumps({}), 404

--- a/application/templates/cms/base_measure_page.html
+++ b/application/templates/cms/base_measure_page.html
@@ -7,10 +7,10 @@
         <a href="{{ url_for('cms.index') }}">Home</a>
       </li>
       <li>
-        <a href="{{ url_for('cms.topic_overview', topic=topic.guid) }}">{{ topic.title }}</a>
+        <a href="{{ url_for('cms.topic_overview', topic=topic) }}">{{ topic.replace('topic_', '').title() }}</a>
       </li>
       <li>
-        <a href="{{ url_for('cms.subtopic_overview', topic=topic.guid, subtopic=subtopic.guid) }}">{{ subtopic.title }}</a>
+        <a href="{{ url_for('cms.subtopic_overview', topic=topic, subtopic=subtopic) }}">{{ subtopic.replace('subtopic_', '').title() }}</a>
       </li>
     </ul>
   </nav>

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -9,7 +9,7 @@
 {% block measure_form %}
 <div class="edit-form">
   <form method="POST"
-  action="{{ url_for('cms.edit_measure_page', topic=topic.meta.guid, subtopic=subtopic.meta.guid, measure=measure.meta.guid) }}">
+  action="{{ url_for('cms.edit_measure_page', topic=topic, subtopic=subtopic, measure=measure.meta.guid) }}">
   {{ form.csrf_token }}
       {% block fields %}
   {{ super() }}
@@ -51,14 +51,14 @@
     </li>
     {% endif %}
     <li class='preview-link'>
-      <a href="{{ url_for('static_site.measure_page', topic=topic.meta.uri, subtopic=subtopic.meta.uri, measure=measure.meta.uri) }}">
+      <a href="{{ url_for('static_site.measure_page', topic=topic.replace('topic_',''), subtopic=subtopic.replace('subtopic_',''), measure=measure.meta.uri) }}">
         View preview
       </a>
     </li>
     {% if  "APPROVE" in available_actions %}
     <li>
       <a class="button-secondary"
-      href="{{ url_for('cms.publish_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid) }}">
+      href="{{ url_for('cms.publish_page', topic=topic, subtopic=subtopic, measure=measure.guid) }}">
       {{ next_approval_state | format_approve_button }}
     </a>
   </li>
@@ -99,13 +99,13 @@
         processData: false, // important
         contentType: false, // important
         data: data,
-        url: "{{ url_for('cms.upload_file', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid)}}",
+        url: "{{ url_for('cms.upload_file', topic=topic, subtopic=subtopic, measure=measure.guid)}}",
         dataType: 'json',
         success: function (jsonData) {
           $.ajax({
             type: 'GET',
             dataType: 'json',
-            url: "{{ url_for('cms.get_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid)}}",
+            url: "{{ url_for('cms.get_measure_page', topic=topic, subtopic=subtopic, measure=measure.guid)}}",
             success: function (page) {
               var fileListHtml = '';
               for (i in page.uploads) {

--- a/application/templates/cms/new_measure_page.html
+++ b/application/templates/cms/new_measure_page.html
@@ -3,7 +3,7 @@
 {% block main_content %}
     {% block measure_form %}
         <div class="edit-form">
-            <form method="POST" action="{{ url_for('cms.create_measure_page', topic=topic.guid, subtopic=subtopic.guid) }}">
+            <form method="POST" action="{{ url_for('cms.create_measure_page', topic=topic, subtopic=subtopic) }}">
             {{ form.csrf_token }}
                 {% block fields %}
                     <label for="{{ form.guid.id }}">{{ form.guid.label }}</label>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,7 +215,7 @@ def mock_create_page(mocker):
 @pytest.fixture(scope='function')
 def mock_get_page(mocker, stub_topic_page, stub_measure_page):
 
-    def _get_page(guid):
+    def _get_page(guid, path=None):
         if guid == 'test-measure-page':
             return stub_measure_page
         else:

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -59,8 +59,8 @@ def test_create_measure_page(test_app_client,
 
     mock_create_page.assert_called_with(data=form_data,
                                         page_type='measure',
-                                        parent='test-topic-page')
-    mock_get_page.assert_called_with(stub_measure_page.meta.guid)
+                                        parent='test-subtopic-page')
+    mock_get_page.assert_called_with(stub_measure_page.meta.guid, path='test-topic-page/test-subtopic-page')
 
 
 def test_reject_page(test_app_client,


### PR DESCRIPTION
Use topic and subtopic guid passed in url to allow get_page in store to start at a better directory for os.path.walk when searching for a page
with a given guid.

@andrew-thox just an idea. This should reduce the number of topic and measure page lookups as we just pass on topic and subtopic guids from the url.

Also when doing a search with store.get_page(guid), then it can start the walk in the correct directory. It does mean messing about a bit more in templates with some str.replace('topic_','') mularkey.

This probably needs a through manual click about test. I've tried locally but may have missed something.