### PR TITLE
Use TEST_DATABASE_URL env variable in config

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -98,7 +98,7 @@ class TestConfig(DevConfig):
     if os.environ.get('ENVIRONMENT', "CI") == 'CI':
         SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
     else:
-        SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql://localhost/rdcms_test')
+        SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', 'postgresql://localhost/rdcms_test')
     LOGIN_DISABLED = False
     WORK_WITH_REMOTE = False
     FILE_SERVICE = 'Local'


### PR DESCRIPTION
By using DATABASE_URL tests were connecting to local dev db not local test db 
and so getting odd results, if local dev db had existing data.

Use TEST_DATABASE_URL env variable with default to rdcms_test instead.