### PR TITLE
Move google analytics origin to default-src

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -145,8 +145,8 @@ def harden_app(response):
     response.headers.add('Content-Security-Policy', (
         "style-src 'self' 'unsafe-inline';"
         "script-src 'self' 'unsafe-inline' http://widget.surveymonkey.com "
-        "https://ajax.googleapis.com https://www.google-analytics.com;"
-        "default-src 'self';"
+        "https://ajax.googleapis.com;"
+        "default-src 'self' https://www.google-analytics.com;"
         "font-src 'self' data:"))
 
     return response

--- a/application/templates/static_site/_template.html
+++ b/application/templates/static_site/_template.html
@@ -28,7 +28,7 @@
     <meta name="twitter:card" content="summary" />
 
     <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' http://widget.surveymonkey.com https://ajax.googleapis.com https://www.google-analytics.com; font-src 'self' data:; style-src 'self' 'unsafe-inline';">
+      content="default-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' http://widget.surveymonkey.com https://ajax.googleapis.com; font-src 'self' data:; style-src 'self' 'unsafe-inline';">
 
     {% block head %}{% endblock %}
     {% block end_head %}{% endblock %}


### PR DESCRIPTION
We accidentally blocked google analytics as it needs to be whitelisted
for `connect` as well as `script` (so that it can send data to the
origin via AJAX).

Moving the domain to the `default` whitelist should allow it for both.

See https://trello.com/c/QM2xAlA2/715-bug-google-analytics-broken