### PR TITLE
Publication date bugfix

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -452,7 +452,8 @@ class PageService:
             raise PageNotFoundException()
 
     def mark_page_published(self, page):
-        page.publication_date = date.today()
+        if page.publication_date is None:
+            page.publication_date = date.today()
         page.published = True
         message = 'page "{}" published on "{}"'.format(page.guid, page.publication_date.strftime('%Y-%m-%d'))
         self.logger.info(message)


### PR DESCRIPTION
Publication date was always being set in build process which would overwrite publication 
date from pages that had been published earlier.