### PR TITLE
Only build the static site with published measures

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -54,7 +54,7 @@ def do_it(application, build):
 def build_from_homepage(page, build_dir, config):
 
     os.makedirs(build_dir, exist_ok=True)
-    topics = sorted(page.children, key=lambda t: t.title)
+    topics = page.topics_with_published_measures()
     content = render_template('static_site/index.html',
                               topics=topics,
                               build_timestamp=None,


### PR DESCRIPTION
 ## Summary
The static builder was retrieving all topic children of the homepage -
we only want to display topics which have published measures.

 ## Ticket
https://trello.com/c/AhgrGiIL/857