### PR TITLE
Remove url from source text in png

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -560,13 +560,28 @@
         var subtitle = 'Location: ' + dimension.location
                                     + '. Time period: '
                                     + dimension.time_period
-                                    + '. Source: ' + dimension.source
+                                    + '. Source: ' + getSourceText(dimension.source)
                                     + '|Ethnicity Facts and Figures GOV.UK';
 
         chart.highcharts().options.subtitle.text = subtitle;
         chart.highcharts().exportChart();
     });
 
+
+    function getSourceText(source){
+        var regex = /\[(.*?)\]\(.*?\)/;
+        if(regex.test(source)){
+            var match = regex.exec(source);
+            if(match.length == 2) {
+               return match[1];
+            }
+            else {
+                return source;
+            }
+        } else {
+            return source;
+        }
+    };
 
   });
 </script>


### PR DESCRIPTION
If dimension source looks like a markdown link, just get the link text, not the whole thing or URL.

@akinegb one for you.