### PR TITLE
Ignore exit status from `pg_restore`

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "rd_cms",
   "description": "",
   "scripts": {
-    "postdeploy": "pg_dump -F custom --data-only --no-acl --no-owner -d  $HEROKU_POSTGRESQL_RED_URL | pg_restore --disable-trigger --no-owner --no-acl -d $DATABASE_URL"
+    "postdeploy": "pg_dump -F custom --data-only --no-acl --no-owner -d  $HEROKU_POSTGRESQL_RED_URL | (pg_restore --disable-trigger --no-owner --no-acl -d || :) $DATABASE_URL"
   },
   "env": {
     "ACCEPT_HIGHCHARTS_LICENSE": {


### PR DESCRIPTION
`pg_restore` seems to return a nonzero exit status because of a bunch
of errors which we can safely ignore.