### PR TITLE
Add migration for existing population topics

### DIFF
--- a/scripts/data_migrations/migrate-population-measures.sql
+++ b/scripts/data_migrations/migrate-population-measures.sql
@@ -1,0 +1,2 @@
+UPDATE page SET parent_guid = 'subtopic_demographics' WHERE parent_guid = 'subtopic_community' and uri = 'english-language-skills';
+UPDATE page SET parent_guid = 'subtopic_demographics' WHERE parent_guid = 'subtopic_community' and uri = 'people-living-in-deprived-neighbourhoods';


### PR DESCRIPTION
 ## Summary
Moves the existing population topics, 'English language skills' and
'People living in deprived neighbourhoods', to the British Population ->
Demographics subtopic.

 ## Ticket
https://trello.com/c/CrOTTaRE/861