### PR TITLE
bug fix from save and send to review bug

### DIFF
--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -24,13 +24,13 @@ class FileService:
     def init_app(self, app):
         self.logger = setup_module_logging(self.logger, app.config['LOG_LEVEL'])
         service_type = app.config['FILE_SERVICE']
-        if service_type in ['S3', 's3']:
+        if service_type.lower() == 's3':
             self.system = S3FileSystem(bucket_name=app.config['S3_BUCKET_NAME'],
                                        region=app.config['S3_REGION'])
-            message = 'initialised S3 file system %s in %s' % (app.config['S3_BUCKET_NAME'],
+            message = 'Initialised S3 file system %s in %s' % (app.config['S3_BUCKET_NAME'],
                                                                app.config['S3_REGION'])
             self.logger.info(message)
-        elif service_type in ['Local', 'LOCAL']:
+        elif service_type.lower() == 'local':
             self.system = LocalFileSystem(root=app.config['LOCAL_ROOT'])
             self.logger.info('initialised local file system in %s' % (app.config['LOCAL_ROOT']))
 
@@ -90,7 +90,6 @@ class S3FileSystem:
 
     def read(self, fs_path, local_path):
         with open(file=local_path, mode='wb') as file:
-            print("KEY", fs_path)
             self.bucket.download_fileobj(Key=fs_path, Fileobj=file)
 
     def write(self, local_path, fs_path):

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -109,8 +109,6 @@ class UploadForm(FlaskForm):
 class MeasurePageRequiredForm(MeasurePageForm):
     def __init__(self, *args, **kwargs):
         kwargs['meta'] = kwargs.get('meta') or {}
-        kwargs['meta'].setdefault('csrf', False)
-
         super(MeasurePageRequiredForm, self).__init__(*args, **kwargs)
 
     measure_summary = TextAreaField(label='What the data measures',  validators=[DataRequired()])

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -160,7 +160,7 @@ class PageService:
             file_name = "%s.%s" % (slugify(data['title']), extension)
 
             # TODO Refactor this into a rename_file method
-            if current_app.config['FILE_SERVICE'] == 'local' or current_app.config['FILE_SERVICE'] == 'Local':
+            if current_app.config.get('FILE_SERVICE', 'local').lower() == 'local':
                 path = page_service.get_url_for_file(measure, upload.file_name)
                 dir_path = os.path.dirname(path)
                 page_file_system.rename_file(upload.file_name, file_name, dir_path)
@@ -351,7 +351,6 @@ class PageService:
         return message
 
     def upload_data(self, page, file, filename=None):
-        print("FILENAME: ", filename)
         page_file_system = current_app.file_service.page_system(page)
         if not filename:
             filename = file.name

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -327,7 +327,7 @@ def send_to_review(topic, subtopic, measure, version):
     except PageNotFoundException:
         abort(404)
 
-    measure_form = MeasurePageRequiredForm(obj=measure_page)
+    measure_form = MeasurePageRequiredForm(obj=measure_page, meta={'csrf': False})
     invalid_dimensions = []
 
     for dimension in measure_page.dimensions:
@@ -336,15 +336,21 @@ def send_to_review(topic, subtopic, measure, version):
             invalid_dimensions.append(dimension)
 
     if not measure_form.validate() or invalid_dimensions:
+        form = MeasurePageRequiredForm(obj=measure_page)
+        for key, val in measure_form.errors.items():
+            form.errors[key] = val
+            field = getattr(form, key)
+            field.errors = val
+            setattr(form, key, field)
+
         message = 'Cannot submit for review, please see errors below'
-        print("ERRORS: ", measure_form.errors)
         flash(message, 'error')
         if invalid_dimensions:
             for invalid_dimension in invalid_dimensions:
                 message = 'Cannot submit for review ' \
                           '<a href="./%s/edit?validate=true">%s</a> dimension is not complete.'\
                           % (invalid_dimension.guid, invalid_dimension.title)
-                flash(message, 'error')
+                flash(message, 'dimension-error')
 
         current_status = measure_page.status
         available_actions = measure_page.available_actions()
@@ -353,7 +359,7 @@ def send_to_review(topic, subtopic, measure, version):
             approval_state = publish_status.inv[numerical_status + 1]
 
         context = {
-            'form': measure_form,
+            'form': form,
             'topic': topic_page,
             'subtopic': subtopic_page,
             'measure': measure_page,

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -28,7 +28,7 @@
                     <div class="row">
                         <div class="flash-message">
                             {% for category, message in messages %}
-                                <div data-alert class="alert-box {% if category == 'error' %}error{% else %}{{ category }}{% endif %}">
+                                <div data-alert class="alert-box {% if category in ['error', 'dimension-error'] %}error{% else %}{{ category }}{% endif %}">
                                     <span>{{ message| render_markdown }}</span>
                                     {% if form.errors and category =='error' %}
                                         <ul>


### PR DESCRIPTION
Added some jiggery pokery to add crsf token to measure required form for
the case where save and submit clicked with updated fields after first validation error.

This required as the rendering of edit measure page with the csrf free measure page required 
form would otherwise stop a user from making an update to invalid fields.

This is for https://trello.com/c/2zM0Itxk