### PR TITLE
Add hostname and protocol redirect elements

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -90,6 +90,8 @@ class Config:
     GOOGLE_CUSTOM_SEARCH_ID = '013520531703188648524:9giiejumedo'
 
     REDIRECT_HTTP_CODE = os.environ.get('REDIRECT_HTTP_CODE', 301)
+    REDIRECT_PROTOCOL = os.environ.get('REDIRECT_PROTOCOL', 'http')
+    REDIRECT_HOSTNAME = os.environ.get('REDIRECT_HOSTNAME', 'localhost')
 
     NEWSLETTER_SUBSCRIBE_URL = os.environ.get('NEWSLETTER_SUBSCRIBE_URL')
 

--- a/application/redirects/views.py
+++ b/application/redirects/views.py
@@ -35,8 +35,15 @@ def _build_routing_rules_xml(redirects):
         redirect = SubElement(routing_rule, 'Redirect')
         replace_key_prefix = SubElement(redirect, 'ReplaceKeyPrefixWith')
         replace_key_prefix.text = r.to_uri
+
         http_redirect_code = SubElement(redirect, 'HttpRedirectCode')
         http_redirect_code.text = str(current_app.config['REDIRECT_HTTP_CODE'])
+
+        redirect_hostname = SubElement(redirect, 'HostName')
+        redirect_hostname.text = current_app.config['REDIRECT_HOSTNAME']
+
+        redirect_protocol = SubElement(redirect, 'Protocol')
+        redirect_protocol.text = current_app.config['REDIRECT_PROTOCOL']
 
     return tostring(root)
 


### PR DESCRIPTION
 ## Summary
When CloudFront sits in front of an S3 static site with redirects we
need to define the hostname and protocol to use when performing the
redirect, otherwise S3 redirects to the raw S3 site domain.