### PR TITLE
Let iso-8859-1 files be iso-8859-1 files and utf-8 be utf-8 and the rest can get lost

### DIFF
--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -93,12 +93,18 @@ class S3FileSystem:
     def read(self, fs_path, local_path):
         obj = self.s3.Object(self.bucket_name, fs_path)
         try:
-            content = obj.get()['Body'].read().decode('latin-1')
+            content = obj.get()['Body'].read().decode('utf-8')
             with codecs.open(local_path, 'w', encoding='utf-8') as file:
                 file.write(content)
             return local_path
+        except UnicodeDecodeError:
+            print('Could not decode %s using %s' % (fs_path, 'utf-8, trying iso-8859-1'))
+            content = obj.get()['Body'].read().decode('iso-8859-1')
+            with codecs.open(local_path, 'w', encoding='iso-8859-1') as file:
+                file.write(content)
+            return local_path
         except Exception as e:
-            print('Could not decode %s using %s' % (fs_path, 'latin-1'))
+            print('Could not decode %s using %s' % (fs_path, 'utf-8 or iso-8859-1'))
             raise e
 
     def write(self, local_path, fs_path, max_age_seconds=300, strict=True):

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -434,9 +434,9 @@ class PageService:
                     break
             detector.close()
             encoding = detector.result.get('encoding')
-
-        if encoding is not None and encoding.lower() not in ['ascii', 'iso-8859-1', 'utf-8']:
-            message = 'File encoding %s not valid. File should be encoded as ascii, iso-8859-1 or utf-8' % encoding
+        valid_encodings = ['ascii', 'iso-8859-1', 'utf-8']
+        if encoding is not None and encoding.lower() not in valid_encodings:
+            message = 'File encoding %s not valid. Valid encodings: %s' % (encoding, valid_encodings)
             self.logger.exception(message)
             raise UploadCheckError(message)
 

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -164,9 +164,9 @@ def write_measure_page_downloads(page, uri):
 
     for d in page.uploads:
         filename = page_service.get_measure_download(d, d.file_name, 'source')
-        content_with_metadata = get_content_with_metadata(filename, page)
+        encoding, content_with_metadata = get_content_with_metadata(filename, page)
         file_path = os.path.join(download_dir, d.file_name)
-        with open(file_path, 'w', encoding='utf-8') as download_file:
+        with open(file_path, 'w', encoding=encoding) as download_file:
             try:
                 download_file.write(content_with_metadata)
             except Exception as e:


### PR DESCRIPTION
On upload try to decode as utf-8 and then on download return as utf-8.
If unicode decode error encountered, try to decode as iso-8859-1
and return it in same encoding.

The above will handle anything that is plain ascii just fine.

I've had a look at lots of csv downloads on gov.uk, and those that
include the £ symbol (the thing that alerted us to the problem) are
encoded as iso-8859-1. In fact most files I found are encoded
as iso-8859-1 with a small number encoded as ascii.

It is possible that if someone uploads csv as utf-8 (as would happen if exported
from google sheets) then a user who downloads that utf-8 file and imports
into excel on a mac, may see some strange characters. But I think they'll
need to be comfortable seeing strange characters, or move to live in another
area.