### PR TITLE
Don't attempt to render arbitrary files on the server

### DIFF
--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -22,7 +22,6 @@ from application.utils import (
     user_has_access,
 )
 
-
 from application.cms.api_builder import build_index_json, build_measure_json
 
 
@@ -46,9 +45,18 @@ def ethnicity_in_the_uk():
 
 @static_site_blueprint.route("/ethnicity-in-the-uk/<file>")
 @login_required
-def ethnicity_in_the_uk_page(file):
-    f = file.replace("-", "_")
-    return render_template("static_site/static_pages/ethnicity_in_the_uk/%s.html" % f)
+def ethnicity_in_the_uk_page(page_name):
+    ETHNICITY_IN_THE_UK_PAGES = [
+        "ethnic-groups-and-data-collected",
+        "ethnic-groups-by-place-of-birth",
+        "ethnic-groups-by-sexual-identity",
+        "ethnicity-and-type-of-family-or-household",
+    ]
+    if page_name in ETHNICITY_IN_THE_UK_PAGES:
+        f = page_name.replace("-", "_")
+        return render_template("static_site/static_pages/ethnicity_in_the_uk/%s.html" % f)
+    else:
+        abort(404)
 
 
 @static_site_blueprint.route("/background")


### PR DESCRIPTION
It seems better to only try to render a template if we know it's a file
we want to render, rather than anything that a user types in to the
address bar.

These pages are mostly going away soon when the new measures are
published to replace them, except (I think) ethnic-groups-and-data-collected.

Once we're down to one page we can make this prettier, but for now let's
patch it.