### PR TITLE
Use `main_content` as block name everywhere

### DIFF
--- a/application/templates/error/400.html
+++ b/application/templates/error/400.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Bad Request{% endblock %}
-{% block content %}
+{% block main_content %}
     <main id="content" role="main">
         <div class='grid-row'>
             <div class='column-full'>

--- a/application/templates/error/401.html
+++ b/application/templates/error/401.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Unauthorized{% endblock %}
-{% block content %}
+{% block main_content %}
     <main id="content" role="main">
         <div class='grid-row'>
             <div class='column-full'>

--- a/application/templates/error/403.html
+++ b/application/templates/error/403.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Forbidden{% endblock %}
-{% block content %}
+{% block main_content %}
     <main id="content" role="main">
         <div class='grid-row'>
             <div class='column-full'>

--- a/application/templates/error/404.html
+++ b/application/templates/error/404.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Page not found{% endblock %}
-{% block content %}
+{% block main_content %}
 <main id="content" role="main">
     <div class='grid-row'>
         <div class='column-full'>

--- a/application/templates/error/500.html
+++ b/application/templates/error/500.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Sorry, we're experiencing technical difficulties{% endblock %}
-{% block content %}
+{% block main_content %}
 <main id="content" role="main">
     <div class='grid-row'>
         <div class='column-full'>

--- a/application/templates/review/token_expired.html
+++ b/application/templates/review/token_expired.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Page can't be viewed{% endblock %}
-{% block content %}
+{% block main_content %}
     <main id="content" role="main">
         <div class='grid-row'>
             <div class='column-full'>

--- a/application/templates/static_site/_base.html
+++ b/application/templates/static_site/_base.html
@@ -26,12 +26,7 @@
 {% endblock %}
 {% block header_class %}with-proposition{% endblock %}
 
-{% block content %}
-
-    {% block main_content %}
-    {% endblock %}
-
-{% endblock %}
+{% block main_content %}{% endblock %}
 
 
 {% block footer_top %}

--- a/application/templates/static_site/_template.html
+++ b/application/templates/static_site/_template.html
@@ -82,7 +82,7 @@
 
     <div id="global-header-bar"></div>
 
-    {% block content %}{% endblock %}
+    {% block main_content %}{% endblock %}
 
     <footer class="group js-footer" id="footer">
 

--- a/application/templates/static_site/error/403.html
+++ b/application/templates/static_site/error/403.html
@@ -1,5 +1,5 @@
 {% extends "static_site/_base.html" %}
-{% block content %}
+{% block main_content %}
     <main id="content">
       {% include 'static_site/_phase_banner.html' %}
         <p>You aren't allowed here</p>

--- a/application/templates/static_site/error/404.html
+++ b/application/templates/static_site/error/404.html
@@ -1,5 +1,5 @@
 {% extends "static_site/_base.html" %}
-{% block content %}
+{% block main_content %}
 <main id="content">
   {% include 'static_site/_phase_banner.html' %}
     <div class='grid-row'>

--- a/application/templates/static_site/error/500.html
+++ b/application/templates/static_site/error/500.html
@@ -1,5 +1,5 @@
 {% extends "static_site/_base.html" %}
-{% block content %}
+{% block main_content %}
 <main id="content">
   {% include 'static_site/_phase_banner.html' %}
     <div class='grid-row'>

--- a/application/templates/static_site/export/_base_export.html
+++ b/application/templates/static_site/export/_base_export.html
@@ -7,12 +7,7 @@
 {% endblock %}
 {% block header_class %}with-proposition{% endblock %}
 
-{% block content %}
-
-    {% block main_content %}
-    {% endblock %}
-
-{% endblock %}
+{% block main_content %}{% endblock %}
 
 {% block body_end %}
   <script type="text/javascript" src="{{ asset_path }}javascripts/{{ 'all.js' | version_filter }}"></script>

--- a/application/templates/static_site/export/_template_export.html
+++ b/application/templates/static_site/export/_template_export.html
@@ -41,7 +41,7 @@
     </header>
 
 
-    {% block content %}{% endblock %}
+    {% block main_content %}{% endblock %}
 
 
     <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>

--- a/application/templates/static_site/not_ready_for_review.html
+++ b/application/templates/static_site/not_ready_for_review.html
@@ -1,5 +1,5 @@
 {% extends "static_site/_base.html" %}
-{% block content %}
+{% block main_content %}
     <main id="content" role="main">
       {% include 'static_site/_phase_banner.html' %}
         <div class='grid-row'>


### PR DESCRIPTION
**REVIEWER**: I'm not sure if there's a good reason not to do this? Tests pass and as far as I can tell things all look OK still...

I noticed that error pages in the CMS don't render any content on the
page - it's just a header and footer. This is because the error page
templates have `block content` but the CMS base template includes only
`block main_content`.

There was a workaround in the export templates where they wrapped
`block main_content` inside `block content`.

It feels nicer to just use the same name everywhere.