### PR TITLE
Bump Selenium to version 3.8.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,5 +11,5 @@ pytest==3.4.0
 pytest-cov==2.5.1
 pytest-flask==0.10.0
 pytest-mock==1.10.0
-selenium==3.5.0
+selenium==3.8.0
 text-unidecode==1.2   # Required by Faker


### PR DESCRIPTION
According to this issue:
https://github.com/SeleniumHQ/selenium/issues/5296

And confirmed by "rigorous" testing pushing up various
branches with different Selenium versions to Heroku -
the issue we've been seeing was apparently introduced
in patch version 3.8.1 and has not yet been fixed.

I have tried the most recent version (3.13.0, released
earlier today) but have seen the same failure on Heroku.