### PR TITLE
Use environment variable if present for session lifetime

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -36,7 +36,7 @@ class Config:
                                                                                 HTML_CONTENT_REPO)))
 
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
-    PERMANENT_SESSION_LIFETIME = timedelta(minutes=30)
+    PERMANENT_SESSION_LIFETIME = timedelta(minutes=int(os.environ.get('PERMANENT_SESSION_LIFETIME_MINS', 60)))
     SECURITY_PASSWORD_SALT = SECRET_KEY
     SECURITY_PASSWORD_HASH = 'bcrypt'
     SECURITY_URL_PREFIX = '/auth'


### PR DESCRIPTION
If no environment variable for value present, then default to 60 mins.

Some users have complained about being kicked out too soon.

@andrew-thox or @thomasridd 