### PR TITLE
[None] table headers

### DIFF
--- a/application/src/js/cms/rd-table-objects.js
+++ b/application/src/js/cms/rd-table-objects.js
@@ -114,7 +114,7 @@ function simpleTable(data, title, subtitle, footer, category_column, parent_colu
         tableData = adjustSimpleTableDataForParents(tableData);
     }
 
-    var index_column = !index_column_caption ? category_column : index_column_caption;
+    var index_column = index_column_caption ? index_column_caption : category_column;
 
     return {
         'type':'simple',
@@ -307,7 +307,7 @@ function groupedTable(data, title, subtitle, footer,  category_column, parent_co
 
 
     // --------------------- COMPLETE THE TABLE OBJECT --------------------------
-    var index_column = !index_column_caption ? category_column : index_column_caption;
+    var index_column = index_column_caption ? index_column_caption : category_column;
 
     return {
         'group_columns': group_columns,

--- a/application/src/js/cms/rd-table-objects.js
+++ b/application/src/js/cms/rd-table-objects.js
@@ -114,7 +114,7 @@ function simpleTable(data, title, subtitle, footer, category_column, parent_colu
         tableData = adjustSimpleTableDataForParents(tableData);
     }
 
-    var index_column = index_column_caption == null ? category_column : index_column_caption;
+    var index_column = !index_column_caption ? category_column : index_column_caption;
 
     return {
         'type':'simple',
@@ -307,7 +307,7 @@ function groupedTable(data, title, subtitle, footer,  category_column, parent_co
 
 
     // --------------------- COMPLETE THE TABLE OBJECT --------------------------
-    var index_column = index_column_caption == null ? category_column : index_column_caption;
+    var index_column = !index_column_caption ? category_column : index_column_caption;
 
     return {
         'group_columns': group_columns,

--- a/application/src/js/cms/rd-table.js
+++ b/application/src/js/cms/rd-table.js
@@ -52,9 +52,9 @@ function simpleHtmlTable(container_id, tableObject) {
 function appendSimpleTableHeader(table_html, tableObject) {
     var header_html = "";
     if (tableObject['category_caption'] == null) {
-        header_html = "<thead><tr><th></th>";
+        header_html = "<thead><tr><td></td>";
     } else {
-        header_html = "<thead><tr><th id='index-column-caption'>" + tableObject.category_caption + "</th>";
+        header_html = "<thead><tr><th>" + tableObject.category_caption + "</th>";
     }
 
     _.forEach(tableObject.columns, function (column) {
@@ -156,9 +156,9 @@ function appendGroupTableHeader(table_html, tableObject) {
 
     var header_html = '';
     if (doSecondRow || tableObject['category_caption'] == null) {
-        header_html = "<thead><tr><th></th>";
+        header_html = "<thead><tr><td></td>";
     } else {
-        header_html = "<thead><tr><th id='index-column-caption'>" + tableObject.category_caption + "</th>";
+        header_html = "<thead><tr><th>" + tableObject.category_caption + "</th>";
     }
 
     // Add a row with titles for each group
@@ -171,14 +171,14 @@ function appendGroupTableHeader(table_html, tableObject) {
     if (doSecondRow) {
         // category_caption should go in the second row if there is one
         if (tableObject['category_caption'] != null) {
-            header_html = header_html + "<tr><td id='index-column-caption'>" + tableObject.category_caption + "</td>";
+            header_html = header_html + "<tr><th>" + tableObject.category_caption + "</th>";
         } else {
             header_html = header_html + '<tr><td></td>';
         }
 
         _.forEach(tableObject.groups, function (group) {
             _.forEach(tableObject.columns, function (column) {
-                header_html = header_html + '<td>' + column + '</td>';
+                header_html = header_html + '<th>' + column + '</th>';
             });
         });
         header_html = header_html + '</tr>';

--- a/application/src/js/cms/rd-table.js
+++ b/application/src/js/cms/rd-table.js
@@ -54,7 +54,7 @@ function appendSimpleTableHeader(table_html, tableObject) {
     if (tableObject['category_caption'] == null) {
         header_html = "<thead><tr><th></th>";
     } else {
-        header_html = "<thead><tr><th>" + tableObject.category_caption + "</th>";
+        header_html = "<thead><tr><th id='index-column-caption'>" + tableObject.category_caption + "</th>";
     }
 
     _.forEach(tableObject.columns, function (column) {
@@ -146,20 +146,7 @@ function appendGroupedTableBody(table_html, tableObject) {
 
 
 function appendGroupTableHeader(table_html, tableObject) {
-    var header_html = '';
-    if (tableObject['category_caption'] == null) {
-        header_html = "<thead><tr><th></th>";
-    } else {
-        header_html = "<thead><tr><th>" + tableObject.category_caption + "</th>";
-    }
-
-    // Add a row with titles for each group
-    _.forEach(tableObject.groups, function (group) {
-        header_html = header_html + multicell(group.group, tableObject.columns.length);
-    });
-    header_html = header_html + '</tr>';
-
-    // Check if we need to add a second row (based if any column headings exist)
+    // Check if we need two rows of headers (based on whether any column headings exist)
     var doSecondRow = false;
     _.forEach(tableObject.columns, function (column) {
         if (column !== '') {
@@ -167,9 +154,28 @@ function appendGroupTableHeader(table_html, tableObject) {
         }
     });
 
+    var header_html = '';
+    if (doSecondRow || tableObject['category_caption'] == null) {
+        header_html = "<thead><tr><th></th>";
+    } else {
+        header_html = "<thead><tr><th id='index-column-caption'>" + tableObject.category_caption + "</th>";
+    }
+
+    // Add a row with titles for each group
+    _.forEach(tableObject.groups, function (group) {
+        header_html = header_html + multicell_th(group.group, tableObject.columns.length);
+    });
+    header_html = header_html + '</tr>';
+
     // If a second row is required add it
     if (doSecondRow) {
-        header_html = header_html + '<tr><td></td>';
+        // category_caption should go in the second row if there is one
+        if (tableObject['category_caption'] != null) {
+            header_html = header_html + "<tr><td id='index-column-caption'>" + tableObject.category_caption + "</td>";
+        } else {
+            header_html = header_html + '<tr><td></td>';
+        }
+
         _.forEach(tableObject.groups, function (group) {
             _.forEach(tableObject.columns, function (column) {
                 header_html = header_html + '<td>' + column + '</td>';
@@ -213,6 +219,6 @@ function insertTableFooter(table_html, tableObject) {
     }
 }
 
-function multicell(text, total_cells) {
-    return '<td colspan=' + total_cells + '>' + text + '</td>';
+function multicell_th(text, total_cells) {
+    return '<th colspan=' + total_cells + '>' + text + '</th>';
 }

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -9,7 +9,7 @@
           <div>
             <span><a href="https://www.ethnicity-facts-figures.service.gov.uk">Live website</a></span>
 
-            {% if not static_mode and not current_user.is_anonymous and not preview %}
+            {% if not current_user.is_anonymous and not preview %}
               <span><a href="{{ url_for('static_site.topic', topic_uri='testing-space') }}">Testing space</a></span>
 
               {% if current_user.can(MANAGE_USERS) %}

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -893,7 +893,7 @@ class TableBuilderPage(BasePage):
         return element.get_attribute("value")
 
     def table_index_column_name(self):
-        element = self.driver.find_element_by_id("index-column-caption")
+        element = self.driver.find_element_by_css_selector("thead tr:last-child th:first-child")
         return element.text
 
     def source_contains(self, text):

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -893,7 +893,7 @@ class TableBuilderPage(BasePage):
         return element.get_attribute("value")
 
     def table_index_column_name(self):
-        element = self.driver.find_element_by_xpath(f"//table/thead/tr/th")
+        element = self.driver.find_element_by_id("index-column-caption")
         return element.text
 
     def source_contains(self, text):

--- a/tests/functional/test_table_builder.py
+++ b/tests/functional/test_table_builder.py
@@ -231,8 +231,8 @@ def run_complex_table_by_row_scenario(table_builder_page, driver):
     """
     THEN a complex table exists with ethnicities on the left, gender along the top, and sub-columns of value and gender.
     """
-    assert table_builder_page.table_headers() == ["Ethnicity", "F", "M"]
-    assert table_builder_page.table_secondary_headers() == ["Value", "Gender", "Value", "Gender"]
+    assert table_builder_page.table_headers() == ["", "F", "M"]
+    assert table_builder_page.table_secondary_headers() == ["Ethnicity", "Value", "Gender", "Value", "Gender"]
     assert table_builder_page.table_column_contents(1) == ["Asian", "Black", "Mixed", "White", "Other"]
     assert table_builder_page.table_column_contents(2) == ["4", "1", "5", "4", "2"]
     assert table_builder_page.table_column_contents(3) == ["F"] * 5
@@ -279,8 +279,9 @@ def run_complex_table_by_column_scenario(table_builder_page, driver):
     """
     AND a complex table exists with ethnicities across the columns, gender on the left, and sub-columns of value and gender.
     """
-    assert table_builder_page.table_headers() == ["Gender", "Asian", "Black", "Mixed", "White", "Other"]
+    assert table_builder_page.table_headers() == ["", "Asian", "Black", "Mixed", "White", "Other"]
     assert table_builder_page.table_secondary_headers() == [
+        "Gender",
         "Value",
         "Gender",
         "Value",


### PR DESCRIPTION
For this card: https://trello.com/c/NizdSB55/952-publishing-pick-up-missing-table-column-headings

I've figured out that:
* Tablebuilder 2 won't allow things to be saved with [None] headers
* We only have three "latest" pages on the site affected by the issue (see ticket for details)

This PR changes Tablebuilder 2 to always show the first column header - previously it only showed it if a custom value was set, even though the published page gets a heading.

I've also re-jigged it so that index column headings appear in the second header row of the preview if there is one. This matches how things look on the published tables.  (Previously the index column appeared in the top row alongside ethnicities, which wasn't right).