### PR TITLE
Add warning when not uploading object

### DIFF
--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -116,8 +116,11 @@ class S3FileSystem:
                                            Fileobj=file,
                                            ExtraArgs={'ContentType': mimetype,
                                                       'CacheControl': 'max-age=%s' % max_age_seconds})
-            if mimetype is None and strict:
-                raise UploadCheckError("Couldn't determine the type of file you uploaded")
+            if mimetype is None:
+                if strict:
+                    raise UploadCheckError("Couldn't determine the type of file you uploaded")
+                else:
+                    logger.warning(f'Not writing file {fs_path} due to unknown mimetype.')
 
     def list_paths(self, fs_path):
         return [x.key for x in self.bucket.objects.filter(Prefix=fs_path)]


### PR DESCRIPTION
 ## Summary
I spent quite a while trying to work out why a file wasn't being
uploaded to s3, despite the fact we were clearly calling `s3.write`.
This method silently refuses to write an object if it can't work out
what kind of file it is. It feels nice to add a message indicating that
the file is not being written because of this reason, to prevent any
wasted time trying to work out why it's not being uploaded.