### PR TITLE
static build subtopic order bug.

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -34,8 +34,8 @@ def do_it(application):
             build_measure_pages(page_service, subtopics, topic, topic_dir, beta_publication_states)
 
         build_other_static_pages(build_dir)
-        # push_site(build_dir, build_timestamp)
-        # clear_up(build_dir)
+        push_site(build_dir, build_timestamp)
+        clear_up(build_dir)
 
 
 def build_subtopic_pages(subtopics, topic, topic_dir):


### PR DESCRIPTION
For static build order of topics as listed in db_page.subtopics wasn't being maintained.

This fixes the issue.

@andrew-thox one more, please.