### PR TITLE
Don't remove csrf token from form when validation is turned on.

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -96,7 +96,6 @@ class MeasurePageRequiredForm(MeasurePageForm):
 class DimensionRequiredForm(DimensionForm):
     def __init__(self, *args, **kwargs):
         kwargs['meta'] = kwargs.get('meta') or {}
-        kwargs['meta'].setdefault('csrf', False)
 
         super(DimensionRequiredForm, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Potential bug fix for https://trello.com/c/UBhzXnRs/390-bug-update-does-not-save-on-first-click-need-to-click-update-a-second-time

For some reason, the csrf token isn't being included with the form when the `?validate=true` option is turned on, which causes the update to fail, but without any warning or error as to why.

I'm not sure what the reason for explicitly turning off the token before?
