### PR TITLE
Remove unused "top-bar" classes, remove weird "Back" buttons, plus other tweaks 

### DIFF
--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -40,11 +40,6 @@ $(document).ready(function () {
     $('#edit-data').click(editChartData);
     $('#cancel-edit-data').click(cancelEditData);
     $('#save').click(saveChart);
-    $('#exit').click(back);
-
-    function back(evt) {
-        window.location.replace(url_edit_dimension)
-    }
 
     /*
     Events from the DATA ENTRY PANEL

--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -69,11 +69,6 @@ $(document).ready(function () {
     $('#edit-data').click(editTableData);
     $('#cancel-edit-data').click(cancelEditData);
     $('#save').click(saveTable);
-    $('#exit').click(back);
-
-    function back(evt) {
-        window.location.replace(url_edit_dimension);
-    }
 
     /*
         Events from the DATA ENTRY PANEL

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -56,7 +56,7 @@ $border-colour: #BFC1C3;
     font-weight: normal;
   }
 
-  button, .button {
+  .button {
     display: inline-block;
     background-color: $button-colour;
     box-shadow: 0 2px 0 #003618;

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -611,6 +611,10 @@ button.link {
   background-color: transparent;
   box-shadow: none;
   cursor: pointer;
+
+  &:focus {
+      background-color: #ffbf47;
+  }
 }
 
 button.link.hidden {

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -524,35 +524,6 @@ input.date {
   }
 }
 
-.top-bar {
-  background-color: $black;
-  padding: 10px 0 20px;
-  height: auto;
-  font-size: 19px;
-  line-height: 19px;
-  .top-bar-content-container {
-    max-width: 960px;
-    margin: auto;
-    margin-top: 10px;
-  }
-  a {
-    color: white;
-    font-size: 14px;
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-  .site-title {
-    font-weight: bold;
-    a {
-      font-size: 19px;
-    }
-  }
-  .site-sub-title {
-    color: white;
-  }
-}
-
 .button-group {
   li {
     margin-bottom: 20px;

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -258,7 +258,6 @@
                     {% if 'UPDATE' in measure.available_actions() %}
                         <button class="button" id="save">Save</button>
                     {% endif %}
-                    <button class="button" id="exit">Back</button>
                 </div>
             </div>
         </div>
@@ -277,15 +276,9 @@
         $('#data_text_area').keyup(paste);
         $('#preview').click(preview);
         $('#save').click(saveChart);
-        $('#exit').click(back);
 
         var source_data = null;
         var data = null;
-        function back(evt) {
-            console.log("back");
-            window.location.replace("{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}")
-        }
-
 
         function uniqueDataInColumn(data, index) {
             var values = _.map(data.slice(start = 1), function(item) {

--- a/application/templates/cms/create_chart_2.html
+++ b/application/templates/cms/create_chart_2.html
@@ -23,8 +23,7 @@
     
     var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
     var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}";
-    var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}";
-</script>
+  </script>
 {% endblock %}
 
 {% block content %}
@@ -409,7 +408,6 @@
                             {% if 'UPDATE' in measure.available_actions() %}
                                 <button class="button" id="save">Save</button>
                             {% endif %}
-                            <button class="button" id="exit">Back</button>
                         </div>
                     </div>
                 </div>

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -37,12 +37,11 @@
                     {{ render_textarea_field(form.summary, rows='7', cols='100', disabled=form_disabled) }}
 
                 {% endblock fields %}
-                <ul class="button-group" data-topbar data-options="sticky_on: large">
-                    <li>
-                        <button type="submit" class="button" name="save">Save
-                        </button>
-                    </li>
-                </ul>
+
+                <button type="submit" class="button" name="save">
+                    Save
+                </button>
+
             </form>
         {% endblock %}
     </div>

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -139,7 +139,6 @@
                     {% if 'UPDATE' in measure.available_actions() %}
                         <button class="button" id="save">Save</button>
                     {% endif %}
-                    <button class="button" id="exit">Back</button>
                 </div>
             </div>
         </div>
@@ -155,12 +154,8 @@
         $('#data_text_area').keyup(paste);
         $('#preview').click(preview);
         $('#save').click(saveTable);
-        $('#exit').click(back);
-        data = null;
 
-        function back(evt) {
-            window.location.replace("{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}")
-        }
+        data = null;
 
         function uniqueDataInColumn(data, index) {
             var values = _.map(data.slice(start = 1), function(item) {

--- a/application/templates/cms/create_table_2.html
+++ b/application/templates/cms/create_table_2.html
@@ -13,17 +13,16 @@
 {% block bodyClasses %}rd_cms{% endblock %}
 
 {% block headEnd %}
-{{ super() }}
-<script>
-  {% if dimension.table_2_source_data %}
-  var settings = {{ dimension.table_2_source_data|tojson|safe }};
-  {% else %}
-  var settings = {};
-  {% endif %}
-  var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-  var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}";
-  var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}";
-</script>
+  {{ super() }}
+  <script>
+    {% if dimension.table_2_source_data %}
+    var settings = {{ dimension.table_2_source_data|tojson|safe }};
+    {% else %}
+    var settings = {};
+    {% endif %}
+    var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
+    var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}";
+  </script>
 {% endblock %}
 
 {% block content %}
@@ -242,7 +241,6 @@
                           {% if 'UPDATE' in measure.available_actions() %}
                           <button class="button" id="save">Save</button>
                           {% endif %}
-                          <button class="button" id="exit">Back</button>
                         </div>
                     </div>
                 </div>

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -28,14 +28,13 @@
                     {% block fields %}
                         {{ super() }}
                     {% endblock fields %}
-                    <ul class="button-group" data-topbar data-options="sticky_on: large">
-                        <li>
-                            {% if 'UPDATE' in  measure.available_actions() %}
-                                <button type="submit" class="button" name="update">Update</button>
-                            {% endif %}
-                            <button class="button" id="exit">Back</button>
-                        </li>
-                    </ul>
+
+                    {% if 'UPDATE' in  measure.available_actions() %}
+                    <button type="submit" class="button" name="update">
+                        Update
+                    </button>
+                    {% endif %}
+
                     <div id="charts">
                         <h2 class="heading-medium">Charts & Tables</h2>
                         <table>
@@ -67,24 +66,24 @@
                             {% endif %}
                         </table>
                         {% if 'UPDATE' in  measure.available_actions() %}
-                            <ul class="button-group">
+
                                 {% if not dimension.chart or dimension.chart == '""' %}
-                                    <li>
-                                        <a id="create_chart" class="button"
-                                           href="{{ url_for('cms.chartbuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
-                                            Add chart
-                                        </a>
-                                    </li>
+                                <p>
+                                    <a id="create_chart"
+                                       href="{{ url_for('cms.chartbuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
+                                        Add chart
+                                    </a>
+                                </p>
                                 {% endif %}
                                 {% if not dimension.table or dimension.table == '""' %}
-                                    <li>
-                                        <a id="create_table" class="button"
-                                           href="{{ url_for('cms.create_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
-                                            Add table
-                                        </a>
-                                    </li>
+                                <p>
+                                    <a id="create_table"
+                                       href="{{ url_for('cms.create_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
+                                        Add table
+                                    </a>
+                                </p>
                                 {% endif %}
-                            </ul>
+
                         {% endif %}
                     </div>
 
@@ -118,18 +117,4 @@
             {% endblock %}
         </div>
     </div>
-{% endblock %}
-
-{% block bodyEnd %}
-  {{ super() }}
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('#exit').click(back);
-            function back(evt) {
-                evt.preventDefault();
-                window.location.replace("{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}")
-            }
-
-        });
-    </script>
 {% endblock %}

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -73,27 +73,16 @@
                         {% endif %}
 
                     {% endblock fields %}
-                    <ul class="button-group" data-topbar data-options="sticky_on: large">
-                        <li>
-                            {% if 'UPDATE' in measure.available_actions() %}
-                                <button type="submit" class="button">Save</button>
-                            {% endif %}
-                            <button class="button" id="exit">Back</button>
-                        </li>
-                    </ul>
+
+                    {% if 'UPDATE' in measure.available_actions() %}
+                        <button type="submit" class="button" name="save">
+                            Save
+                        </button>
+                    {% endif %}
+
                 </form>
             {% endblock %}
         </div>
     </div>
 {% endblock %}
 
-{% block bodyEnd %}
-  {{ super() }}
-<script type="text/javascript">
-        $('#exit').click(back);
-        function back(evt) {
-            evt.preventDefault();
-            window.location.replace("{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}")
-        }
-</script>
-{% endblock %}


### PR DESCRIPTION
This started off when I noticed some of our buttons bundled up into lists with `topbar` classes.  I wondered what this did, and it turns out... nothing at all.  Execpt that putting the buttons in lists means they aren't properly left-aligned with the other form elements (textboxes) above them.

So this removes the lists and unused styles.

But then I realised that a lot of the buttons we have are weird "Back" buttons that use javascript to emulate the back button of the browser.  These are really weird and completely superfluous, especially now we've fixed the breadcrumbs to allow people to go back to the "previous" page in a journey.

So this removes all the "Back" buttons that only work with Javascript, and the associated Javascript.

I also noticed some styling inconsistencies between the "Edit" link and "Delete" link-styled-button on the version history list (e.g. see https://rd-cms-staging.herokuapp.com/cms/culture-and-community/community/feeling-of-belonging-to-britain/versions).

So there are a couple of styling tweaks in here to make these look the same.

Looking at commits one-by-one it should all make sense.