### PR TITLE
remove-tooltip-from-bar-charts

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -130,25 +130,7 @@ function barchartHighchartObject(chartObject) {
           }
         },
         tooltip: {
-            pointFormatter: function() {
-                var chart = this.series.chart;
-                var series = this.series;
-
-                if(this['text'] === undefined) {
-                    // for original charts without text
-                    if(this.y > 0.0001) {
-                        return tooltipWithNumber(chart, series, chartObject.number_format.prefix, chartObject.number_format.suffix, chartObject.decimalPlaces, this.y)
-                    } else {
-                        return tooltipWithText(chart, series, 'Not enough data');
-                    }
-                } else if (this.text === 'number') {
-                    // for points saved as numbers
-                    return tooltipWithNumber(chart, series, chartObject.number_format.prefix, chartObject.number_format.suffix, chartObject.decimalPlaces, this.y)
-                } else {
-                    // for points saved as strings
-                    return tooltipWithText(chart, series, this.text);
-                };
-            }
+            enabled: false
         },
         series: chartObject.series,
         navigation: {


### PR DESCRIPTION
Remove these as they get layered beneath the bar chart labels (because
those have to be added as HTML in order to show the missing data
symbols). Also they don’t actually add any extra information.