### PR TITLE
gulp needed on prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "govuk_frontend_toolkit": "^5.2.0",
+    "mocha": "^3.4.2"
+  },
+  "dependencies": {
+    "sass": "^0.5.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-watch": "^4.3.11",
-    "mocha": "^3.4.2",
-    "sass": "^0.5.0"
-  },
-  "dependencies" : {
+    "gulp-rev": "^8.0.0",
     "highcharts-export-server": "^1.0.18"
   },
   "scripts": {


### PR DESCRIPTION
Gulp is now a production dependency as well and missing gulp-rev plugin. These are needed for asset versioning in the static build. This was missing in earlier pr.