### PR TITLE
Don't log out user emails to application log

### DIFF
--- a/application/auth/models.py
+++ b/application/auth/models.py
@@ -35,6 +35,9 @@ class User(db.Model, UserMixin):
     active = db.Column(db.Boolean(), default=False)
     confirmed_at = db.Column(db.DateTime())
 
+    def user_name(self):
+        return self.email.split('@')[0]
+
     # TODO remove distinction between internal and departmental user. Instead have users and admin users
     # to restrict views to specific measures, instead we can have notion of ownership of page, i.e. page created
     # by and then that user can share page with specific user or all users.

--- a/application/factory.py
+++ b/application/factory.py
@@ -184,5 +184,5 @@ class ContextualFilter(logging.Filter):
         log_record.url = request.path
         log_record.method = request.method
         log_record.ip = request.environ.get("REMOTE_ADDR")
-        log_record.user_id = -1 if current_user.is_anonymous else current_user.email
+        log_record.user_id = -1 if current_user.is_anonymous else current_user.user_name()
         return True


### PR DESCRIPTION
Add user name method to user object so we don't log full email to application log.

@thomasridd 