### PR TITLE
Update Sqreen version to latest (v1.10.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ six==1.11.0
 smmap2==2.0.3
 speaklater==1.3
 SQLAlchemy==1.2.2
-sqreen==1.8.4
+sqreen==1.10.0
 Unidecode==0.4.21
 urllib3==1.22
 Werkzeug==0.14.1


### PR DESCRIPTION
Sqreen emails are reporting that "Your agent is outdated"
This updates it to the latest version, see https://pypi.org/project/sqreen/1.10.0/