### PR TITLE
Upgrade mini racer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ MarkupSafe==1.0
 passlib==1.7.1
 passwordmeter==0.1.8
 psycopg2==2.7.3.2
-py-mini-racer==0.1.12
+py-mini-racer==0.1.15
 py-trello==0.10.0
 pycparser==2.18
 python-dateutil==2.7.3  # Required by alembic


### PR DESCRIPTION
 ## Summary
Installation of pip requirements failed with a clean setup (Python 3.7.0
and Pip 10.0.3) due to some part of the setup script using Python2
syntax. Upgrading to this version allows the package to install
correctly.