### PR TITLE
Disable coverage unless on CI

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,6 +35,6 @@ py.test --cov application/ --cov-report term-missing
 pytest_exitcode=$?
 
 display_result ${pytest_exitcode} 3 "Python tests"
-if [[ "${pytest_exitcode}" == "0" ]]; then
+if [[ "${pytest_exitcode}" == "0" ]] && [[ "${CI}" ]]; then
   coveralls
 fi


### PR DESCRIPTION
 ## Summary
We don't want coverage reports to be submitted from local test runs, so
this patch adds a check on the CI environment variable.