### PR TITLE
Duplicates of measures on subtopic measure list in cms

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -201,17 +201,6 @@ class DbPage(db.Model):
     def next_major_version(self):
         return '%s.0' % str(self.major() + 1)
 
-    def get_latest_measures(self):
-        if not self.children:
-            return []
-        latest = []
-        seen = set([])
-        for measure in self.children:
-            if measure.guid not in seen and measure.is_latest():
-                latest.append(measure)
-                seen.add(measure.guid)
-        return latest
-
     def latest_version(self):
         versions = self.get_versions()
         versions.sort(reverse=True)

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -549,13 +549,9 @@ class PageService:
         filtered = []
         seen = set([])
         for m in subtopic.children:
-            if m.guid not in seen:
-                versions = m.get_versions()
-                if versions:
-                    versions.sort(reverse=True)
-                    v = versions[0]
-                    filtered.append(v)
-                    seen.add(v.guid)
+            if m.guid not in seen and m.is_latest():
+                filtered.append(m)
+                seen.add(m.guid)
         return filtered
 
     def delete_measure_page(self, measure, version):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -258,22 +258,8 @@ def subtopic_overview(topic, subtopic):
         abort(404)
 
     topic_page = page_service.get_page(topic)
-    ordered_subtopics = []
 
-    latest_measures = page.get_latest_measures()
-
-    if page.subtopics is not None:
-        for st in page.subtopics:
-            for c in latest_measures:
-                if c.guid == st:
-                    ordered_subtopics.append(c)
-
-    measures = ordered_subtopics if ordered_subtopics else page.children
-
-    # if any pages left over after ordering by subtopic add them to the list
-    for p in latest_measures:
-        if p not in measures:
-            measures.append(p)
+    measures = page_service.get_latest_measures(page)
 
     context = {'page': page,
                'topic': topic_page,


### PR DESCRIPTION
I noticed this bug when adding new editions. The whole ordering of measures on subtopic page never worked or made any sense as implemented as the data was not in db to support it.

The change is to return the latest measures for the cms view
of measures by subtopic.

Also there was some duplication on model and service, which is
now moved to the page service.

@andrew-thox one for you.