### PR TITLE
Disable json representation of measure page for launch.

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -67,6 +67,8 @@ class Config:
     ATTACHMENT_SCANNER_API_URL = os.environ.get('ATTACHMENT_SCANNER_API_URL', '')
     ATTACHMENT_SCANNER_API_KEY = os.environ.get('ATTACHMENT_SCANNER_API_KEY', '')
 
+    JSON_ENABLED = get_bool(os.environ.get('JSON_ENABLED', False))
+
 
 class DevConfig(Config):
     DEBUG = True

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -17,6 +17,7 @@ def do_it(application, build):
     with application.app_context():
         base_build_dir = application.config['STATIC_BUILD_DIR']
         application_url = application.config['RDU_SITE']
+        json_enabled = application.config['JSON_ENABLED']
         if not os.path.isdir(base_build_dir):
             os.mkdir(base_build_dir)
         build_timestamp = build.created_at.strftime('%Y%m%d_%H%M%S.%f')
@@ -40,7 +41,8 @@ def do_it(application, build):
             all_unpublished.extend(build_measure_pages(subtopics, topic,
                                                        topic_dir,
                                                        publication_states,
-                                                       application_url))
+                                                       application_url,
+                                                       json_enabled=json_enabled))
 
         build_other_static_pages(build_dir)
 
@@ -90,7 +92,7 @@ def _get_earlier_page_for_unpublished(to_unpublish):
     return earlier
 
 
-def write_versions(topic, topic_dir, subtopic, versions, application_url):
+def write_versions(topic, topic_dir, subtopic, versions, application_url, json_enabled=False):
     for page in versions:
         page_dir = '%s/%s/%s/%s' % (topic_dir, subtopic.uri, page.uri, page.version)
         if not os.path.exists(page_dir):
@@ -122,7 +124,6 @@ def write_versions(topic, topic_dir, subtopic, versions, application_url):
         write_measure_page_downloads(page, download_dir)
 
         page_html_file = '%s/index.html' % page_dir
-        page_json_file = '%s/data.json' % page_dir
 
         out = render_template('static_site/measure.html',
                               topic=topic.uri,
@@ -136,11 +137,13 @@ def write_versions(topic, topic_dir, subtopic, versions, application_url):
         with open(page_html_file, 'w') as out_file:
             out_file.write(_prettify(out))
 
-        with open(page_json_file, 'w') as out_file:
-            out_file.write(json.dumps(page.to_dict()))
+        if json_enabled:
+            page_json_file = '%s/data.json' % page_dir
+            with open(page_json_file, 'w') as out_file:
+                out_file.write(json.dumps(page.to_dict()))
 
 
-def build_measure_pages(subtopics, topic, topic_dir, beta_publication_states, application_url):
+def build_measure_pages(subtopics, topic, topic_dir, beta_publication_states, application_url, json_enabled=False):
     all_unpublished = []
     for st in subtopics:
         measure_pages = page_service.get_latest_publishable_measures(st, beta_publication_states)
@@ -164,9 +167,6 @@ def build_measure_pages(subtopics, topic, topic_dir, beta_publication_states, ap
             chart_dir = measure_dir + '/charts'
             if not os.path.exists(chart_dir):
                 os.makedirs(chart_dir)
-
-            measure_html_file = '%s/index.html' % measure_dir
-            measure_json_file = '%s/data.json' % measure_dir
 
             dimensions = []
             for d in measure_page.dimensions:
@@ -197,7 +197,7 @@ def build_measure_pages(subtopics, topic, topic_dir, beta_publication_states, ap
             write_measure_page_downloads(measure_page, download_dir)
 
             versions = page_service.get_previous_versions(measure_page)
-            write_versions(topic, topic_dir, st, versions, application_url)
+            write_versions(topic, topic_dir, st, versions, application_url, json_enabled)
 
             out = render_template('static_site/measure.html',
                                   topic=topic.uri,
@@ -208,11 +208,14 @@ def build_measure_pages(subtopics, topic, topic_dir, beta_publication_states, ap
                                   asset_path='/static/',
                                   static_mode=True)
 
+            measure_html_file = '%s/index.html' % measure_dir
             with open(measure_html_file, 'w') as out_file:
                 out_file.write(_prettify(out))
 
-            with open(measure_json_file, 'w') as out_file:
-                out_file.write(json.dumps(measure_page.to_dict()))
+            if json_enabled:
+                measure_json_file = '%s/data.json' % measure_dir
+                with open(measure_json_file, 'w') as out_file:
+                    out_file.write(json.dumps(measure_page.to_dict()))
 
         page_service.mark_pages_unpublished(to_unpublish)
 

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -4,16 +4,19 @@
 
 {% block head %}
     {{ super() }}
-    {% if static_mode %}
-        {% set version = 'latest' if measure_page.has_no_later_published_versions(config['PUBLICATION_STATES']) else measure_page.version %}
-        <link rel="alternate" type="application/json" title="{{ measure_page.title }}"
-              href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/data.json">
-    {% else %}
-        <link rel="alternate" type="application/json" title="{{ measure_page.title }}" href="{{ url_for('static_site.measure_page_json',
-                      topic=topic,
-                      subtopic=subtopic,
-                      measure=measure_page.uri,
-                      version=measure_page.version) }}">
+    {% if config.JSON_ENABLED %}
+        {% if static_mode %}
+            {% set version = 'latest' if measure_page.has_no_later_published_versions(config['PUBLICATION_STATES']) else measure_page.version %}
+            <link rel="alternate" type="application/json" title="{{ measure_page.title }}"
+                  href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/data.json">
+        {% else %}
+            <link rel="alternate" type="application/json" title="{{ measure_page.title }}" href="{{ url_for('static_site.measure_page_json',
+                          topic=topic,
+                          subtopic=subtopic,
+                          measure=measure_page.uri,
+                          version=measure_page.version) }}">
+        {% endif %}
+
     {% endif %}
 {% endblock %}
 
@@ -470,6 +473,7 @@
                 {% endif %}
               {% endif %}
             {% endfor %}
+            {% if config.JSON_ENABLED %}
               {% if static_mode %}
                   {% set version = 'latest' if measure_page.has_no_later_published_versions(config['PUBLICATION_STATES']) else measure_page.version %}
                   <a href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/data.json">View this page as JSON</a>
@@ -480,7 +484,8 @@
                       measure=measure_page.uri,
                       version=measure_page.version) }}">View this page as JSON</a>
               {% endif %}
-              <button class="js--print print-btn">Print this page</button>
+            {% endif %}
+            <button class="js--print print-btn">Print this page</button>
           </div>
         </div>
 


### PR DESCRIPTION
Added config to turn on/off json representation of measure page. 

Default is false, therefore to test for json on set env variable JSON_ENABLED=True

https://trello.com/c/mvCCDLhX

https://rd-cms-dev-pr-387.herokuapp.com/
