### PR TITLE
Remove Secondary Source 2 section from measure page

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -459,50 +459,6 @@
 
             {% endif %}
 
-            {% if measure_page.secondary_source_2_title %}
-
-              <div class="secondary-source">
-                <h3 class="heading-small">Secondary source</h3>
-                <p><a href="{{ measure_page.secondary_source_2_url }}" data-on="click" data-event-category="External link clicked" data-event-action="Data Source (Source Details section)" data-event-label="{{ measure_page.secondary_source_2_title }}">
-                    {{ measure_page.secondary_source_2_title }}
-                </a></p>
-
-                {% if measure_page.secondary_source_2_publisher %}
-                  <h3 class="heading-small">Publisher</h3>
-                  <p>{{ measure_page.secondary_source_2_publisher.name }}</p>
-                {% endif %}
-
-                {% if measure_page.secondary_source_2_type_of_statistic_description %}
-                  <h3 class="heading-small">Type of statistic</h3>
-                  <p>{{ measure_page.secondary_source_2_type_of_statistic_description.external }}</p>
-                {% endif %}
-
-                {% if measure_page.secondary_source_2_frequency_of_release %}
-                  <h3 class="heading-small">Publication frequency</h3>
-                  {% if measure_page.secondary_source_2_frequency_of_release.description == 'Other' %}
-                        {{ measure_page.secondary_source_2_frequency_other }}
-                  {% else %}
-                      {{ measure_page.secondary_source_2_frequency_of_release.description }}
-                  {% endif %}
-                {% endif %}
-
-                {% if measure_page.secondary_source_2_suppression_rules %}
-                <h3 class="heading-small">
-                  Suppression rules
-                </h3>
-                  {{ measure_page.secondary_source_2_suppression_rules | render_markdown }}
-                {% endif %}
-
-                {% if measure_page.secondary_source_2_disclosure_control %}
-                <h3 class="heading-small">
-                  Disclosure control
-                </h3>
-                  {{ measure_page.secondary_source_2_disclosure_control | render_markdown  }}
-                {% endif %}
-              </div>
-
-            {% endif %}
-
           </div>
 
         </div>


### PR DESCRIPTION
We no longer have a secondary source 2 in the model or database, so no
point in trying to show it on the measure page.