### PR TITLE
CMS views check topic/subtopic/measure hierarchy is correct

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -77,6 +77,10 @@ def create_measure_page(topic, subtopic):
     except PageNotFoundException:
         abort(404)
 
+    # Check the subtopic belongs to the topic
+    if subtopic_page.parent != topic_page:
+        abort(404)
+
     form = MeasurePageForm(frequency_choices=FrequencyOfRelease,
                            type_of_statistic_choices=TypeOfStatistic,
                            lowest_level_of_geography_choices=LowestLevelOfGeography)
@@ -129,15 +133,10 @@ def create_measure_page(topic, subtopic):
 @login_required
 @user_has_access
 def delete_upload(topic, subtopic, measure, version, upload):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        upload_object = measure_page.get_upload(upload)
-    except PageNotFoundException:
-        current_app.logger.exception('Page id: {} not found'.format(measure))
-        abort(404)
-    except UploadNotFoundException:
-        current_app.logger.exception('upload id: {} not found'.format(upload))
-        abort(404)
+
+    *_, measure_page, upload_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, upload=upload)
+
     upload_service.delete_upload_obj(measure_page, upload_object)
 
     message = 'Deleted upload {}'.format(upload_object.title)
@@ -155,17 +154,11 @@ def delete_upload(topic, subtopic, measure, version, upload):
 @login_required
 @user_has_access
 def edit_upload(topic, subtopic, measure, version, upload):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        upload_obj = measure_page.get_upload(upload)
-    except PageNotFoundException:
-        abort(404)
-    except UploadNotFoundException:
-        abort(404)
 
-    form = UploadForm(obj=upload_obj)
+    topic_page, subtopic_page, measure_page, upload_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, upload=upload)
+
+    form = UploadForm(obj=upload_object)
 
     if request.method == 'POST':
         form = UploadForm(CombinedMultiDict((request.files, request.form)))
@@ -173,10 +166,10 @@ def edit_upload(topic, subtopic, measure, version, upload):
             f = form.upload.data if form.upload.data else None
             try:
                 upload_service.edit_upload(measure=measure_page,
-                                           upload=upload_obj,
+                                           upload=upload_object,
                                            file=f,
                                            data=form.data)
-                message = 'Updated upload {}'.format(upload_obj.title)
+                message = 'Updated upload {}'.format(upload_object.title)
                 flash(message, 'info')
                 return redirect(url_for("cms.edit_measure_page",
                                         topic=topic,
@@ -192,7 +185,7 @@ def edit_upload(topic, subtopic, measure, version, upload):
                "topic": topic_page,
                "subtopic": subtopic_page,
                "measure": measure_page,
-               "upload": upload_obj
+               "upload": upload_object
                }
     return render_template("cms/edit_upload.html", **context)
 
@@ -201,13 +194,9 @@ def edit_upload(topic, subtopic, measure, version, upload):
 @login_required
 @user_has_access
 def delete_dimension(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    *_, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension)
 
     dimension_service.delete_dimension(measure_page, dimension_object.guid)
 
@@ -241,42 +230,40 @@ def _diff_updates(form, page):
 @login_required
 @user_has_access
 def edit_measure_page(topic, subtopic, measure, version):
+
+    *_, measure_page = _get_measure_hierarchy_if_consistent_or_404(topic, subtopic, measure, version)
+    topics = page_service.get_pages_by_type('topic')
+    topics.sort(key=lambda page: page.title)
     diffs = {}
-    try:
-        subtopic_page = page_service.get_page(subtopic)
-        topic_page = page_service.get_page(topic)
-        page = page_service.get_page_with_version(measure, version)
 
-        topics = page_service.get_pages_by_type('topic')
-        topics.sort(key=lambda page: page.title)
-
-    except PageNotFoundException:
-        abort(404)
-
-    if page.type_of_data is not None:
-        administrative_data = True if TypeOfData.ADMINISTRATIVE in page.type_of_data else False
-        survey_data = True if TypeOfData.SURVEY in page.type_of_data else False
+    if measure_page.type_of_data is not None:
+        administrative_data = True if TypeOfData.ADMINISTRATIVE in measure_page.type_of_data else False
+        survey_data = True if TypeOfData.SURVEY in measure_page.type_of_data else False
     else:
         administrative_data = survey_data = False
 
-    if page.secondary_source_1_type_of_data is not None:
-        secondary_source_1_administrative_data = True if TypeOfData.ADMINISTRATIVE in page.secondary_source_1_type_of_data else False  # noqa
-        secondary_source_1_survey_data = True if TypeOfData.SURVEY in page.secondary_source_1_type_of_data else False  # noqa
+    if measure_page.secondary_source_1_type_of_data is not None:
+        secondary_source_1_administrative_data = (
+            True if TypeOfData.ADMINISTRATIVE in measure_page.secondary_source_1_type_of_data else False
+        )
+        secondary_source_1_survey_data = (
+            True if TypeOfData.SURVEY in measure_page.secondary_source_1_type_of_data else False
+        )
     else:
         secondary_source_1_administrative_data = secondary_source_1_survey_data = False
 
-    if page.area_covered is not None:
-        if UKCountry.UK in page.area_covered:
+    if measure_page.area_covered is not None:
+        if UKCountry.UK in measure_page.area_covered:
             england = wales = scotland = northern_ireland = True
         else:
-            england = True if UKCountry.ENGLAND in page.area_covered else False
-            wales = True if UKCountry.WALES in page.area_covered else False
-            scotland = True if UKCountry.SCOTLAND in page.area_covered else False
-            northern_ireland = True if UKCountry.NORTHERN_IRELAND in page.area_covered else False
+            england = True if UKCountry.ENGLAND in measure_page.area_covered else False
+            wales = True if UKCountry.WALES in measure_page.area_covered else False
+            scotland = True if UKCountry.SCOTLAND in measure_page.area_covered else False
+            northern_ireland = True if UKCountry.NORTHERN_IRELAND in measure_page.area_covered else False
     else:
         england = wales = scotland = northern_ireland = False
 
-    form = MeasurePageForm(obj=page,
+    form = MeasurePageForm(obj=measure_page,
                            administrative_data=administrative_data,
                            survey_data=survey_data,
                            secondary_source_1_administrative_data=secondary_source_1_administrative_data,
@@ -306,18 +293,18 @@ def edit_measure_page(topic, subtopic, measure, version):
             # the original design was move was a separate activity not bundled up with edit
             form_data = form.data
             form_data['subtopic'] = request.form.get('subtopic', None)
-            page_service.update_page(page, data=form_data, last_updated_by=current_user.email)
-            message = 'Updated page "{}"'.format(page.title)
+            page_service.update_page(measure_page, data=form_data, last_updated_by=current_user.email)
+            message = 'Updated page "{}"'.format(measure_page.title)
             current_app.logger.info(message)
             flash(message, 'info')
             saved = True
         except PageExistsException as e:
             current_app.logger.info(e)
             flash(str(e), 'error')
-            form.title.data = page.title
+            form.title.data = measure_page.title
         except StaleUpdateException as e:
             current_app.logger.error(e)
-            diffs = _diff_updates(form, page)
+            diffs = _diff_updates(form, measure_page)
             if diffs:
                 flash('Your update will overwrite the latest content. Resolve the conflicts below', 'error')
             else:
@@ -330,29 +317,29 @@ def edit_measure_page(topic, subtopic, measure, version):
         message = 'This page could not be saved. Please check for errors below'
         flash(message, 'error')
 
-    current_status = page.status
-    available_actions = page.available_actions()
+    current_status = measure_page.status
+    available_actions = measure_page.available_actions()
     if 'APPROVE' in available_actions:
-        numerical_status = page.publish_status(numerical=True)
+        numerical_status = measure_page.publish_status(numerical=True)
         approval_state = publish_status.inv[(numerical_status + 1) % 6]
 
     if saved and 'save-and-review' in request.form:
         return redirect(url_for('cms.send_to_review',
-                                topic=page.parent.parent.guid,
-                                subtopic=page.parent.guid,
-                                measure=page.guid,
-                                version=page.version))
+                                topic=measure_page.parent.parent.guid,
+                                subtopic=measure_page.parent.guid,
+                                measure=measure_page.guid,
+                                version=measure_page.version))
     elif saved:
         return redirect(url_for('cms.edit_measure_page',
-                                topic=page.parent.parent.guid,
-                                subtopic=page.parent.guid,
-                                measure=page.guid,
-                                version=page.version))
+                                topic=measure_page.parent.parent.guid,
+                                subtopic=measure_page.parent.guid,
+                                measure=measure_page.guid,
+                                version=measure_page.version))
     context = {
         'form': form,
-        'topic': page.parent.parent,
-        'subtopic': page.parent,
-        'measure': page,
+        'topic': measure_page.parent.parent,
+        'subtopic': measure_page.parent,
+        'measure': measure_page,
         'status': current_status,
         'available_actions': available_actions,
         'next_approval_state': approval_state if 'APPROVE' in available_actions else None,
@@ -369,12 +356,10 @@ def edit_measure_page(topic, subtopic, measure, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_upload(topic, subtopic, measure, version):
-    try:
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        measure_page = page_service.get_page_with_version(measure, version)
-    except PageNotFoundException:
-        abort(404)
+
+    topic_page, subtopic_page, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
 
     form = UploadForm()
     if request.method == 'POST':
@@ -421,35 +406,33 @@ def create_upload(topic, subtopic, measure, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def send_to_review(topic, subtopic, measure, version):
-    try:
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        page = page_service.get_page_with_version(measure, version)
-    except PageNotFoundException:
-        abort(404)
+
+    topic_page, subtopic_page, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
 
     # in case user tries to directly GET this page
-    if page.status == 'DEPARTMENT_REVIEW':
+    if measure_page.status == 'DEPARTMENT_REVIEW':
         abort(400)
 
-    if page.type_of_data is not None:
-        administrative_data = TypeOfData.ADMINISTRATIVE in page.type_of_data
-        survey_data = TypeOfData.SURVEY in page.type_of_data
+    if measure_page.type_of_data is not None:
+        administrative_data = TypeOfData.ADMINISTRATIVE in measure_page.type_of_data
+        survey_data = TypeOfData.SURVEY in measure_page.type_of_data
     else:
         administrative_data = survey_data = False
 
-    if page.area_covered is not None:
-        if UKCountry.UK in page.area_covered:
+    if measure_page.area_covered is not None:
+        if UKCountry.UK in measure_page.area_covered:
             england = wales = scotland = northern_ireland = True
         else:
-            england = True if UKCountry.ENGLAND in page.area_covered else False
-            wales = True if UKCountry.WALES in page.area_covered else False
-            scotland = True if UKCountry.SCOTLAND in page.area_covered else False
-            northern_ireland = True if UKCountry.NORTHERN_IRELAND in page.area_covered else False
+            england = True if UKCountry.ENGLAND in measure_page.area_covered else False
+            wales = True if UKCountry.WALES in measure_page.area_covered else False
+            scotland = True if UKCountry.SCOTLAND in measure_page.area_covered else False
+            northern_ireland = True if UKCountry.NORTHERN_IRELAND in measure_page.area_covered else False
     else:
         england = wales = scotland = northern_ireland = False
 
-    form_to_validate = MeasurePageRequiredForm(obj=page,
+    form_to_validate = MeasurePageRequiredForm(obj=measure_page,
                                                meta={'csrf': False},
                                                administrative_data=administrative_data,
                                                survey_data=survey_data,
@@ -463,7 +446,7 @@ def send_to_review(topic, subtopic, measure, version):
 
     invalid_dimensions = []
 
-    for dimension in page.dimensions:
+    for dimension in measure_page.dimensions:
         dimension_form = DimensionRequiredForm(obj=dimension, meta={'csrf': False})
         if not dimension_form.validate():
             invalid_dimensions.append(dimension)
@@ -474,7 +457,7 @@ def send_to_review(topic, subtopic, measure, version):
         session.pop('_flashes', None)
 
         # Recreate form with csrf token for next update
-        form = MeasurePageForm(obj=page,
+        form = MeasurePageForm(obj=measure_page,
                                administrative_data=administrative_data,
                                survey_data=survey_data,
                                frequency_choices=FrequencyOfRelease,
@@ -500,17 +483,17 @@ def send_to_review(topic, subtopic, measure, version):
                           % (invalid_dimension.guid, invalid_dimension.title)
                 flash(message, 'dimension-error')
 
-        current_status = page.status
-        available_actions = page.available_actions()
+        current_status = measure_page.status
+        available_actions = measure_page.available_actions()
         if 'APPROVE' in available_actions:
-            numerical_status = page.publish_status(numerical=True)
+            numerical_status = measure_page.publish_status(numerical=True)
             approval_state = publish_status.inv[numerical_status + 1]
 
         context = {
             'form': form,
             'topic': topic_page,
             'subtopic': subtopic_page,
-            'measure': page,
+            'measure': measure_page,
             'status': current_status,
             'available_actions': available_actions,
             'next_approval_state': approval_state if 'APPROVE' in available_actions else None,
@@ -520,7 +503,7 @@ def send_to_review(topic, subtopic, measure, version):
 
         return render_template("cms/edit_measure_page.html", **context)
 
-    message = page_service.next_state(page, updated_by=current_user.email)
+    message = page_service.next_state(measure_page, updated_by=current_user.email)
     current_app.logger.info(message)
     flash(message, 'info')
 
@@ -536,21 +519,23 @@ def send_to_review(topic, subtopic, measure, version):
 @user_has_access
 @user_can(PUBLISH)
 def publish(topic, subtopic, measure, version):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        if measure_page.status != 'DEPARTMENT_REVIEW':
-            abort(400)
-        message = page_service.next_state(measure_page, current_user.email)
-        current_app.logger.info(message)
-        _build_if_necessary(measure_page)
-        flash(message, 'info')
-        return redirect(url_for("cms.edit_measure_page",
-                                topic=topic,
-                                subtopic=subtopic,
-                                measure=measure,
-                                version=version))
-    except PageNotFoundException:
-        abort(404)
+
+    *_, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
+
+    if measure_page.status != 'DEPARTMENT_REVIEW':
+        abort(400)
+
+    message = page_service.next_state(measure_page, current_user.email)
+    current_app.logger.info(message)
+    _build_if_necessary(measure_page)
+    flash(message, 'info')
+    return redirect(url_for("cms.edit_measure_page",
+                            topic=topic,
+                            subtopic=subtopic,
+                            measure=measure,
+                            version=version))
 
 
 @cms_blueprint.route('/<topic>/<subtopic>/<measure>/<version>/reject')
@@ -558,6 +543,15 @@ def publish(topic, subtopic, measure, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def reject_page(topic, subtopic, measure, version):
+
+    *_, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
+
+    # Can only reject if currently under review
+    if measure_page.status != 'DEPARTMENT_REVIEW':
+        abort(400)
+
     message = page_service.reject_page(measure, version)
     flash(message, 'info')
     current_app.logger.info(message)
@@ -573,6 +567,15 @@ def reject_page(topic, subtopic, measure, version):
 @user_has_access
 @user_can(PUBLISH)
 def unpublish_page(topic, subtopic, measure, version):
+
+    *_, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
+
+    # Can only unpublish if currently published
+    if measure_page.status != 'APPROVED':
+        abort(400)
+
     page, message = page_service.unpublish(measure, version, current_user.email)
     _build_if_necessary(page)
     flash(message, 'info')
@@ -589,6 +592,9 @@ def unpublish_page(topic, subtopic, measure, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def send_page_to_draft(topic, subtopic, measure, version):
+
+    _ = _get_measure_hierarchy_if_consistent_or_404(topic, subtopic, measure, version)
+
     message = page_service.send_page_to_draft(measure, version)
     flash(message, 'info')
     current_app.logger.info(message)
@@ -604,12 +610,10 @@ def send_page_to_draft(topic, subtopic, measure, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_dimension(topic, subtopic, measure, version):
-    try:
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        measure_page = page_service.get_page_with_version(measure, version)
-    except PageNotFoundException:
-        abort(404)
+
+    topic_page, subtopic_page, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
 
     form = DimensionForm()
     if request.method == 'POST':
@@ -663,22 +667,15 @@ def create_dimension(topic, subtopic, measure, version):
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def edit_dimension(topic, subtopic, measure, dimension, version):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        dimension_object = measure_page.get_dimension(dimension)
-        current_cat_link = categorisation_service.get_categorisation_link_for_dimension_by_family(
-            dimension=dimension_object,
-            family='Ethnicity')
+def edit_dimension(topic, subtopic, measure, version, dimension):
 
-    except PageNotFoundException:
-        current_app.logger.exception('Page id {} not found'.format(measure))
-        abort(404)
-    except DimensionNotFoundException:
-        current_app.logger.exception('Dimension id {} of page id {} not found'.format(dimension, measure))
-        abort(404)
+    topic_page, subtopic_page, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
+
+    current_cat_link = categorisation_service.get_categorisation_link_for_dimension_by_family(
+        dimension=dimension_object,
+        family='Ethnicity')
 
     if request.method == 'POST':
         form = DimensionForm(request.form)
@@ -718,15 +715,10 @@ def edit_dimension(topic, subtopic, measure, dimension, version):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_chart(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    topic_page, subtopic_page, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     context = {'topic': topic_page,
                'subtopic': subtopic_page,
@@ -742,15 +734,10 @@ def create_chart(topic, subtopic, measure, version, dimension):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_table(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    topic_page, subtopic_page, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     context = {'topic': topic_page,
                'subtopic': subtopic_page,
@@ -765,13 +752,10 @@ def create_table(topic, subtopic, measure, version, dimension):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def save_chart_to_page(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    *_, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     if measure_page.not_editable():
         message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_page.guid)
@@ -794,13 +778,10 @@ def save_chart_to_page(topic, subtopic, measure, version, dimension):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def delete_chart(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    *_, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     dimension_service.delete_chart(dimension_object)
 
@@ -821,13 +802,10 @@ def delete_chart(topic, subtopic, measure, version, dimension):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def save_table_to_page(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    *_, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     if measure_page.not_editable():
         message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_page.guid)
@@ -850,13 +828,10 @@ def save_table_to_page(topic, subtopic, measure, version, dimension):
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def delete_table(topic, subtopic, measure, version, dimension):
-    try:
-        measure_page = page_service.get_page_with_version(measure, version)
-        dimension_object = measure_page.get_dimension(dimension)
-    except PageNotFoundException:
-        abort(404)
-    except DimensionNotFoundException:
-        abort(404)
+
+    *_, measure_page, dimension_object = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version, dimension=dimension
+    )
 
     dimension_service.delete_table(dimension_object)
 
@@ -875,12 +850,10 @@ def delete_table(topic, subtopic, measure, version, dimension):
 @cms_blueprint.route('/<topic>/<subtopic>/<measure>/<version>/uploads', methods=['GET'])
 @login_required
 def get_measure_page_uploads(topic, subtopic, measure, version):
-    try:
-        page = page_service.get_page_with_version(measure, version)
-        uploads = upload_service.get_page_uploads(page)
-        return json.dumps({'uploads': uploads}), 200
-    except PageNotFoundException:
-        return json.dumps({}), 404
+
+    *_, measure_page = _get_measure_hierarchy_if_consistent_or_404(topic, subtopic, measure, version)
+    uploads = upload_service.get_page_uploads(measure_page) or {}
+    return json.dumps({'uploads': uploads}), 200
 
 
 def _build_is_required(page, req, beta_publication_states):
@@ -902,6 +875,9 @@ def process_input_data():
         return json.dumps(request.json), 200
 
 
+# TODO: Figure out if this endpoint really needs to take topic/subtopic/measure?
+# * If so, it should also take version and call _get_measure_hierarchy_if_consistent_or_404
+# * If not, refactor to remove these parameters from the url and call signature
 @cms_blueprint.route('/<topic>/<subtopic>/<measure>/set-dimension-order', methods=['POST'])
 @login_required
 def set_dimension_order(topic, subtopic, measure):
@@ -917,8 +893,12 @@ def set_dimension_order(topic, subtopic, measure):
 @login_required
 @user_has_access
 def list_measure_page_versions(topic, subtopic, measure):
-    topic_page = page_service.get_page(topic)
-    subtopic_page = page_service.get_page(subtopic)
+    try:
+        topic_page = page_service.get_page(topic)
+        subtopic_page = page_service.get_page(subtopic)
+    except PageNotFoundException:
+        current_app.logger.exception('Page id: {} not found'.format(measure))
+        abort(404)
     measures = page_service.get_measure_page_versions(subtopic, measure)
     measures.sort(reverse=True)
     if not measures:
@@ -935,24 +915,27 @@ def list_measure_page_versions(topic, subtopic, measure):
 @login_required
 @user_can(DELETE_MEASURE)
 def delete_measure_page(topic, subtopic, measure, version):
-    try:
-        page_service.delete_measure_page(measure, version)
-        topic_page = page_service.get_page(topic)
-        if request.referrer.endswith('/versions'):
-            return redirect(url_for('cms.list_measure_page_versions', topic=topic, subtopic=subtopic, measure=measure))
-        else:
-            return redirect(url_for('static_site.topic', uri=topic_page.uri))
-    except PageNotFoundException:
-        abort(404)
+
+    topic_page, *_ = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
+
+    page_service.delete_measure_page(measure, version)
+    if request.referrer.endswith('/versions'):
+        return redirect(url_for('cms.list_measure_page_versions', topic=topic, subtopic=subtopic, measure=measure))
+    else:
+        return redirect(url_for('static_site.topic', uri=topic_page.uri))
 
 
 @cms_blueprint.route('/<topic>/<subtopic>/<measure>/<version>/new-version', methods=['GET', 'POST'])
 @login_required
 @user_can(CREATE_VERSION)
 def new_version(topic, subtopic, measure, version):
-    topic_page = page_service.get_page(topic)
-    subtopic_page = page_service.get_page(subtopic)
-    measure_page = page_service.get_page_with_version(measure, version)
+
+    topic_page, subtopic_page, measure_page = _get_measure_hierarchy_if_consistent_or_404(
+        topic, subtopic, measure, version
+    )
+
     form = NewVersionForm()
     if form.validate_on_submit():
         version_type = form.data['version_type']
@@ -1007,3 +990,45 @@ def _build_if_necessary(page):
     elif page.eligible_for_build():
         page_service.mark_page_published(page)
         build_service.request_build()
+
+
+def _get_measure_hierarchy_if_consistent_or_404(topic, subtopic, measure, version, dimension=None, upload=None):
+    try:
+        topic_page = page_service.get_page(topic)
+        subtopic_page = page_service.get_page(subtopic)
+        measure_page = page_service.get_page_with_version(measure, version)
+        dimension_object = measure_page.get_dimension(dimension) if dimension else None
+        upload_object = measure_page.get_upload(upload) if upload else None
+    except PageNotFoundException:
+        current_app.logger.exception('Page id: {} not found'.format(measure))
+        abort(404)
+    except UploadNotFoundException:
+        current_app.logger.exception('Upload id: {} not found'.format(upload))
+        abort(404)
+    except DimensionNotFoundException:
+        current_app.logger.exception('Dimension id: {} not found'.format(dimension))
+        abort(404)
+
+    # Check the topic and subtopics in the URL are the right ones for the measure
+    if measure_page.parent != subtopic_page or measure_page.parent.parent != topic_page:
+        abort(404)
+
+    # Check the dimension belongs to the measure
+    if dimension_object and (
+            dimension_object.page_id != measure_page.guid or dimension_object.page_version != measure_page.version
+    ):
+        abort(404)
+
+    # Check the upload belongs to the measure
+    if upload_object and (
+            upload_object.page_id != measure_page.guid or upload_object.page_version != measure_page.version
+    ):
+        abort(404)
+
+    return_items = [topic_page, subtopic_page, measure_page]
+    if dimension_object:
+        return_items.append(dimension_object)
+    if upload_object:
+        return_items.append(upload_object)
+
+    return (item for item in return_items)


### PR DESCRIPTION
For this Trello ticket: https://trello.com/c/dURIvqsB/845-bug-some-cms-views-do-not-check-that-measures-belong-to-topic-subtopic-specified-in-the-url

Previously some of the CMS views didn't enforce that the topic/subtopic
mentioned in the URL are the ones that the measure belongs to.

It's a bit odd that you could update a measure at a URL that has
mismatched topic and subtopic parameters, so this makes CMS endpoints
that take topic/subtopic/measure/version check that the hierarchy
is consistent.