### PR TITLE
Ensure static files are uploaded to S3 before updated pages

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -296,7 +296,7 @@ def clear_up(build_dir):
 
 def create_versioned_assets(build_dir):
     subprocess.run(['gulp', 'version'])
-    static_dir = '%s/static' % build_dir
+    static_dir = get_static_dir(build_dir)
     if os.path.exists(static_dir):
         shutil.rmtree(static_dir)
     shutil.copytree(current_app.static_folder, static_dir)
@@ -314,3 +314,7 @@ def _prettify(out):
 
 def cleanup_filename(filename):
     return slugify(filename)
+
+
+def get_static_dir(build_dir):
+    return '%s/static' % build_dir


### PR DESCRIPTION
For this ticket: https://trello.com/c/ZANHhelx/768-tech-task-change-static-build-so-that-css-js-etc-sent-to-bucket-first

We've seen an issue where new/updated pages are uploaded before the CSS they need, and so users can see the pages without CSS.  This persists for 15 minutes because of cacheing, even if the required files upload in the meantime.

By ensuring all static assets are uploaded first we should prevent this from happening again.