### PR TITLE
BUGFIX: Additional whitespace in links from BeautifulSoup

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -101,6 +101,10 @@ def create_app(config_object):
     register_errorhandlers(app)
     app.after_request(harden_app)
 
+    # Render jinja templates with less whitespace; applies to both CMS and static build
+    app.jinja_env.trim_blocks = True
+    app.jinja_env.lstrip_blocks = True
+
     app.add_template_filter(format_page_guid)
     app.add_template_filter(format_approve_button)
     app.add_template_filter(format_date_time)

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import subprocess
 
-from bs4 import BeautifulSoup
 from flask import current_app, render_template
 from git import Repo
 from slugify import slugify
@@ -304,12 +303,7 @@ def create_versioned_assets(build_dir):
 
 def write_html(file_path, content):
     with open(file_path, 'w') as out_file:
-        out_file.write(_prettify(content))
-
-
-def _prettify(out):
-    soup = BeautifulSoup(out, 'html.parser')
-    return soup.prettify()
+        out_file.write(content)
 
 
 def cleanup_filename(filename):


### PR DESCRIPTION
For this ticket: https://trello.com/c/afF5IWVz/803-bug-whitespace-after-inline-links-added-by-beautifulsoup

We were using BeautifulSoup to "prettify" our HTML in the static site
build, but it has a tendency to add whitespace at the end of inline
links which shouldn't be there.

Jinja's `trim_blocks` and `lstrip_blocks` directives can be used to
control the amount of whitespace in rendered templates (see
http://jinja.pocoo.org/docs/dev/templates/#whitespace-control).

The results look good, and we don't get those pesky extra spaces in the
links.

Build with no processing: 85.3 MB
Current BeautifulSoup build: 80.2 MB
New Jinja stripped build: 75.8 MB

![build_sizes](https://user-images.githubusercontent.com/6525554/40129088-4e97849a-592b-11e8-956f-f2d52a2ba491.png)

## Before
![before](https://user-images.githubusercontent.com/6525554/40129102-55ace446-592b-11e8-9057-807bf03263cc.png)

## After
![after](https://user-images.githubusercontent.com/6525554/40129116-5c9c1222-592b-11e8-85ab-a15b897f7756.png)
