### PR TITLE
Fix gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,11 +87,10 @@ gulp.task('scripts-cms-autosave', function(cb) {
 });
 
 gulp.task('watch', function () {
-  gulp.watch(['./application/src/js/**/*.js', './application/src/sass/*.scss', './application/src/sass/**/*.scss'], ['version']);
+  gulp.watch(['./application/src/js/**/*.js', './application/src/sass/*.scss', './application/src/sass/**/*.scss'], gulp.series('version'));
 });
 
-gulp.task('version-js', gulp.series(gulp.parallel('scripts-all', 'scripts-charts', 'scripts-cms', 'scripts-cms-autosave'), function() {
-    console.log(production);
+gulp.task('version-js', gulp.parallel('scripts-all', 'scripts-charts', 'scripts-cms', 'scripts-cms-autosave'), function() {
   return gulp.src(['./application/static/javascripts/all.js',
     './application/static/javascripts/charts.js',
     './application/static/javascripts/cms.js',
@@ -100,15 +99,15 @@ gulp.task('version-js', gulp.series(gulp.parallel('scripts-all', 'scripts-charts
     .pipe(gulp.dest('./application/static/javascripts'))
     .pipe(rev.manifest())
     .pipe(gulp.dest('./application/static/javascripts'))
-}));
+});
 
-gulp.task('version-css', gulp.series('sass', function() {
+gulp.task('version-css', gulp.series('sass'), function() {
   return gulp.src(['./application/static/stylesheets/application.css', './application/static/stylesheets/cms.css'])
     .pipe(rev())
     .pipe(gulp.dest('./application/static/stylesheets'))
     .pipe(rev.manifest())
     .pipe(gulp.dest('./application/static/stylesheets'))
-}));
+});
 
 
 gulp.task('version', gulp.parallel('version-css', 'version-js'));


### PR DESCRIPTION
 ## Summary
Gulp tasks need to be functions - preferably either using `gulp.series` or `gulp.parallel`. We can use the former for our watch task, as the `version` task contains subtasks which are parallelised as appropriate.

 ## Ticket
https://trello.com/c/e6GIUK7n/936