### PR TITLE
Detect if radio/checkboxes selected

### DIFF
--- a/application/src/js/all/_secondary_sources.js
+++ b/application/src/js/all/_secondary_sources.js
@@ -33,12 +33,19 @@ function SecondarySource(fieldset, secondary_sources) {
 
   function setup() {
 
+    var checkedFieldTypes = ['radio', 'checkbox'];
+    var ignorableFieldTypes = ['submit', 'hidden', 'button'];
+
     var fields = that.fieldset.querySelectorAll('input, textarea')
     var anyFieldsHaveValue = false;
 
     for (var i = fields.length - 1; i >= 0; i--) {
 
-      if (fields[i].value != "") {
+      if (
+        (checkedFieldTypes.includes(fields[i].type) && fields[i].checked === true) ||
+        (!checkedFieldTypes.includes(fields[i].type) && !ignorableFieldTypes.includes(fields[i].type) && fields[i].value != "")
+        ) {
+
         anyFieldsHaveValue = true
         break;
       }
@@ -137,6 +144,7 @@ SecondarySource.prototype.removeSourceButtonClicked = function(event) {
 
   for (var i = 0; i < fields.length; i++) {
     fields[i].value = ""
+    fields[i].checked = false
   };
 
   this.setHidden(true)


### PR DESCRIPTION
When the page loads, we need to check whether to display the secondary
source sections or not, based on whether there is any data specified
for any of those sources.  The current code just checks the `value`
attribute of all the `<input>` elements within the fieldset. For radio
and checkboxes we should detect whether any of them were `checked` or
not instead.

Also, upon removing a secondary source, we should set `checked` to
`false` to reset the radio and checkboxes back to their default state.