### PR TITLE
A little less versioning for the faint hearted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,12 +95,11 @@ ENV/
 test_results.xml
 
 node_modules
-
-application/static_site/static/stylesheets/homepage.css
-application/static_site/static/stylesheets/measure.css
-application/static_site/static/stylesheets/tables.css
-application/static_site/static/stylesheets/typography-prototype.css
-
 screenshots
 
 None
+
+application-*.css
+cms-*.css
+all-*.js
+rev-manifest.json

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -335,16 +335,11 @@ def clear_up(build_dir):
 
 
 def create_versioned_assets(build_dir):
+    subprocess.run(['gulp', 'version'])
     static_dir = '%s/static' % build_dir
     if os.path.exists(static_dir):
         shutil.rmtree(static_dir)
     shutil.copytree(current_app.static_folder, static_dir)
-
-    js_dir = '%s/javascripts' % static_dir
-    css_dir = '%s/stylesheets' % static_dir
-
-    subprocess.run(['gulp', 'version-js', '--out', js_dir])
-    subprocess.run(['gulp', 'version-css', '--out', css_dir])
 
 
 def _filter_out_subtopics_with_no_ready_measures(subtopics, beta_publication_states):

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -19,12 +19,14 @@
     <script type="text/javascript" src="/static/vendor/details.polyfill.js"></script>
     <![endif]-->
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/cms.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/') }}{{ 'cms.css' | version_filter }}">
+
     <script type="text/javascript" src="{{ url_for('static', filename='vendor/modernizr/modernizr.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='vendor/jquery.min.js') }}"></script>
 
     {% block endhead %} {% endblock %}
-    <script type="text/javascript" src="{{ url_for('static', filename='javascripts/all.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'all.js' | version_filter }}"></script>
+
   </head>
   <body class='rd_cms'>
     {% include "_header.html" %}

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -6,7 +6,7 @@
 <script src="{{ url_for('static', filename='javascripts/rd-data-tools.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-table-objects.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-table.js') }}"></script>
-<link rel="stylesheet" type="text/css" href="/static/stylesheets/application.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/') }}{{ 'application.css' | version_filter }}">
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/application/templates/static_site/error/403.html
+++ b/application/templates/static_site/error/403.html
@@ -1,7 +1,4 @@
 {% extends "_template.html" %}
-{% block head %}
-    <link rel="stylesheet" type="text/css" href="{{ asset_path }}stylesheets/application.css">
-{% endblock %}
 {% block content %}
     <div id="hero-container">
         <main id="content">

--- a/application/templates/static_site/error/404.html
+++ b/application/templates/static_site/error/404.html
@@ -1,7 +1,4 @@
 {% extends "static_site/_base.html" %}
-{% block head %}
-    <link rel="stylesheet" type="text/css" href="{{ asset_path }}stylesheets/application.css">
-{% endblock %}
 {% block content %}
 <main id="content" role="main">
     <div class='grid-row'>

--- a/application/templates/static_site/error/500.html
+++ b/application/templates/static_site/error/500.html
@@ -1,7 +1,4 @@
 {% extends "static_site/_base.html" %}
-{% block head %}
-    <link rel="stylesheet" type="text/css" href="{{ asset_path }}stylesheets/application.css">
-{% endblock %}
 {% block content %}
 <main id="content" role="main">
     <div class='grid-row'>

--- a/application/templates/static_site/not_allowed.html
+++ b/application/templates/static_site/not_allowed.html
@@ -1,7 +1,4 @@
 {% extends "static_site/_template.html" %}
-{% block head %}
-    <link rel="stylesheet" type="text/css" href="{{ asset_path }}stylesheets/application.css">
-{% endblock %}
 {% block content %}
     <div id="hero-container">
         <main id="content">

--- a/application/templates/static_site/not_ready_for_review.html
+++ b/application/templates/static_site/not_ready_for_review.html
@@ -1,7 +1,4 @@
 {% extends "static_site/_template.html" %}
-{% block head %}
-    <link rel="stylesheet" type="text/css" href="{{ asset_path }}stylesheets/application.css">
-{% endblock %}
 {% block content %}
     <div id="hero-container">
         <main id="content">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,19 +25,20 @@ gulp.task('watch', function () {
 });
 
 gulp.task('version-js', ['scripts'], function() {
-  var out_directory = process.argv[process.argv.length - 1];
   return gulp.src(['./application/static/javascripts/all.js'])
     .pipe(rev())
-    .pipe(gulp.dest(out_directory))
+    .pipe(gulp.dest('./application/static/javascripts'))
     .pipe(rev.manifest())
-    .pipe(gulp.dest(out_directory))
+    .pipe(gulp.dest('./application/static/javascripts'))
 });
 
 gulp.task('version-css', ['sass'], function() {
-  var out_directory = process.argv[process.argv.length - 1];
-  return gulp.src(['./application/static/stylesheets/application.css'])
+  return gulp.src(['./application/static/stylesheets/application.css', './application/static/stylesheets/cms.css'])
     .pipe(rev())
-    .pipe(gulp.dest(out_directory))
+    .pipe(gulp.dest('./application/static/stylesheets'))
     .pipe(rev.manifest())
-    .pipe(gulp.dest(out_directory))
+    .pipe(gulp.dest('./application/static/stylesheets'))
 });
+
+
+gulp.task('version', ['version-css', 'version-js'])

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "highcharts-export-server": "^1.0.18"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "postinstall": "gulp version"
   }
 }


### PR DESCRIPTION
 This pr does nothing to address the duplication of vendor files
and leaves it up to the developer if they care about using
versioned assets as compiled assets are still committed to
git and are available regardless of whether they use
versioned assets locally.

In heroku and static build assets will be versioned.

Also, there may be duplicate js loaded separately as well as in
the all bundle. That's up to future generations.