### PR TITLE
Allow create_app to recognise config names

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -60,6 +60,18 @@ def create_app(config_object):
     from application.review import review_blueprint
     from application.redirects import redirects_blueprint
 
+    if isinstance(config_object, str):
+        from application.config import DevConfig, Config, TestConfig
+
+        if config_object.lower().startswith("production"):
+            config_object = Config
+        elif config_object.lower().startswith("dev"):
+            config_object = DevConfig
+        elif config_object.lower().startswith("test"):
+            config_object = TestConfig
+        else:
+            raise ValueError(f"Invalid config name passed into create_app: {config_object}")
+
     app = Flask(__name__)
     app.config.from_object(config_object)
     app.file_service = FileService()


### PR DESCRIPTION
 ## Summary
`flask shell` is a neat feature provided by flask v1+ to allow dropping
into an application context from the command line. In order to do this,
we need to be able to construct an app from a string-representation of a
config class. This patch adds the ability to derive config class names
from strings.

In order to use `flask shell`, you just need to define `FLASK_APP` in
your `.env.` file in a fashion similar to this:

`FLASK_APP="application.factory:create_app('development')"`