### PR TITLE
Pull the full database using script

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -118,22 +118,36 @@ def pull_prod_data():
     command = "scripts/get_data.sh %s %s" % (prod_db, out_file)
     subprocess.call(shlex.split(command))
 
+    db.session.execute("DELETE FROM alembic_version;")
+    db.session.execute("DELETE FROM redirect;")
+    db.session.execute("DELETE FROM build;")
+    db.session.execute("DELETE FROM data_source_in_page;")
+    db.session.execute("DELETE FROM data_source;")
     db.session.execute("DELETE FROM ethnicity_in_classification;")
     db.session.execute("DELETE FROM parent_ethnicity_in_classification;")
     db.session.execute("DELETE FROM ethnicity;")
     db.session.execute("DELETE FROM dimension_categorisation;")
-    db.session.execute("DELETE FROM classification;")
     db.session.execute("DELETE FROM dimension;")
+    db.session.execute("DELETE FROM dimension_chart;")
+    db.session.execute("DELETE FROM dimension_table;")
+    db.session.execute("DELETE FROM classification;")
     db.session.execute("DELETE FROM upload;")
     db.session.execute("DELETE FROM page;")
     db.session.execute("DELETE FROM frequency_of_release;")
     db.session.execute("DELETE FROM lowest_level_of_geography;")
     db.session.execute("DELETE FROM organisation;")
     db.session.execute("DELETE FROM type_of_statistic;")
+    db.session.execute("DELETE FROM user_page;")
+    db.session.execute("DELETE FROM users;")
     db.session.commit()
 
     command = "pg_restore -d %s %s" % (app.config["SQLALCHEMY_DATABASE_URI"], out_file)
     subprocess.call(shlex.split(command))
+
+    print("anonymising users")
+    db.session.execute("UPDATE users set email = round(random() * 1000000000000)::text || '@anon.invalid', password = null, active = false")
+    db.session.commit()
+
 
     import contextlib
 

--- a/manage.py
+++ b/manage.py
@@ -103,7 +103,7 @@ def force_build_static_site():
 @manager.command
 def pull_prod_data(default_user_password=None):
     environment = os.environ.get("ENVIRONMENT", "PRODUCTION")
-    if environment == "PRODUCTION":
+    if environment.upper() == "PRODUCTION":
         print("It looks like you are running this in production or some unknown environment.")
         print("Do not run this command in this environment as it deletes data")
         sys.exit(-1)
@@ -183,7 +183,7 @@ def pull_prod_data(default_user_password=None):
 
 def _create_default_users_with_password(password_for_default_users):
     environment = os.environ.get("ENVIRONMENT", "PRODUCTION")
-    if environment == "PRODUCTION":
+    if environment.upper() == "PRODUCTION":
         print("No default users in production!")
         sys.exit(-1)
     if not password_for_default_users:

--- a/scripts/get_data.sh
+++ b/scripts/get_data.sh
@@ -8,4 +8,4 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
-pg_dump --no-acl --no-owner --data-only -Fc -T users -T alembic_version -T build -d $1 > $2
+pg_dump --no-acl --no-owner --data-only -Fc -d $1 > $2


### PR DESCRIPTION
Currently the `pull_prod_data` command doesn't actually work, as it deliberately excludes the `users` table, which is required because the `user_page` table has foreign keys which depend on it.

The original reason for excluding the users table was so that you could maintain your local users, enabling you to still be able to login to your local version of the application. On balance though, I’m not sure this is workable.

This update pulls the full database, including the users table, the build table and the alembic_version table. All tables are also truncated before importing the data (in the right order).

After importing the data, the users table is "pseudonymised" to remove the e-mail addresses (replacing them with a random invalid one), the hashed passwords, and to make all users deactive.

To then gain access to the application you would need to create a new local user.