### PR TITLE
PageNotFoundException should return a 404

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -12,7 +12,7 @@ from raven.contrib.flask import Sentry
 from application import db, mail
 from application.auth.models import User
 from application.cms.data_utils import Harmoniser, AutoDataGenerator
-from application.cms.exceptions import InvalidPageHierarchy
+from application.cms.exceptions import InvalidPageHierarchy, PageNotFoundException
 from application.cms.file_service import FileService
 from application.cms.filters import (
     format_page_guid,
@@ -230,10 +230,11 @@ def harden_app(response):
 
 
 def register_errorhandlers(app):
-    def invalid_page_hierarchy_handler(error):
+    def what_you_asked_for_is_not_there_handler(error):
         return render_template("error/404.html"), 404
 
-    app.errorhandler(InvalidPageHierarchy)(invalid_page_hierarchy_handler)
+    app.errorhandler(InvalidPageHierarchy)(what_you_asked_for_is_not_there_handler)
+    app.errorhandler(PageNotFoundException)(what_you_asked_for_is_not_there_handler)
 
     def render_error(error):
         # If a HTTPException, pull the `code` attribute; default to 500


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/c8uCXYWM/984-measure-page-urls-which-dont-exist-should-display-page-not-found-not-sorry-were-experiencing-technical-difficulties