### PR TITLE
Check that card.labels exists before trying to iterate it

### DIFF
--- a/application/dashboard/trello_service.py
+++ b/application/dashboard/trello_service.py
@@ -91,9 +91,10 @@ class TrelloService(Service):
         return obj
 
     def find_flag(self, card, flags):
-        for flag in card.labels:
-            if flag.name in flags:
-                return flag.name
+        if card.labels:
+            for flag in card.labels:
+                if flag.name in flags:
+                    return flag.name
         return ""
 
 


### PR DESCRIPTION
We are getting build failures in dev and staging with
```
   File "/app/application/dashboard/trello_service.py", line 94, in find_flag
     for flag in card.labels:
 TypeError: 'NoneType' object is not iterable
```

The build is fine locally and there don't seem to be any cards on the
Trello board without any labels, but still... this feels like it might
fix things.