### PR TITLE
More attempts to tame csv file downloads.

### DIFF
--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -91,8 +91,17 @@ class S3FileSystem:
         self.bucket_name = bucket_name
 
     def read(self, fs_path, local_path):
-        with open(file=local_path, mode='wb') as file:
-            self.bucket.download_fileobj(Key=fs_path, Fileobj=file)
+        obj = self.s3.Object(self.bucket_name, fs_path)
+        for encoding in ['iso-8859-1', 'utf-8']:
+            try:
+                content = obj.get()['Body'].read().decode(encoding)
+                with open(local_path, 'w') as file:
+                    file.write(content)
+                break
+            except Exception as e:
+                print('Could not decode %s using %s' % (fs_path, encoding))
+                print(e)
+        return local_path
 
     def write(self, local_path, fs_path, max_age_seconds=300, strict=True):
 

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -501,12 +501,10 @@ class PageService:
     @staticmethod
     def get_measure_download(upload, file_name, directory):
         page_file_system = current_app.file_service.page_system(upload.measure)
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            key = '%s/%s' % (directory, file_name)
-            output_file = '%s/%s.processed' % (tmp_dir, file_name)
-            page_file_system.read(key, output_file)
-            f = open(output_file, 'rb')
-            return f.read()
+        output_file = tempfile.NamedTemporaryFile(delete=False)
+        key = '%s/%s' % (directory, file_name)
+        page_file_system.read(key, output_file.name)
+        return output_file.name
 
     def get_pages_by_uri(self, subtopic, measure):
         return DbPage.query.filter_by(parent_guid=subtopic, uri=measure).all()

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -167,8 +167,8 @@ def write_measure_page_downloads(page, uri):
         os.makedirs(download_dir, exist_ok=True)
 
     for d in page.uploads:
-        file_contents = page_service.get_measure_download(d, d.file_name, 'source')
-        content_with_metadata = get_content_with_metadata(file_contents, page)
+        filename = page_service.get_measure_download(d, d.file_name, 'source')
+        content_with_metadata = get_content_with_metadata(filename, page)
         file_path = os.path.join(download_dir, d.file_name)
         with open(file_path, 'w') as download_file:
             try:

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -144,13 +144,14 @@ def measure_page_file_download(topic, subtopic, measure, version, filename):
     try:
         page = page_service.get_page_with_version(measure, version)
         upload_obj = page_service.get_upload(measure, version, filename)
-        file_contents = page_service.get_measure_download(upload_obj, filename, 'source')
-        content_with_metadata = get_content_with_metadata(file_contents, page)
+        downloaded_file = page_service.get_measure_download(upload_obj, filename, 'source')
+        content_with_metadata = get_content_with_metadata(downloaded_file, page)
+        if os.path.exists(downloaded_file):
+            os.remove(downloaded_file)
         if content_with_metadata.strip() == '':
             abort(404)
 
         response = make_response(content_with_metadata)
-
         response.headers["Content-Disposition"] = 'attachment; filename="%s"' % upload_obj.file_name
         return response
     except (FileNotFoundError, ClientError) as e:


### PR DESCRIPTION
Start decoding process during download from s3. Try
iso-8559-1 first then utf-8. Then write as string to
local temp file.

Read local temp file using csv reader in order to preserve
oquoting of fields and any instances of delimeter within fields.

The local temp file contents are then read into memory as list 
of csv rows.

Write metadata using stringio/csv writer first, then write
rows (read from local file) to stringio/csv writer.

Return that stringio output to client.

In build process, the step of writing to stringio is replace with write to file.