### PR TITLE
Add favicon(s) to CMS base template

### DIFF
--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -14,6 +14,13 @@
     <!--[if IE 8]><link href="{{ url_for('static', filename='govuk_template-0.20.0/assets/stylesheets/fonts-ie8.css') }}" media="all" rel="stylesheet" /><![endif]-->
     <!--[if gte IE 9]><!--><link href="{{ url_for('static', filename='govuk_template-0.20.0/assets/stylesheets/fonts.css') }}" media="all" rel="stylesheet" /><!--<![endif]-->
 
+    <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.ico') }}?0.19.2" type="image/x-icon" />
+    <link rel="mask-icon" href="{{ url_for('static', filename='images/gov.uk_logotype_crown.svg') }}?0.19.2" color="#0b0c0c" />
+    <link rel="apple-touch-icon" sizes="152x152" href="{{ url_for('static', filename='images/apple-touch-icon-152x152.png') }}?0.19.2" />
+    <link rel="apple-touch-icon" sizes="120x120" href="{{ url_for('static', filename='images/apple-touch-icon-120x120.png') }}?0.19.2" />
+    <link rel="apple-touch-icon" sizes="76x76" href="{{ url_for('static', filename='images/apple-touch-icon-76x76.png') }}?0.19.2" />
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='images/apple-touch-icon-60x60.png') }}?0.19.2" />
+
     <!--[if lte IE 8 ]>
     <link href="/static/stylesheets/ie8-fixes.css" media="screen" rel="stylesheet" />
     <script type="text/javascript" src="/static/vendor/details.polyfill.js"></script>


### PR DESCRIPTION
For this bug ticket: https://trello.com/c/6k2kYuS1/806-bug-no-favicon-on-dashboard-pages

The recently published dashboard pages don't have a favicon because they
use the CMS base template, which for some reason differs from the static
site base template.

It would probably be nice to fix it so the CMS and static site both use
the same base template, but for now I think we can just add the icons to
the CMS template.