### PR TITLE
BUGFIX: Require file for uploads form

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -190,7 +190,7 @@ class DimensionForm(FlaskForm):
 
 class UploadForm(FlaskForm):
     guid = StringField()
-    upload = FileField(label="File")
+    upload = FileField(label="File", validators=[DataRequired(message="Please choose a file for users to download")])
     title = StringField(label="Title", validators=[DataRequired()])
     description = TextAreaField()
 


### PR DESCRIPTION
For this ticket: https://trello.com/c/0UlQZuUv/804-bug-empty-file-upload-causes-500-error

We recently (16th May ~10am) saw a production error in Sentry due to an uncaught error when someone tried to submit the "download" form with no file chosen.

Previously, if the form was submitted without a file having been chosen
then an error was thrown by the upload_service as it tried to get a
filename from the empty upload field.

By adding validation at the form level that a file has been chosen we
can avoid the error and instead show a validation message on the upload
field.

On the validation message Spencer says "yep, that seems clear to me :+1:"

## Before
![before](https://user-images.githubusercontent.com/6525554/40118474-f8772f34-5911-11e8-98ab-161309f85d52.png)

## After
![after](https://user-images.githubusercontent.com/6525554/40118488-0071b86c-5912-11e8-9daa-bfe4e0e1d5db.png)

