### PR TITLE
Make JS debugging easier

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('scripts-cms', function() {
 });
 
 gulp.task('watch', function () {
-  gulp.watch(['./application/src/js/*.js', './application/src/sass/*.scss','./application/src/sass/*.css', './application/src/sass/**/*.scss', './application/src/sass/**/**/*.scss'], ['sass', 'scripts-all',, 'scripts-charts', 'scripts-cms']);
+  gulp.watch(['./application/src/js/**/*.js', './application/src/sass/**/*.scss'], ['sass', 'scripts-all','scripts-charts', 'scripts-cms']);
 });
 
 gulp.task('version-js', ['scripts-all', 'scripts-charts','scripts-cms'], function() {


### PR DESCRIPTION
This updates the Gulpfile to include the JS content within the generate sourcemaps to enable debugging (as we don’t host the source files).

Also updates the `watch` command to make this work properly with all source files.
