### PR TITLE
Restrict some things.

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -120,13 +120,20 @@ def harden_app(response):
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')
-    # response.headers.add('Content-Security-Policy', (
-    #     "default-src 'self' 'unsafe-inline';"
-    #     "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
-    #     "object-src 'self';"
-    #     "font-src 'self' data:;"
-    # ))
-    # wait and see for the content security policy stuff
+    response.headers.add('Content-Security-Policy', (
+        "worker-src 'self';"
+        "connect-src 'self';"
+        "style-src 'self' 'unsafe-inline';"
+        "script-src 'self' 'unsafe-inline';"
+        "media-src 'self';"
+        "default-src 'self';"
+        "img-src 'self';"
+        "manifest-src 'self';"
+        "child-src 'self';"
+        "frame-src 'self';"
+        "object-src 'self';"
+        "font-src 'self' data:"))
+
     return response
 
 

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -1,7 +1,7 @@
 {% extends "base_cms.html" %}
 {% block endhead %}
 
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="{{ url_for('static', filename='vendor/highcharts/5.0.11/highcharts.js') }}"></script>
 <script src="{{ url_for('static', filename='vendor/underscore-min.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-data-tools.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-chart-objects.js') }}"></script>

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -1,7 +1,7 @@
 {% extends "base_cms.html" %}
 {% block endhead %}
 
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="{{ url_for('static', filename='vendor/highcharts/5.0.11/highcharts.js') }}"></script>
 <script src="{{ url_for('static', filename='vendor/underscore-min.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-data-tools.js') }}"></script>
 <script src="{{ url_for('static', filename='javascripts/rd-table-objects.js') }}"></script>


### PR DESCRIPTION
Load highcharts from vendor directory.

Allow 'unsafe-inline' for style and script src. The latter
might be able to be changed if/when we move away from in
page scripts.

Allow data: for font-src