### PR TITLE
Add timestamps to dimension table

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -553,6 +553,9 @@ class Dimension(db.Model):
     time_period = db.Column(db.String(255))
     summary = db.Column(db.Text())
 
+    created_at = db.Column(db.DateTime)
+    updated_at = db.Column(db.DateTime)
+
     chart = db.Column(JSON)
     table = db.Column(JSON)
     chart_builder_version = db.Column(db.Integer)

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -1,0 +1,26 @@
+"""Add created and updated timestamps to dimensions
+
+Revision ID: 90eef812019a
+Revises: 2018_10_05_chart_table_fkeys
+Create Date: 2018-11-12 10:31:40.860099
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '2018_11_12_add_timestamps_to_dimension'
+down_revision = '2018_10_05_chart_table_fkeys'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('dimension', sa.Column('created_at', sa.DateTime(), nullable=True))
+    op.add_column('dimension', sa.Column('updated_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('dimension', 'updated_at')
+    op.drop_column('dimension', 'created_at')

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '2018_11_12_add_timestamps_to_dimension'
+revision = '2018_11_12_dimension_timestamps'
 down_revision = '2018_10_05_chart_table_fkeys'
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
These will be used to give guidance to publishers about if/when each dimension was last updated.