### PR TITLE
[Proposal] Do not fail entire test run until all tests have been run

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,6 +9,8 @@
 
 set -o pipefail
 
+last_bad_exit_status=0
+
 function display_result {
   RESULT=$1
   EXIT_STATUS=$2
@@ -16,7 +18,7 @@ function display_result {
 
   if [ $RESULT -ne 0 ]; then
     echo -e "\033[31m$TEST failed\033[0m"
-    exit $EXIT_STATUS
+    last_bad_exit_status=$EXIT_STATUS
   else
     echo -e "\033[32m$TEST passed\033[0m"
   fi
@@ -37,4 +39,8 @@ pytest_exitcode=$?
 display_result ${pytest_exitcode} 3 "Python tests"
 if [[ "${pytest_exitcode}" == "0" ]]; then
   coveralls
+fi
+
+if [ "$last_bad_exit_status" != 0 ] ; then
+    exit $last_bad_exit_status
 fi


### PR DESCRIPTION
Sometimes you don't care that the code style failed but just want
to see your python tests run in CI environment.

This change means the test run will still be flagged as a fail,
but only after everything has run.

The downside to this is that we'll have to wait longer for feedback
from bad CI builds in the build channel.  I'm not sure if this
outweighs the upside of being able to see full test suite output
for the broken build - for discussion.