### PR TITLE
Fix subtopic guids

### DIFF
--- a/application/review/views.py
+++ b/application/review/views.py
@@ -22,7 +22,9 @@ def review_page(review_token):
 
         return render_template('static_site/measure.html',
                                topic=page.parent.parent.uri,
+                               topic_guid=page.parent.parent.guid,
                                subtopic=page.parent.uri,
+                               subtopic_guid=page.parent.guid,
                                measure_page=page,
                                dimensions=dimensions,
                                preview=True)

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -91,7 +91,7 @@ def topic(uri):
 @static_site_blueprint.route('/<topic>/<subtopic>/<measure>/<version>/data.json')
 @user_has_access
 def measure_page_json(topic, subtopic, measure, version):
-    subtopic_guid = 'subtopic_%s' % subtopic.replace('-', '')
+    subtopic_guid = page_service.get_page_by_uri_and_type(subtopic, 'subtopic').guid
 
     try:
         if version == 'latest':
@@ -108,8 +108,9 @@ def measure_page_json(topic, subtopic, measure, version):
 @login_required
 @user_has_access
 def measure_page_markdown(topic, subtopic, measure, version):
+    topic_guid = page_service.get_page_by_uri_and_type(topic, 'topic').guid
+    subtopic_guid = page_service.get_page_by_uri_and_type(subtopic, 'subtopic').guid
 
-    subtopic_guid = 'subtopic_%s' % subtopic.replace('-', '')
     try:
         if version == 'latest':
             page = page_service.get_latest_version(subtopic_guid, measure)
@@ -124,7 +125,9 @@ def measure_page_markdown(topic, subtopic, measure, version):
     dimensions = [dimension.to_dict() for dimension in page.dimensions]
     return render_template('static_site/export/measure_export.html',
                            topic=topic,
+                           topic_guid=topic_guid,
                            subtopic=subtopic,
+                           subtopic_guid=subtopic_guid,
                            measure_page=page,
                            dimensions=dimensions)
 
@@ -138,8 +141,9 @@ def index_page_json():
 @login_required
 @user_has_access
 def measure_page(topic, subtopic, measure, version):
+    topic_guid = page_service.get_page_by_uri_and_type(topic, 'topic').guid
+    subtopic_guid = page_service.get_page_by_uri_and_type(subtopic, 'subtopic').guid
 
-    subtopic_guid = 'subtopic_%s' % subtopic.replace('-', '')
     try:
         if version == 'latest':
             page = page_service.get_latest_version(subtopic_guid, measure)
@@ -159,7 +163,9 @@ def measure_page(topic, subtopic, measure, version):
 
     return render_template('static_site/measure.html',
                            topic=topic,
+                           topic_guid=topic_guid,
                            subtopic=subtopic,
+                           subtopic_guid=subtopic_guid,
                            measure_page=page,
                            dimensions=dimensions,
                            versions=versions,

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -27,14 +27,14 @@
               <li>
                 {% if measure_page.latest_version() %}
                     <a href="{{ url_for('cms.edit_measure_page',
-                 topic='topic_%s' % topic.replace('-', ''),
-                 subtopic='subtopic_%s' % subtopic.replace('-', ''),
+                 topic=topic_guid,
+                 subtopic=subtopic_guid,
                  measure=measure_page.guid,
                  version=measure_page.version) }}">Edit</a>
                 {% else %}
                     <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic='topic_%s' % topic.replace('-', ''),
-                        subtopic='subtopic_%s' % subtopic.replace('-', ''),
+                        topic=topic_guid,
+                        subtopic=subtopic_guid,
                         measure=measure_page.guid) }}">Edit</a>
                 {% endif %}
               </li>
@@ -47,8 +47,8 @@
                  version=measure_page.version) }}">Export</a>
                 {% else %}
                     <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic='topic_%s' % topic.replace('-', ''),
-                        subtopic='subtopic_%s' % subtopic.replace('-', ''),
+                        topic=topic_guid,
+                        subtopic=subtopic_guid,
                         measure=measure_page.guid) }}">Export</a>
                 {% endif %}
               </li>


### PR DESCRIPTION
 ## Summary
Our subtopic/measure views try to build an ideal subtopic guid from the
URI rather than looking it up in the database and using that to
retrieve the _actual_ guid. This updates the views to actually use the
information they have to retrieve the correct information from the
database.

Note: **not** an optimal solution - but a working one until we have time to revisit and refactor.

 ## Ticket
https://trello.com/c/XylzPf4Y/909

 ## Tech debt ticket created
https://trello.com/c/Epn14w5O/910