### PR TITLE
BUGFIX: Strip trailing slash from Dashboards footer link

### DIFF
--- a/application/templates/static_site/_footer.html
+++ b/application/templates/static_site/_footer.html
@@ -13,7 +13,7 @@
               <a href="https://guide.ethnicity-facts-figures.service.gov.uk">Style guide and templates</a>
           </li>
           <li>
-              <a href="{{ url_for('dashboards.index') }}">Dashboards</a>
+              <a href="{{ url_for('dashboards.index').rstrip('/') }}">Dashboards</a>
           </li>
       </ul>
   </div>


### PR DESCRIPTION
The CMS will work with `/dashboards/` or `/dashboard` as Flask is clever
enough to figure it out.

However, the way we push the static site to S3 (converting index.html
files into content with the same name as the containing folder) means
that the link generated by url_for (`/dashboards/`) gives a Not Found
error when Cloudfront tries to find the renamed index file in S3.

By dropping the trailing slash the footer link will work for both CMS
and the static build.