### PR TITLE
Update python heroku buildpack

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.5
+python-3.6.6


### PR DESCRIPTION
 ## Summary
Heroku no longer supports the python-3.6.5 buildpack, having upgraded to
python-3.6.6. We should do the same so that we benefit from their
supported infrastructure.

https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-python