### PR TITLE
Anonymise IP addresses at Google Analytics

### DIFF
--- a/application/templates/static_site/_base.html
+++ b/application/templates/static_site/_base.html
@@ -10,6 +10,7 @@
           })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
           ga('create', '{{ config.GOOGLE_ANALYTICS_ID }}', 'auto');
+          ga('set', 'anonymizeIp', true);
           ga('require', 'eventTracker', {
             attributePrefix: 'data-'
           });


### PR DESCRIPTION
This tells Google to anomyise IP addresses (by changing the last octet to 0).

See https://support.google.com/analytics/answer/2763052?hl=en

Part of https://trello.com/c/cw5ETTqU/779-gdpr