### PR TITLE
Fix logger initialisation

### DIFF
--- a/application/cms/service.py
+++ b/application/cms/service.py
@@ -1,15 +1,13 @@
+import inspect
 import logging
 
 from application.utils import setup_module_logging
 
 
-logger = logging.Logger(__name__)
-
-
 class Service:
 
     def __init__(self):
-        self.logger = logger
+        self.logger = logging.Logger(inspect.getmodule(self).__name__)
 
     def init_app(self, app):
         self.logger = setup_module_logging(self.logger, app.config['LOG_LEVEL'])

--- a/application/utils.py
+++ b/application/utils.py
@@ -26,6 +26,10 @@ def setup_module_logging(logger, level):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(level)
+
+    if len(logger.handlers) > 1:
+        logger.warning('The same logger may have been initialised multiple times.')
+
     return logger
 
 


### PR DESCRIPTION
 ## Summary
We weren't passing loggers created in the context of each module into
the `setup_module_logging` function, so each service was using a shared
logger from `application.cms.service`. Every time `setup_module_logging`
is called it appends a new handler to the logger, which would result in
multiple stdout stream handlers for the same root module, generating
duplicated logging entries. This patch creates a logger for each service
and passes it down the chain correctly so that each one receives its own
stream handler.