### PR TITLE
Make Sqreen version less specific

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ six==1.11.0             # Required by aadict
 smmap2==2.0.3
 speaklater==1.3
 SQLAlchemy==1.2.8
-sqreen==1.12.8
+sqreen>=1.13,<2.0
 Unidecode==1.0.22       # Required by python-slugify
 urllib3==1.22
 Werkzeug==0.14.1


### PR DESCRIPTION
They seem to release a lot of updates to this and we start to get nagging emails within a week of bumping to latest version.

Making the pin to anything 1.x should mean we get nagged less frequently.