### PR TITLE
Include failure reason in email

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -211,10 +211,11 @@ def report_broken_build():
         .first()
     )
     if failed:
-        message = "Build failure in application %s. Build id %s created at %s" % (
+        message = "Build failure in application %s. Build id %s created at %s\n\n%s" % (
             app.config["ENVIRONMENT"],
             failed.id,
             failed.created_at,
+            failed.failure_reason,
         )
         subject = "Build failure in application %s on %s" % (app.config["ENVIRONMENT"], date.today())
         recipients = db.session.query(User).filter(User.user_type == TypeOfUser.DEV_USER.name).all()


### PR DESCRIPTION
 ## Summary
We get emails when static builds of the site fail, but it doesn't
include the stack trace for quick debugging/triaging.