### PR TITLE
Hopefully this will speed up dashboard.

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -145,6 +145,7 @@ class Page(db.Model):
 
     parent_guid = db.Column(db.String(255))
     parent_version = db.Column(db.String())
+    parent = relation('Page', order_by='Page.position', remote_side=[guid, version], backref='children')
 
     __table_args__ = (
         PrimaryKeyConstraint('guid', 'version', name='page_guid_version_pk'),
@@ -157,8 +158,6 @@ class Page(db.Model):
     __mapper_args__ = {
         "version_id_col": db_version_id
     }
-
-    children = relation('Page', lazy='dynamic', order_by='Page.position')
 
     uploads = db.relationship('Upload', backref='page', lazy='dynamic', cascade='all,delete')
     dimensions = db.relationship('Dimension',
@@ -461,9 +460,6 @@ class Page(db.Model):
     def major_updates(self):
         versions = Page.query.filter(Page.guid == self.guid, Page.version != self.version)
         return [page for page in versions if page.major() > self.major()]
-
-    def parent(self):
-        return Page.query.filter(Page.guid == self.parent_guid, Page.version == self.parent_version).first()
 
     def to_dict(self, with_dimensions=False):
         page_dict = {

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from flask import render_template
 from flask_login import login_required
 from sqlalchemy import not_
+from sqlalchemy.orm import joinedload
 
 from application.factory import page_service
 from application.dashboard import dashboard_blueprint
@@ -13,22 +14,23 @@ from application.utils import internal_user_required
 from application.cms.models import Page
 
 
+def page_in_week(page, week):
+    return page.publication_date >= week[0] and page.publication_date <= week[6]
+
+
 @dashboard_blueprint.route('/')
 @internal_user_required
 @login_required
 def index():
 
-    original_publications = Page.query.filter(
-        Page.publication_date.isnot(None),
-        Page.version == '1.0',
-        Page.page_type == 'measure'
-    ).all()
+    original_publications = Page.query.filter(Page.publication_date.isnot(None),
+                                              Page.version == '1.0',
+                                              Page.page_type == 'measure').order_by(Page.publication_date.desc()).all()
 
-    major_updates = Page.query.filter(
-        Page.publication_date.isnot(None),
-        Page.page_type == 'measure',
-        not_(Page.version.startswith('1'))
-    ).all()
+    major_updates = Page.query.filter(Page.publication_date.isnot(None),
+                                      Page.page_type == 'measure',
+                                      not_(Page.version.startswith('1')))\
+        .order_by(Page.publication_date.desc()).all()
 
     first_publication = Page.query.filter(
         Page.publication_date.isnot(None)
@@ -45,30 +47,17 @@ def index():
         c = calendar.Calendar(calendar.MONDAY).monthdatescalendar(d.year, d.month)
         for week in c:
             if _in_range(week, first_publication.publication_date, d.month):
-                    publications = Page.query.filter(
-                        Page.publication_date.isnot(None),
-                        Page.publication_date >= week[0],
-                        Page.publication_date <= week[6],
-                        Page.version == '1.0',
-                        Page.page_type == 'measure'
-                    ).order_by(Page.publication_date.desc()).all()
-                    major_updates = Page.query.filter(
-                        Page.publication_date.isnot(None),
-                        Page.publication_date >= week[0],
-                        Page.publication_date <= week[6],
-                        not_(Page.version.startswith('1')),
-                        Page.page_type == 'measure'
-                    ).all()
+                publications = [page for page in original_publications if page_in_week(page, week)]
+                updates = [updated_page for updated_page in major_updates if page_in_week(updated_page, week)]
+                weeks.append({'week': week[0],
+                              'publications': publications,
+                              'major_updates': updates})
 
-                    weeks.append({'week': week[0],
-                                  'publications': publications,
-                                  'major_updates': major_updates})
-
-                    if not cumulative_total:
-                        cumulative_total.append(len(publications) + len(major_updates))
-                    else:
-                        last_total = cumulative_total[-1]
-                        cumulative_total.append(last_total + len(publications) + len(major_updates))
+                if not cumulative_total:
+                    cumulative_total.append(len(publications) + len(updates))
+                else:
+                    last_total = cumulative_total[-1]
+                    cumulative_total.append(last_total + len(publications) + len(updates))
     weeks.reverse()
     data['weeks'] = weeks
     data['graph_values'] = cumulative_total

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -110,8 +110,8 @@ def write_topic_html(page, build_dir, config):
 def write_measure_page(page, build_dir, json_enabled=False, latest=False, local_build=False):
 
     uri = os.path.join(build_dir,
-                       page.parent().parent().uri,
-                       page.parent().uri,
+                       page.parent.parent.uri,
+                       page.parent.uri,
                        page.uri,
                        'latest' if latest else page.version)
 
@@ -128,8 +128,8 @@ def write_measure_page(page, build_dir, json_enabled=False, latest=False, local_
     dimensions = process_dimensions(page, uri, local_build)
 
     content = render_template('static_site/measure.html',
-                              topic=page.parent().parent().uri,
-                              subtopic=page.parent().uri,
+                              topic=page.parent.parent.uri,
+                              subtopic=page.parent.uri,
                               measure_page=page,
                               dimensions=dimensions,
                               versions=versions,
@@ -236,7 +236,7 @@ def unpublish_pages(build_dir):
     pages_to_unpublish = page_service.get_pages_to_unpublish()
     for page in pages_to_unpublish:
         if page.get_previous_version() is None:
-            page_dir = os.path.join(build_dir, page.parent().parent().uri, page.parent().uri, page.uri, 'latest')
+            page_dir = os.path.join(build_dir, page.parent.parent.uri, page.parent.uri, page.uri, 'latest')
             if os.path.exists(page_dir):
                 shutil.rmtree(page_dir, ignore_errors=True)
 

--- a/application/templates/dashboard/index.html
+++ b/application/templates/dashboard/index.html
@@ -63,8 +63,8 @@
                               <ul>
                                 {% for page in  week['publications'] %}
                                     <li><a href="{{ url_for('static_site.measure_page',
-                                                            topic=page.parent().parent().uri,
-                                                            subtopic=page.parent().uri,
+                                                            topic=page.parent.uri,
+                                                            subtopic=page.parent.uri,
                                                             measure=page.uri,
                                                             version='latest') }}">{{ page.title }}</a>
                                         <span class="source">{{ page.department_source.name }}</span>{{ page.publication_date | format_friendly_short_date}}</li>
@@ -76,8 +76,8 @@
                               <ul>
                                 {% for page in week['major_updates'] %}
                                     <li><a href="{{ url_for('static_site.measure_page',
-                                                            topic=page.parent().parent().uri,
-                                                            subtopic=page.parent().uri,
+                                                            topic=page.parent.parent.uri,
+                                                            subtopic=page.parent.uri,
                                                             measure=page.uri,
                                                             version='latest') }}">{{ page.title }}</a>
                                         <span class="source">{{ page.department_source.name }}</span>{{ page.publication_date | format_friendly_short_date}}</li>


### PR DESCRIPTION
First change is proper birectional parent/child relationship with
page model, so that getting subtopic and topic for measure page is
quicker.

Second change is filter list for publications and updates from original
queries rather than re run queries week by week.

@thomasridd and @frankieroberto  want to take this for a test drive?