### PR TITLE
Allow HTML content repo name to be configurable

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -29,7 +29,7 @@ class Config:
     SESSION_COOKIE_SECURE = True
 
     GITHUB_ACCESS_TOKEN = os.environ['GITHUB_ACCESS_TOKEN']
-    HTML_CONTENT_REPO = 'rd_html'
+    HTML_CONTENT_REPO = os.environ.get('RDU_GITHUB_HTML_REPO', 'rd_html')
     GITHUB_URL = os.environ.get('RDU_GITHUB_URL', 'github.com/methods')
     STATIC_SITE_REMOTE_REPO = "https://{}:x-oauth-basic@{}.git".format(GITHUB_ACCESS_TOKEN,
                                                                        '/'.join((GITHUB_URL,


### PR DESCRIPTION
The name of the HTML content repo may change depending on environments,
so we should make it configurable with an environment variable.

We should keep the default `rd_html` option so we don’t break the
existing setup