### PR TITLE
Use pump to pipe Gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const gulp = require('gulp'),
     uglify = require('gulp-uglify'),
     gulpif = require('gulp-if'),
     argv = require('yargs').argv,
+    pump = require('pump'),
     production = (argv.production === undefined) ? false : true;
 
 
@@ -32,31 +33,40 @@ gulp.task('scripts-all', function() {
     .pipe(gulp.dest('./application/static/javascripts'))
 });
 
-gulp.task('scripts-charts', function() {
-  return gulp.src([
-        './application/src/js/charts/vendor/jquery.min.js',
-        './application/src/js/charts/vendor/underscore-min.js',
-        './application/src/js/charts/vendor/highcharts.js',
-        './application/src/js/charts/vendor/highcharts-exporting.js',
-        './application/src/js/charts/rd-graph.js',
-        './application/src/js/charts/rd-data-tools.js'
-    ])
-    .pipe(sourcemaps.init())
-    .pipe(concat('charts.js'))
-    .pipe(gulpif(production, uglify()))
-    .pipe(sourcemaps.write('.', {sourceRoot: '../src'}))
-    .pipe(gulp.dest('./application/static/javascripts'))
+gulp.task('scripts-charts', function(cb) {
+
+  pump([
+    gulp.src([
+      './application/src/js/charts/vendor/jquery.min.js',
+      './application/src/js/charts/vendor/underscore-min.js',
+      './application/src/js/charts/vendor/highcharts.js',
+      './application/src/js/charts/vendor/highcharts-exporting.js',
+      './application/src/js/charts/rd-graph.js',
+      './application/src/js/charts/rd-data-tools.js'
+    ]),
+    sourcemaps.init(),
+    concat('charts.js'),
+    gulpif(production, uglify()),
+    sourcemaps.write('.', {sourceRoot: '../src'}),
+    gulp.dest('./application/static/javascripts')
+  ], cb);
 });
 
-gulp.task('scripts-cms', function() {
-  return gulp.src([
-        './application/src/js/cms/*.js'
-    ])
-    .pipe(sourcemaps.init())
-    .pipe(concat('cms.js'))
-    .pipe(gulpif(production, uglify()))
-    .pipe(sourcemaps.write('.', {sourceRoot: '../src'}))
-    .pipe(gulp.dest('./application/static/javascripts'))
+gulp.task('scripts-cms', function(cb) {
+
+  pump([
+    gulp.src([
+      './application/src/js/cms/*.js'
+    ]),
+    sourcemaps.init(),
+    concat('cms.js'),
+    gulpif(production, uglify()),
+    sourcemaps.write('.', {sourceRoot: '../src'}),
+    gulp.dest('./application/static/javascripts')
+  ],
+  cb
+  );
+
 });
 
 gulp.task('watch', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4827,6 +4827,35 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "pump": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
+      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.3.3"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "requires": {
+            "once": "1.4.0"
+          },
+          "dependencies": {
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            }
+          }
+        }
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-uglify": "^3.0.0",
     "gulp-watch": "^4.3.11",
     "highcharts-export-server": "^1.0.18",
+    "pump": "^2.0.0",
     "sass": "^0.5.0",
     "yargs": "^10.0.3"
   },


### PR DESCRIPTION
Using ‘pump’ instead of ‘pipe’ to chain a bunch of gulp tasks together
allows full errors to be propagated to the console, rather than just a
generic ‘error’ event.

This is particularly annoying with Uglify.

See
https://github.com/terinjokes/gulp-uglify/blob/master/docs/why-use-pump/README.md#why-use-pump