### PR TITLE
Specify versions of node and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Racial Disparity Audit",
   "author": "methods",
   "license": "ISC",
+  "engines": {
+    "node": "~8.9.1",
+    "npm": "~5.5.1"
+  },
   "devDependencies": {
     "chai": "^4.1.0",
     "govuk_frontend_toolkit": "^5.2.0",


### PR DESCRIPTION
This should help make sure developers are using the same versions of
node and npm as each other and production.