### PR TITLE
Bugfix: table headers not appearing aligned

### DIFF
--- a/application/templates/static_site/table.html
+++ b/application/templates/static_site/table.html
@@ -10,7 +10,7 @@
     <thead>
 
       {% if dimension.table.type == "grouped" %}
-        {% set total_cells = (dimension.table.columns|length * (dimension.table.group_columns|length - 1 )) + 1 %}
+        {% set total_cells = (dimension.table.columns|length * (dimension.table.group_columns|length)) + 1 %}
 
         <tr>
           <td class="first" style="width:{{ 100 / total_cells }}%"></td>


### PR DESCRIPTION
Seemed to be accounting for an extra column which was being included by
the old table builder code, but isn’t by the new code.

We’ll need to rebuild old tables to take account of this fix.