### PR TITLE
disable all form fields when you can't save anyway

### DIFF
--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -1,8 +1,10 @@
 {% extends "base_cms.html" %}
+
+{%  set form_disabled = measure.status != 'DRAFT' %}
+
 {% block endhead %}
-
-
 {% endblock %}
+
 
 {% block breadcrumbs %}
     <div class="grid-row">
@@ -66,7 +68,7 @@
                         <label for="data_text_area">
                             <h2 class="heading-medium">1. Copy data from excel</h2>
                         </label>
-                        <textarea class="form-control" id="data_text_area" rows="3"></textarea>
+                        <textarea class="form-control" id="data_text_area" rows="3" {% if form_disabled %}disabled="disabled"{% endif %}></textarea>
                     </div>
                 </form>
             </div>
@@ -75,7 +77,7 @@
                 <label for="chart_type_selector">
                     <h2 class="heading-medium">2. Select chart type</h2>
                 </label>
-                <select class="form-control" id="chart_type_selector">
+                <select class="form-control" id="chart_type_selector" {% if form_disabled %}disabled="disabled"{% endif %}>
                     <option value="none">Select a chart type</option>
                     <option value="line_graph">Line graph</option>
                     <option value="bar_chart">Bar chart</option>
@@ -119,25 +121,25 @@
                 <form>
                     <div class="form-group">
                         <label for="primary_column">Primary grouping</label>
-                        <select id="primary_column" class="form-control">
+                        <select id="primary_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>Ethnicity</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="secondary_column">Secondary grouping</label>
-                        <select id="secondary_column" class="form-control">
+                        <select id="secondary_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="parent_column">Parent</label>
-                        <select id="parent_column" class="form-control">
+                        <select id="parent_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="order_column">Order</label>
-                        <select id="order_column" class="form-control">
+                        <select id="order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -149,13 +151,13 @@
                 <form>
                     <div class="form-group">
                         <label for="component_bar_column">Bar grouping</label>
-                        <select id="component_bar_column" class="form-control">
+                        <select id="component_bar_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>Ethnicity</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="component_component_column">Component grouping</label>
-                        <select id="component_component_column" class="form-control">
+                        <select id="component_component_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -165,13 +167,13 @@
                  <form>
                      <div class="form-group">
                          <label for="component_row_order_column">Bar order</label>
-                         <select id="component_row_order_column" class="form-control">
+                         <select id="component_row_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                              <option>[None]</option>
                          </select>
                      </div>
                      <div class="form-group">
                          <label for="component_series_order_column">Component order</label>
-                         <select id="component_series_order_column" class="form-control">
+                         <select id="component_series_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                              <option>[None]</option>
                          </select>
                      </div>
@@ -183,13 +185,13 @@
                 <form>
                     <div class="form-group">
                         <label for="panel_primary_column">Primary grouping</label>
-                        <select id="panel_primary_column" class="form-control">
+                        <select id="panel_primary_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="panel_grouping_column">Panel grouping</label>
-                        <select id="panel_grouping_column" class="form-control">
+                        <select id="panel_grouping_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>Ethnicity</option>
                         </select>
                     </div>
@@ -198,13 +200,13 @@
                 <form>
                     <div class="form-group">
                         <label for="panel_primary_order_column">Primary order</label>
-                        <select id="panel_primary_order_column" class="form-control">
+                        <select id="panel_primary_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="panel_order_column">Panel order</label>
-                        <select id="panel_order_column" class="form-control">
+                        <select id="panel_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -216,13 +218,13 @@
                 <form>
                     <div class="form-group">
                         <label for="panel_line_series">Panels</label>
-                        <select id="panel_line_series" class="form-control">
+                        <select id="panel_line_series" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>Ethnicity</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="panel_line_x_axis">X-Axis</label>
-                            <select id="panel_line_x_axis" class="form-control">
+                            <select id="panel_line_x_axis" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                                 <option>Time</option>
                             </select>
                     </div>
@@ -231,7 +233,7 @@
                 <form>
                     <div class="form-group">
                         <label for="panel_line_order_column">Panel order</label>
-                        <select id="panel_line_order_column" class="form-control">
+                        <select id="panel_line_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -243,19 +245,19 @@
                 <form>
                     <div class="form-group">
                         <label for="chart_title">Chart title</label>
-                        <input id="chart_title">
+                        <input id="chart_title" {% if form_disabled %}disabled="disabled"{% endif %}>
                     </div>
                     <div class="form-group">
                         <label for="x_axis_label">X axis</label>
-                        <input id="x_axis_label">
+                        <input id="x_axis_label" {% if form_disabled %}disabled="disabled"{% endif %}>
                     </div>
                     <div class="form-group">
                         <label for="y_axis_label">Y axis</label>
-                        <input id="y_axis_label">
+                        <input id="y_axis_label" {% if form_disabled %}disabled="disabled"{% endif %}>
                     </div>
                     <div class="form-group">
                         <label for="number_format">Number format</label>
-                        <select id="number_format" class="form-control">
+                        <select id="number_format" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option value="none" selected="selected">[None]</option>
                             <option value="percent">Percentage</option>
                             <option value="percent100">Multiply up to percentage</option>
@@ -263,13 +265,13 @@
                         </select>
                         <div id="other_number_format" class="form-group" style="display:none">
                             <label for="number_format_prefix">Prefix</label>
-                            <input id="number_format_prefix">
+                            <input id="number_format_prefix" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <label for="number_format_suffix">Suffix</label>
-                            <input id="number_format_suffix">
+                            <input id="number_format_suffix" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <label for="number_format_min">Minimum</label>
-                            <input id="number_format_min">
+                            <input id="number_format_min" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <label for="number_format_max">Maximum</label>
-                            <input id="number_format_max">
+                            <input id="number_format_max" {% if form_disabled %}disabled="disabled"{% endif %}>
                         </div>
                     </div>
                 </form>
@@ -288,7 +290,9 @@
             <div id="container" class="chart-container"></div>
 
             <div id="save_section" class="chart-builder-section" style="display:none">
-                <h2 class="heading-medium">5. Save chart</h2>
+                {% if 'UPDATE' in measure.available_actions() %}
+                    <h2 class="heading-medium">5. Save chart</h2>
+                {%  endif %}
                 <div>
                     {% if 'UPDATE' in measure.available_actions() %}
                         <button class="button" id="save">Save</button>

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -1,4 +1,9 @@
 {% extends "base_cms.html" %}
+
+{%  set form_disabled = measure.status != 'DRAFT' %}
+
+{% from "cms/forms.html" import render_field, render_textarea_field %}
+
 {% block title %}Create dimension{% endblock %}
 {% block breadcrumbs %}
     <nav class="" aria-label="You are here:" role="navigation">
@@ -52,33 +57,12 @@
             <form method="POST" action="{{ url_for('cms.create_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version )}}">
                 {{ form.csrf_token }}
                 {% block fields %}
-                    {{ form.title.label }}
-                    {% if form.title.errors %}
-                        - {{ form.title.errors[0] }}
-                        {{ form.title(class="error") }}
-                    {% else %}
-                        {{ form.title }}
-                    {% endif %}
-                    {# You can only have errors if the dimension has been saved so time period won't be autopop'ed #}
-                    {{ form.time_period.label }}
-                    {% if form.time_period.errors %}
-                        - {{ form.time_period.errors[0] }}
-                        {{ form.time_period(class="error") }}
-                    {% else %}
-                        {% if create %}
-                            {{ form.time_period(value=measure.time_covered) }}
-                        {% else %}
-                            {{ form.time_period }}
-                        {% endif %}
-                    {% endif %}
 
-                    {{ form.summary.label }}
-                    {% if form.summary.errors %}
-                        - {{ form.summary.errors[0] }}
-                        {{ form.summary(rows='7',cols='100', class="error") }}
-                    {% else %}
-                        {{ form.summary(rows='7',cols='100') }}
-                    {% endif %}
+                    {{ render_field(form.title, disabled=form_disabled) }}
+
+                    {{ render_field(form.time_period, disabled=form_disabled) }}
+
+                    {{ render_textarea_field(form.summary, rows='7', cols='100', disabled=form_disabled) }}
 
                 {% endblock fields %}
                 <ul class="button-group" data-topbar data-options="sticky_on: large">

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -1,5 +1,7 @@
 {% extends "base_cms.html" %}
 
+{%  set form_disabled = measure.status != 'DRAFT' %}
+
 {% block breadcrumbs %}
     <div class="grid-row">
         <div class='column-two-thirds'>
@@ -61,7 +63,7 @@
                 <div>
                     <form>
                         <div class="form-group">
-                            <textarea class="form-control" id="data_text_area" rows="3"></textarea>
+                            <textarea class="form-control" id="data_text_area" rows="3" {% if form_disabled %}disabled="disabled"{% endif %}></textarea>
                         </div>
                     </form>
                 </div>
@@ -72,23 +74,23 @@
                 <form>
                     <div class="form-group">
                         <label for="table_title">Headers</label>
-                        <input id="table_title" placeholder="Title">
-                        <input id="table_subtitle" placeholder="Subtitle" style="display:none">
+                        <input id="table_title" placeholder="Title" {% if form_disabled %}disabled="disabled"{% endif %}>
+                        <input id="table_subtitle" placeholder="Subtitle" style="display:none" {% if form_disabled %}disabled="disabled"{% endif %}>
                     </div>
 
                     <div class="form-group">
                         <label for="table_category_column">Rows</label>
-                        <select id="table_category_column" class="form-control">
+                        <select id="table_category_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>Ethnicity</option>
                         </select>
                     </div>
                     <div class="form-group">
-                        <input class="margin-top-small" id="table_category_caption" placeholder="First column caption">
+                        <input class="margin-top-small" id="table_category_caption" placeholder="First column caption" {% if form_disabled %}disabled="disabled"{% endif %}>
                     </div>
 
                     <div class="form-group">
                         <label for="table_group_column">Grouping</label>
-                        <select id="table_group_column" class="form-control">
+                        <select id="table_group_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -98,19 +100,19 @@
                 <form>
                     <div class="form-group">
                         <label for="table_parent_column">Parent</label>
-                        <select id="table_parent_column" class="form-control">
+                        <select id="table_parent_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="table_order_column">Order rows by</label>
-                        <select id="table_order_column" class="form-control">
+                        <select id="table_order_column" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="table_group_order">Order columns by</label>
-                        <select id="table_group_order" class="form-control">
+                        <select id="table_group_order" class="form-control" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                     </div>
@@ -120,38 +122,38 @@
                 <form>
                     <div class="form-group">
                         <label for="table_column_1">Column 1</label>
-                        <select id="table_column_1" class="form-control column_option_picker">
+                        <select id="table_column_1" class="form-control column_option_picker" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                         <input id="table_column_1_name" class="margin-top-small">
 
                         <label for="table_column_2">Column 2</label>
-                        <select id="table_column_2" class="form-control column_option_picker">
+                        <select id="table_column_2" class="form-control column_option_picker" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                         <input id="table_column_2_name" class="margin-top-small">
 
                         <label for="table_column_3">Column 3</label>
-                        <select id="table_column_3" class="form-control column_option_picker">
+                        <select id="table_column_3" class="form-control column_option_picker" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                         <input id="table_column_3_name" class="margin-top-small">
 
                         <label for="table_column_4">Column 4</label>
-                        <select id="table_column_4" class="form-control column_option_picker">
+                        <select id="table_column_4" class="form-control column_option_picker" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                         <input id="table_column_4_name" class="margin-top-small">
 
                         <label for="table_column_5">Column 5</label>
-                        <select id="table_column_5" class="form-control column_option_picker">
+                        <select id="table_column_5" class="form-control column_option_picker" {% if form_disabled %}disabled="disabled"{% endif %}>
                             <option>[None]</option>
                         </select>
                         <input id="table_column_5_name" class="margin-top-small">
 
                         <div class="form-group">
                             <label for="table_footer">Footer</label>
-                            <input id="table_footer" placeholder="Footer">
+                            <input id="table_footer" placeholder="Footer" {% if form_disabled %}disabled="disabled"{% endif %}>
                         </div>
                     </div>
                 </form>
@@ -167,8 +169,10 @@
             <div id="container"></div>
 
             <div id="save_section" class="chart-builder-section" style="display:none">
-                <h2 class="heading-medium">4. Save</h2>
-                <div>
+                {% if 'UPDATE' in measure.available_actions() %}
+                    <h2 class="heading-medium">4. Save</h2>
+                {%  endif %}
+                <div style="margin-top: 10px">
                     {% if 'UPDATE' in measure.available_actions() %}
                         <button class="button" id="save">Save</button>
                     {% endif %}


### PR DESCRIPTION
Dimension, chart and table form fields should be disabled if measure is not in draft status, as with edit measure form. They couldn't be saved but may as well have same behaviour all
round.

@thomasridd one for you.