### PR TITLE
Tweak to move measure

### DIFF
--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -180,24 +180,26 @@
 
                     {% if measure.version == '1.0' or new %}
                         {{ render_field(form.title, disabled=form_disabled, diffs=diffs) }}
-
-                        <div class="form-group">
-                            <label class="form-label" for="subtopic">Sub-topic</label>
-                            <select id="subtopic" name="subtopic" class="form-control sub-topic" {% if form_disabled %}disabled{% endif %}>
-                                {% for topic in topics %}
-                                    <optgroup label="{{ topic.title }}">
-                                        {% for st in topic.children %}
-                                            <option value="{{ st.guid }}" {% if st.guid == subtopic.guid %}selected{% endif %}>{{ st.title }}</option>
-                                        {% endfor %}
-                                    </optgroup>
-                                {% endfor %}
-                            </select>
-                        </div>
-
                     {% else %}
                         {{ render_field(form.title, disabled=True, diffs=diffs) }}
                     {% endif %}
-                    {{ render_field(form.internal_reference, disabled=form_disabled, diffs=diffs, class='short') }}
+
+                    <div class="form-group">
+                        <label class="form-label" for="subtopic">Sub-topic</label>
+                        <select id="subtopic" name="subtopic" class="form-control sub-topic"
+                                {% if form_disabled or (measure and measure.version != '1.0') %}disabled{% endif %}>
+                            {% for topic in topics %}
+                                <optgroup label="{{ topic.title }}">
+                                    {% for st in topic.children %}
+                                        <option value="{{ st.guid }}"
+                                                {% if st.guid == subtopic.guid %}selected{% endif %}>{{ st.title }}</option>
+                                    {% endfor %}
+                                </optgroup>
+                            {% endfor %}
+                        </select>
+                    </div>
+
+                {{ render_field(form.internal_reference, disabled=form_disabled, diffs=diffs, class='short') }}
             </div>
         </div>
         <div class="grid-row">


### PR DESCRIPTION
Rather than hide select for page versions greater than 1.0 - disable subtopic select.