### PR TITLE
Allow google analytics site-wide

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -178,7 +178,8 @@ def get_content_security_policy(allow_google_custom_search=False):
     content_security_policy = (
         "default-src 'self';"
         "script-src 'self' 'unsafe-inline' http://widget.surveymonkey.com "
-        "https://www.googleapis.com {additional_script_src} data:;"
+        "https://ajax.googleapis.com https://www.google-analytics.com "
+        "{additional_script_src} data:;"
         "connect-src 'self' https://www.google-analytics.com;"
         "style-src 'self' 'unsafe-inline' {additional_style_src};"
         "img-src 'self' https://www.google-analytics.com {additional_img_src};"
@@ -188,7 +189,7 @@ def get_content_security_policy(allow_google_custom_search=False):
 
     additional_script_src = (
         "'unsafe-eval' http://cse.google.com https://cse.google.com https://www.google.com "
-        "https://ajax.googleapis.com https://www.google-analytics.com"
+        "https://www.googleapis.com "
     ) if allow_google_custom_search else ""
     additional_style_src = (
         "'unsafe-eval' https://www.google.com"


### PR DESCRIPTION
 ## Summary
When adding search to the site, we had to open up our Content Security
Policy. In the refactor for this, we accidentally made google analytics
only available on the search site in commit
d9b4c9fdc9d8fe178370ea340570b15807c4556d. This returns the default CSP
to the old settings, which should give us proper analytics again.

 ## Ticket
https://trello.com/c/lSaOw2Dm/897