### PR TITLE
Create DataSource model

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -102,12 +102,16 @@ class ArrayOfEnum(ARRAY):
 
 
 class FrequencyOfRelease(db.Model):
+    __tablename__ = "frequency_of_release"
+
     id = db.Column(db.Integer, primary_key=True)
     description = db.Column(db.String(), nullable=False)
     position = db.Column(db.Integer, nullable=False)
 
 
 class TypeOfStatistic(db.Model):
+    __tablename__ = "type_of_statistic"
+
     id = db.Column(db.Integer, primary_key=True)
     internal = db.Column(db.String(), nullable=False)
     external = db.Column(db.String(), nullable=False)
@@ -127,6 +131,8 @@ class Page(db.Model):
     Each version of a measure page is one record in the Page model, so we have a compound key consisting of `guid`
     coupled with `version`.
     """
+
+    __tablename__ = "page"
 
     def __eq__(self, other):
         return self.guid == other.guid and self.version == other.version
@@ -548,6 +554,8 @@ class Page(db.Model):
 
 
 class Dimension(db.Model):
+    __tablename__ = "dimension"
+
     guid = db.Column(db.String(255), primary_key=True)
     title = db.Column(db.String(255))
     time_period = db.Column(db.String(255))
@@ -731,6 +739,8 @@ class Dimension(db.Model):
 
 
 class Upload(db.Model):
+    __tablename__ = "upload"
+
     guid = db.Column(db.String(255), primary_key=True)
     title = db.Column(db.String(255))
     file_name = db.Column(db.String(255))
@@ -874,6 +884,8 @@ class Table(db.Model, ChartAndTableMixin):
 
 
 class Organisation(db.Model):
+    __tablename__ = "organisation"
+
     id = db.Column(db.String(255), primary_key=True)
     name = db.Column(db.String(255), nullable=False)
     other_names = db.Column(ARRAY(db.String), default=[])
@@ -898,6 +910,8 @@ class Organisation(db.Model):
 
 
 class LowestLevelOfGeography(db.Model):
+    __tablename__ = "lowest_level_of_geography"
+
     name = db.Column(db.String(255), primary_key=True)
     description = db.Column(db.String(255), nullable=True)
     position = db.Column(db.Integer, nullable=False)

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -5,7 +5,16 @@ from functools import total_ordering
 
 import sqlalchemy
 from bidict import bidict
-from sqlalchemy import inspect, ForeignKeyConstraint, PrimaryKeyConstraint, UniqueConstraint, ForeignKey, not_, Index
+from sqlalchemy import (
+    inspect,
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
+    UniqueConstraint,
+    ForeignKey,
+    not_,
+    Index,
+    asc,
+)
 from sqlalchemy.dialects.postgresql import JSON, ARRAY
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relation, relationship, backref, make_transient
@@ -116,6 +125,67 @@ class TypeOfStatistic(db.Model):
     internal = db.Column(db.String(), nullable=False)
     external = db.Column(db.String(), nullable=False)
     position = db.Column(db.Integer, nullable=False)
+
+
+class DataSource(db.Model):
+    __tablename__ = "data_source"
+
+    # columns
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=True)
+
+    type_of_data = db.Column(ArrayOfEnum(db.Enum(TypeOfData, name="type_of_data_types")), default=[], nullable=True)
+    type_of_statistic_id = db.Column(db.Integer, nullable=True)
+
+    publisher_id = db.Column(db.String(255), nullable=True)
+    source_url = db.Column(db.String(255), nullable=True)
+    publication_date = db.Column(db.String(255), nullable=True)
+    note_on_corrections_or_updates = db.Column(db.TEXT, nullable=True)
+
+    frequency_of_release_id = db.Column(db.Integer, nullable=True)
+    frequency_of_release_other = db.Column(db.TEXT, nullable=True)
+
+    purpose = db.Column(db.String(255), nullable=True)
+
+    # relationships
+    type_of_statistic = relationship("TypeOfStatistic", foreign_keys=[type_of_statistic_id])
+    publisher = relationship("Organisation", foreign_keys=[publisher_id], backref="data_sources")
+    frequency_of_release = relationship("FrequencyOfRelease", foreign_keys=[frequency_of_release_id])
+
+    __table_args__ = (
+        ForeignKeyConstraint(["type_of_statistic_id"], ["type_of_statistic.id"]),
+        ForeignKeyConstraint(["publisher_id"], ["organisation.id"]),
+        ForeignKeyConstraint(["frequency_of_release_id"], ["frequency_of_release.id"]),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "type_of_data": self.type_of_data,
+            "type_of_statistic": self.type_of_statistic,
+            "publisher": self.publisher,
+            "source_url": self.source_url,
+            "publication_date": self.publication_date,
+            "note_on_corrections_or_updates": self.note_on_corrections_or_updates,
+            "frequency_of_release": (
+                self.frequency_of_release if self.frequency_of_release else self.frequency_of_release_other
+            ),
+            "purpose": self.purpose,
+        }
+
+
+class DataSourceInPage(db.Model):
+    __tablename__ = "data_source_in_page"
+
+    data_source_id = db.Column(db.Integer, primary_key=True)
+    page_guid = db.Column(db.String(255), primary_key=True)
+    page_version = db.Column(db.String(255), primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint([data_source_id], ["data_source.id"]),
+        ForeignKeyConstraint([page_guid, page_version], ["page.guid", "page.version"]),
+    )
 
 
 @total_ordering
@@ -312,6 +382,11 @@ class Page(db.Model):
     )
     secondary_source_1_frequency_other = db.Column(db.String(255))  # free text for when "Other" is chosen for frequency
     secondary_source_1_data_source_purpose = db.Column(db.TEXT)  # "Purpose of data source" in secondary Data sources
+
+    # DATA SOURCES
+    data_sources = relationship(
+        "DataSource", secondary="data_source_in_page", backref="pages", order_by=asc("data_source.id")
+    )
 
     # Returns an array of measures which have been published, and which
     # were either first version (1.0) or the first version of an update

--- a/migrations/versions/2018_10_31_separation_data_sources_from_page_table_separate_data_sources_from_the_page_.py
+++ b/migrations/versions/2018_10_31_separation_data_sources_from_page_table_separate_data_sources_from_the_page_.py
@@ -1,0 +1,57 @@
+"""Separate data sources from the page table
+
+Revision ID: 2018_10_31_refactor_data_sources
+Revises: 2018_10_15_index_page_type_uri
+Create Date: 2018-11-05 09:05:59.517656
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2018_10_31_refactor_data_sources"
+down_revision = "2018_10_05_chart_table_fkeys"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "data_source",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column(
+            "type_of_data",
+            postgresql.ARRAY(postgresql.ENUM(name="type_of_data_types", create_type=False)),
+            nullable=True,
+        ),
+        sa.Column("type_of_statistic_id", sa.Integer(), nullable=True),
+        sa.Column("publisher_id", sa.String(length=255), nullable=True),
+        sa.Column("source_url", sa.String(length=255), nullable=True),
+        sa.Column("publication_date", sa.String(length=255), nullable=True),
+        sa.Column("note_on_corrections_or_updates", sa.TEXT(), nullable=True),
+        sa.Column("frequency_of_release_id", sa.Integer(), nullable=True),
+        sa.Column("frequency_of_release_other", sa.TEXT(), nullable=True),
+        sa.Column("purpose", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["publisher_id"], ["organisation.id"]),
+        sa.ForeignKeyConstraint(["type_of_statistic_id"], ["type_of_statistic.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "data_source_in_page",
+        sa.Column("data_source_id", sa.Integer(), nullable=False),
+        sa.Column("page_guid", sa.String(length=255), nullable=False),
+        sa.Column("page_version", sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(["data_source_id"], ["data_source.id"]),
+        sa.ForeignKeyConstraint(["data_source_id"], ["data_source.id"]),
+        sa.ForeignKeyConstraint(["page_guid", "page_version"], ["page.guid", "page.version"]),
+        sa.PrimaryKeyConstraint(
+            "data_source_id", "page_guid", "page_version", name="data_source_id_page_guid_version_pk"
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("data_source_in_page")
+    op.drop_table("data_source")


### PR DESCRIPTION
 ## Summary
Add a structural migration that implements the new `DataSource` table,
intended to deprecate and later remove a number of fields on the
existing `Page` model.

This retirement will happen across a number of stages:
1) Creating the new `DataSource` structural model.
2) Running a data migration to copy data from the `Page` table to the
`DataSource` model; at the same time, update views to start referencing
the `DataSource` table for future reads and writes.
3) Drop the existing data source columns from the `Page` table.

 ## Ticket
https://trello.com/c/yV12Lu7Z/949