### PR TITLE
Chart download - prevent scrolling

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -695,6 +695,7 @@
 
         chart.highcharts().options.subtitle.text = subtitle;
         chart.highcharts().exportChart();
+        evt.preventDefault();
     });
 
 


### PR DESCRIPTION
This prevents the page from scrolling to the top when downloading a chart image.