### PR TITLE
Disallow nulls in dimension timestamps

### DIFF
--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -179,7 +179,6 @@ class DimensionService(Service):
             else:
                 self.__set_table_custom_dimension_classification(dimension, data)
 
-
         dimension.updated_at = datetime.utcnow()
 
         # This should be True if the update has come in from chart or table builder

--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -1,6 +1,8 @@
 from flask import current_app
 from sqlalchemy.orm.exc import NoResultFound
 
+from datetime import datetime
+
 from application import db
 from application.cms.exceptions import (
     DimensionNotFoundException,
@@ -35,6 +37,9 @@ class DimensionService(Service):
                 page=page,
                 position=page.dimensions.count(),
             )
+
+            db_dimension.created_at = datetime.utcnow()
+            db_dimension.updated_at = db_dimension.created_at
 
             page.dimensions.append(db_dimension)
             db.session.add(page)
@@ -173,6 +178,9 @@ class DimensionService(Service):
                 self.__set_table_dimension_classification_through_builder(dimension, data)
             else:
                 self.__set_table_custom_dimension_classification(dimension, data)
+
+
+        dimension.updated_at = datetime.utcnow()
 
         # This should be True if the update has come in from chart or table builder
         # but False if the dimension metadata form has been submitted with no update to chart or table

--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -1,6 +1,5 @@
 from flask import current_app
 from sqlalchemy.orm.exc import NoResultFound
-
 from datetime import datetime
 
 from application import db
@@ -37,9 +36,6 @@ class DimensionService(Service):
                 page=page,
                 position=page.dimensions.count(),
             )
-
-            db_dimension.created_at = datetime.utcnow()
-            db_dimension.updated_at = db_dimension.created_at
 
             page.dimensions.append(db_dimension)
             db.session.add(page)
@@ -179,7 +175,7 @@ class DimensionService(Service):
             else:
                 self.__set_table_custom_dimension_classification(dimension, data)
 
-        dimension.updated_at = datetime.utcnow()
+        dimension.set_updated_at()
 
         # This should be True if the update has come in from chart or table builder
         # but False if the dimension metadata form has been submitted with no update to chart or table

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -553,6 +553,9 @@ class Dimension(db.Model):
     time_period = db.Column(db.String(255))
     summary = db.Column(db.Text())
 
+    created_at = db.Column(db.DateTime)
+    updated_at = db.Column(db.DateTime)
+
     chart = db.Column(JSON)
     table = db.Column(JSON)
     chart_builder_version = db.Column(db.Integer)

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -641,8 +641,8 @@ class Dimension(db.Model):
     time_period = db.Column(db.String(255))
     summary = db.Column(db.Text())
 
-    created_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME)
-    updated_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME)
+    created_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME, nullable=False)
+    updated_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME, nullable=False)
 
     chart = db.Column(JSON)
     table = db.Column(JSON)

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     not_,
     Index,
     asc,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSON, ARRAY
 from sqlalchemy.ext.declarative import declared_attr
@@ -631,13 +632,17 @@ class Page(db.Model):
 class Dimension(db.Model):
     __tablename__ = "dimension"
 
+    # This is a database expression to get the current timestamp in UTC.
+    # Possibly specific to PostgreSQL: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT
+    __SQL_CURRENT_UTC_TIME = "timezone('utc', CURRENT_TIMESTAMP)"
+
     guid = db.Column(db.String(255), primary_key=True)
     title = db.Column(db.String(255))
     time_period = db.Column(db.String(255))
     summary = db.Column(db.Text())
 
-    created_at = db.Column(db.DateTime)
-    updated_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME)
+    updated_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME)
 
     chart = db.Column(JSON)
     table = db.Column(JSON)
@@ -692,6 +697,11 @@ class Dimension(db.Model):
             return "Chart"
         else:
             return "Manually selected"
+
+    # This updates the model’s updated_at timestamp to the current time, using the
+    # clock on the database.
+    def set_updated_at(self):
+        self.updated_at = text(self.__SQL_CURRENT_UTC_TIME)
 
     # This updates the metadata on the associated dimension_classification object
     # from either the chart or table, depending upon which exists, or the one with

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -18,8 +18,13 @@ depends_on = None
 
 def upgrade():
 
-    op.execute("ALTER TABLE dimension ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
-    op.execute("ALTER TABLE dimension ADD COLUMN updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
+    # First add the timestamp columns with default NULL values
+    op.execute("ALTER TABLE dimension ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE")
+    op.execute("ALTER TABLE dimension ADD COLUMN updated_at TIMESTAMP WITHOUT TIME ZONE")
+
+    # Now set the default values to the current UTC timestamp for future entries.
+    op.execute("ALTER TABLE dimension ALTER COLUMN created_at SET DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
+    op.execute("ALTER TABLE dimension ALTER COLUMN updated_at SET DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
 
 
 def downgrade():

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -1,0 +1,26 @@
+"""Add created and updated timestamps to dimensions
+
+Revision ID: 90eef812019a
+Revises: 2018_10_05_chart_table_fkeys
+Create Date: 2018-11-12 10:31:40.860099
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '2018_11_12_add_timestamps_to_dimension'
+down_revision = '2018_10_05_chart_table_fkeys'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('dimension', sa.Column('created_at', sa.DateTime(), nullable=True))
+    op.add_column('dimension', sa.Column('updated_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('dimension', 'updated_at')
+    op.drop_column('dimension', 'created_at')

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -17,8 +17,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("dimension", sa.Column("created_at", sa.DateTime(), nullable=True))
-    op.add_column("dimension", sa.Column("updated_at", sa.DateTime(), nullable=True))
+
+    op.execute("ALTER TABLE dimension ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
+    op.execute("ALTER TABLE dimension ADD COLUMN updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT timezone('utc', CURRENT_TIMESTAMP)")
 
 
 def downgrade():

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '2018_11_12_add_timestamps_to_dimension'
+revision = '2018_11_12_dimension_timestamps'
 down_revision = '2018_10_05_chart_table_fkeys'
 branch_labels = None
 depends_on = None

--- a/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
+++ b/migrations/versions/2018_11_12_add_timestamps_to_dimension.py
@@ -1,7 +1,7 @@
 """Add created and updated timestamps to dimensions
 
 Revision ID: 90eef812019a
-Revises: 2018_10_05_chart_table_fkeys
+Revises: 2018_10_31_refactor_data_sources
 Create Date: 2018-11-12 10:31:40.860099
 
 """
@@ -10,17 +10,17 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '2018_11_12_dimension_timestamps'
-down_revision = '2018_10_05_chart_table_fkeys'
+revision = "2018_11_12_dimension_timestamps"
+down_revision = "2018_10_31_refactor_data_sources"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('dimension', sa.Column('created_at', sa.DateTime(), nullable=True))
-    op.add_column('dimension', sa.Column('updated_at', sa.DateTime(), nullable=True))
+    op.add_column("dimension", sa.Column("created_at", sa.DateTime(), nullable=True))
+    op.add_column("dimension", sa.Column("updated_at", sa.DateTime(), nullable=True))
 
 
 def downgrade():
-    op.drop_column('dimension', 'updated_at')
-    op.drop_column('dimension', 'created_at')
+    op.drop_column("dimension", "updated_at")
+    op.drop_column("dimension", "created_at")

--- a/migrations/versions/2018_11_14_ban_dimension_timestamp_nulls.py
+++ b/migrations/versions/2018_11_14_ban_dimension_timestamp_nulls.py
@@ -1,0 +1,27 @@
+"""ban_dimension_timestamp_nulls
+
+Revision ID: aaaff196cfda
+Revises: 2018_11_12_dimension_timestamps
+Create Date: 2018-11-14 11:44:25.071102
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'ban_dimension_timestamp_nulls'
+down_revision = '2018_11_12_dimension_timestamps'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('dimension', 'created_at', nullable=False)
+    op.alter_column('dimension', 'updated_at', nullable=False)
+
+
+def downgrade():
+    op.alter_column('dimension', 'updated_at', nullable=True)
+    op.alter_column('dimension', 'created_at', nullable=True)
+

--- a/scripts/data_migrations/2018-12-12_backfill_dimension_timestamps.sql
+++ b/scripts/data_migrations/2018-12-12_backfill_dimension_timestamps.sql
@@ -1,0 +1,9 @@
+
+-- Copy created_at dates from page to dimension.
+UPDATE dimension SET created_at = page.created_at from page WHERE dimension.page_id = page.guid and dimension.page_version = page.version and dimension.created_at IS NULL;
+
+-- Copy updated_at dates from page updated_at to dimension, where they exist.
+UPDATE dimension SET updated_at = page.updated_at from page WHERE dimension.page_id = page.guid and dimension.page_version = page.version and dimension.updated_at IS NULL and page.updated_at IS NOT NULL;
+
+-- Copy updated_at dates from page created_at to dimension, where the page doesn’t have an updated_at.
+UPDATE dimension SET updated_at = page.created_at from page WHERE dimension.page_id = page.guid and dimension.page_version = page.version and dimension.updated_at IS NULL and page.updated_at IS NULL;

--- a/tests/test_dimension_service.py
+++ b/tests/test_dimension_service.py
@@ -1,6 +1,7 @@
 from application.cms.dimension_service import DimensionService
 from application.cms.models import Chart, Dimension, DimensionClassification, Table
 from application import db
+from datetime import datetime
 
 dimension_service = DimensionService()
 
@@ -17,6 +18,11 @@ def test_create_dimension_on_measure_page(stub_measure_page):
     db_dimension = Dimension.query.all()[0]
     assert stub_measure_page.dimensions[0].guid == db_dimension.guid
     assert stub_measure_page.dimensions[0].title == db_dimension.title
+    assert not stub_measure_page.dimensions[0].created_at == None, "Should have set a creation timestamp"
+
+    assert (datetime.utcnow() - stub_measure_page.dimensions[0].created_at).seconds < 5, "Creation time should be within the last 5 seconds"
+
+    assert stub_measure_page.dimensions[0].updated_at == stub_measure_page.dimensions[0].created_at, "Should have set the updated timestamp to be the same as the creation timestamp"
 
 
 def test_delete_dimension_from_measure_page(stub_measure_page):
@@ -52,6 +58,12 @@ def test_update_dimension(stub_measure_page):
     assert dimension.guid == updated_dimension.guid
     assert updated_dimension.title == "updated-title"
     assert updated_dimension.time_period == "updated_time_period"
+
+    assert updated_dimension.updated_at != updated_dimension.created_at, "Update time should now be different from creation time"
+
+    assert (datetime.utcnow() - updated_dimension.updated_at).seconds < 5, "Update time should be within the last 5 seconds"
+
+
 
 
 def test_update_dimension_does_not_call_update_dimension_classification_by_default(

--- a/tests/test_dimension_service.py
+++ b/tests/test_dimension_service.py
@@ -20,9 +20,13 @@ def test_create_dimension_on_measure_page(stub_measure_page):
     assert stub_measure_page.dimensions[0].title == db_dimension.title
     assert not stub_measure_page.dimensions[0].created_at == None, "Should have set a creation timestamp"
 
-    assert (datetime.utcnow() - stub_measure_page.dimensions[0].created_at).seconds < 5, "Creation time should be within the last 5 seconds"
+    assert (
+        datetime.utcnow() - stub_measure_page.dimensions[0].created_at
+    ).seconds < 5, "Creation time should be within the last 5 seconds"
 
-    assert stub_measure_page.dimensions[0].updated_at == stub_measure_page.dimensions[0].created_at, "Should have set the updated timestamp to be the same as the creation timestamp"
+    assert (
+        stub_measure_page.dimensions[0].updated_at == stub_measure_page.dimensions[0].created_at
+    ), "Should have set the updated timestamp to be the same as the creation timestamp"
 
 
 def test_delete_dimension_from_measure_page(stub_measure_page):
@@ -59,11 +63,13 @@ def test_update_dimension(stub_measure_page):
     assert updated_dimension.title == "updated-title"
     assert updated_dimension.time_period == "updated_time_period"
 
-    assert updated_dimension.updated_at != updated_dimension.created_at, "Update time should now be different from creation time"
+    assert (
+        updated_dimension.updated_at != updated_dimension.created_at
+    ), "Update time should now be different from creation time"
 
-    assert (datetime.utcnow() - updated_dimension.updated_at).seconds < 5, "Update time should be within the last 5 seconds"
-
-
+    assert (
+        datetime.utcnow() - updated_dimension.updated_at
+    ).seconds < 5, "Update time should be within the last 5 seconds"
 
 
 def test_update_dimension_does_not_call_update_dimension_classification_by_default(


### PR DESCRIPTION
This updates the database to no longer allow null values for the `created_at` and `updated_at` timestamps for the dimension rows.

This can only be run after the `2018-12-12_backfill_dimension_timestamps` script has run to backfill the existing null values.