### PR TITLE
Upload static assets to correct subdirectory

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -404,7 +404,7 @@ def clear_up(build_dir):
 
 def create_versioned_assets(build_dir):
     subprocess.run(["gulp", "make"])
-    static_dir = get_static_dir(build_dir)
+    static_dir = os.path.join(build_dir, get_static_dir())
     if os.path.exists(static_dir):
         shutil.rmtree(static_dir)
     shutil.copytree(current_app.static_folder, static_dir)
@@ -419,5 +419,5 @@ def cleanup_filename(filename):
     return slugify(filename)
 
 
-def get_static_dir(build_dir):
-    return "%s/static" % build_dir
+def get_static_dir():
+    return "static"


### PR DESCRIPTION
 ## Summary
A patch intended to upload static assets before deploying the rest of
the site, to prevent misconfigured css on the site during static builds,
accidentally uploaded the files to S3 with the wrong key - i.e. at the
root of the bucket rather than with the `static/` prefix. This commit
fixes that bug.

 ## Ticket
https://trello.com/c/KOFNKrtm/969