### PR TITLE
Show chart title in CMS if present

### DIFF
--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -35,7 +35,7 @@
                             {% if dimension.chart and dimension.chart != '""' %}
                                 <tr>
                                     <td>Chart</td>
-                                    <td>{{ dimension.chart.title.value }}</td>
+                                    <td>{{ dimension.chart.title.text }}</td>
                                     <td><a id="edit_chart"
                                            href="{{ url_for('cms.create_chart', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}


### PR DESCRIPTION
Fix for https://trello.com/c/VSh8KvcP/380-bug-chart-title-doesnt-display-on-cms-editing-page

Has the JSON structure changed? Template code is expecting `title.value` but the title is being saved to `title.text`.