### PR TITLE
Move edit and export links

### DIFF
--- a/application/src/sass/_status_banner.scss
+++ b/application/src/sass/_status_banner.scss
@@ -1,0 +1,60 @@
+// TODO: figure out how to make this responsive
+.status.sticky-js-fixed {
+  max-width: 960px;
+  width: 960px;
+  top: 0px;
+  position: fixed;
+  z-index: 2;
+}
+
+.status {
+  margin-top: 0;
+  background-color: $white;
+  box-sizing: border-box;
+  margin-top: 10px;
+  border: 4px solid $border-colour;
+  padding: 8px;
+}
+
+.status-inner {
+  width: 100%;
+  display: table;
+}
+
+.status .left {
+  display: table-cell;
+}
+
+.status .right {
+  display: table-cell;
+  text-align: right;
+}
+
+.status .info {
+  margin-right: 20px;
+}
+
+.status b {
+  font-weight: bold;
+}
+
+.status .button {
+  vertical-align: baseline;
+}
+
+.status .actions {
+
+  .other-versions {
+    display: table-cell;
+    width: 50%;
+    text-align: right;
+    font-size: 16px;
+
+    a {
+      font-size: 16px;
+      color: $link-colour;
+      padding: 0;
+      margin-left: 10px;
+    }
+  }
+}

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -29,3 +29,4 @@
 @import '_overrides';
 @import '_auto_resize_textarea';
 @import '_measure_progress_dashboard';
+@import '_status_banner';

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -282,67 +282,6 @@ $border-colour: #BFC1C3;
 
   //edit measure page
 
-  .status {
-    margin-top: 10px;
-    border: 4px solid $border-colour;
-    padding: 8px;
-  }
-
-  // TODO: figure out how to make this responsive
-  .status.sticky-js-fixed {
-    margin-top: 0;
-    background-color: $white;
-    box-sizing: border-box;
-    max-width: 960px;
-    width: 960px;
-    top: 0px;
-    position: fixed;
-    z-index: 2;
-  }
-
-  .status-inner {
-    width: 100%;
-    display: table;
-  }
-
-  .status .left {
-    display: table-cell;
-  }
-
-  .status .right {
-    display: table-cell;
-    text-align: right;
-  }
-
-  .status .info {
-    margin-right: 20px;
-  }
-
-  .status b {
-    font-weight: bold;
-  }
-
-  .status .button {
-    vertical-align: baseline;
-  }
-
-  .status .actions {
-
-    .other-versions {
-      display: table-cell;
-      width: 50%;
-      text-align: right;
-      font-size: 16px;
-
-      a {
-        font-size: 16px;
-        color: $link-colour;
-        padding: 0;
-        margin-left: 10px;
-      }
-    }
-  }
-
   #review-url {
     font-size: 14px;
   }

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -16,36 +16,6 @@
           <ul class="header-nav">
             <li><a href="{{ url_for('static_site.ethnicity_in_the_uk') }}">Ethnicity in the UK</a></li>
             <li><a href="{{ url_for('static_site.background') }}">Background</a></li>
-            {% if not static_mode and measure_page %}
-              <li>
-                {% if measure_page.latest_version() %}
-                    <a href="{{ url_for('cms.edit_measure_page',
-                 topic_uri=topic_uri,
-                 subtopic_uri=subtopic_uri,
-                 measure_uri=measure_page.uri,
-                 version=measure_page.version) }}">Edit</a>
-                {% else %}
-                    <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic_uri=topic_uri,
-                        subtopic_uri=subtopic_uri,
-                        measure_uri=measure_page.uri) }}">Edit</a>
-                {% endif %}
-              </li>
-                <li>
-                {% if measure_page.latest_version() %}
-                    <a href="{{ url_for('static_site.measure_page_markdown',
-                 topic_uri=topic_uri,
-                 subtopic_uri=subtopic_uri,
-                 measure_uri=measure_page.uri,
-                 version=measure_page.version) }}">Export</a>
-                {% else %}
-                    <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic_uri=topic_uri,
-                        subtopic_uri=subtopic_uri,
-                        measure_uri=measure_page.uri) }}">Export</a>
-                {% endif %}
-              </li>
-            {% endif %}
           </ul>
         </nav>
       </div>

--- a/application/templates/_shared/_status_banner_macro.html
+++ b/application/templates/_shared/_status_banner_macro.html
@@ -1,0 +1,13 @@
+{% macro status_banner() -%}
+
+  <div class="grid-row">
+    <div class="column-full">
+      <div class="status sticky-js">
+        <div class="status-inner">
+          {{ caller() }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+{%- endmacro %}

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 {% from "_shared/_page_title.html" import page_title %}
+{% from "_shared/_status_banner_macro.html" import status_banner %}
 
 {% from "cms/forms.html" import render_field, render_textarea_field, render_contact_details_fields,
                                 render_checkboxes, render_radio_field, render_department_select %}
@@ -60,122 +61,115 @@
 
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri) }}{% else %}{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}{% endif %}">
 
-        <!-- version info -->
-            <div class="grid-row">
-                <div class="column-full">
-                    <div class="status sticky-js">
-                        <div class="status-inner">
-                            <div class="version-info left">
-                                <span class="info">Version&nbsp;<b>{% if new %}1.0{% else %}{{ measure.version }}{% endif %}</b></span>
-                            </div>
-                            <div class="centre">
-                                <span class="info" id="status">Status:&nbsp;<b>
-                                    {% if measure.published == True and measure.status == "APPROVED" %}
-                                        Published
-                                    {% else %}
-                                        {% if new %}DRAFT{% else %}{{ measure.status | format_status | safe }}{% endif %}
-                                    {% endif %}</b>
-                                </span>
-                                {% if measure.status == 'DEPARTMENT_REVIEW' %}
-                                    <div id="review-url">
-                                        {% if measure.review_token and measure.review_token_expires_in(config) > 0 %}
-                                            {% set expires_in_days = measure.review_token_expires_in(config) %}
-                                                <a href="{{ url_for('review.review_page', review_token=measure.review_token, _external=True) }}"  id='review-link-url'>Review link</a>
-                                                expires in {{ expires_in_days }} {% if expires_in_days == 1 %}
-                                                day{% else %}days{% endif %}<button id="copy-to-clipboard" class="button neutral">Copy link</button>
-                                                <input id="review-link" value="{{ url_for('review.review_page', review_token=measure.review_token, _external=True) }}">
-                                        {% else %}
-                                            <span class="warning">Review link expired <button id="generate-review-url" class="button neutral">Renew</button></span>
-                                        {% endif %}
-                                    </div>
-                                {% endif %}
-                            </div>
-                            <div class="right">
-                                  {% if not new %}
-                                      <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" name="preview">
-                                        {% if measure.status == 'APPROVED' %}View{% else %}Preview this version{% endif %}
-                                      </a>
-                                  {% endif %}
-                            </div>
-                            <div class="actions right">
-                                {% if measure.status == 'APPROVED' and measure.latest and current_user.can(CREATE_VERSION) %}
-                                    <a class="button" href="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                        Edit / Create new version
-                                    </a>
-                                    {% if current_user.can(PUBLISH) %}
-                                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                            Unpublish
-                                        </a>
-                                    {% endif %}
-
-                                {%  elif measure.status == 'APPROVED' and not measure.latest%}
-
-                                    {%  set latest = measure.latest_version() %}
-                                    <div class="other-versions">
-
-                                          {% if latest.status == 'DRAFT' or latest.status == 'INTERNAL_REVIEW' or latest.status == 'DEPARTMENT_REVIEW' %}
-                                            <a href="{{ url_for('cms.edit_measure_page',
-                                                                topic_uri=topic.uri,
-                                                                subtopic_uri=subtopic.uri,
-                                                                measure_uri=latest.uri,
-                                                                version=latest.version) }}">Version {{ latest.version }}</a> of this page is in {{ latest.status | format_status | safe }}
-                                        {% endif %}
-                                        <a href="{{ url_for('cms.list_measure_page_versions',
-                                                            topic_uri=topic.uri,
-                                                            subtopic_uri=subtopic.uri,
-                                                            measure_uri=latest.uri)}}">All versions</a>
-                                    </div>
-
-                                {%  elif measure.status == 'DRAFT' or new %}
-                                     <button class="button" type="submit" name="save">
-                                            Save
-                                     </button>
-                                {% endif %}
-
-                                {% if "REJECT" in available_actions %}
-                                    <a class="button warning"
-                                       id="reject-measure"
-                                       href="{{ url_for('cms.reject_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                        Reject
-                                    </a>
-                                {% endif %}
-
-                                {% if status == 'REJECTED' or status == 'UNPUBLISHED' %}
-                                    <a class="button"
-                                        id="send-back-to-draft"
-                                        href="{{ url_for('cms.send_page_to_draft', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                        Send back to draft
-                                    </a>
-                                {%  endif %}
-
-                                {% if  "APPROVE" in available_actions %}
-                                    {% if status == 'DRAFT' %}
-                                        <button type="submit" class="button {% if next_approval_state == 'INTERNAL_REVIEW' %}neutral{%endif %}" name="save-and-review" id="save-and-review">
-                                            {{ next_approval_state | format_approve_button | safe }}
-                                        </button>
-                                     {% elif next_approval_state == 'INTERNAL_REVIEW' %}
-                                        <a class="button neutral" id="send-to-internal-review"
-                                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                            {{ next_approval_state | format_approve_button | safe }}
-                                        </a>
-                                    {% elif next_approval_state == 'DEPARTMENT_REVIEW' %}
-                                        <a class="button" id="send-to-department-review"
-                                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                            {{ next_approval_state | format_approve_button | safe }}
-                                        </a>
-                                    {% elif next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
-                                        <a class="button" id="send-to-approved"
-                                           href="{{ url_for('cms.publish', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                                            {{ next_approval_state | format_approve_button | safe }}
-                                        </a>
-                                    {% endif %}
-                                {% endif %}
-
-                            </div>
-                        </div>
-                    </div>
-                </div>
+        {% call status_banner() %}
+            <div class="version-info left">
+                <span class="info">Version&nbsp;<b>{{ measure.version }}</b></span>
             </div>
+            <div class="centre">
+                <span class="info" id="status">Status:&nbsp;<b>
+                    {% if measure.published == True and measure.status == "APPROVED" %}
+                        Published
+                    {% else %}
+                        {% if new %}DRAFT{% else %}{{ measure.status | format_status | safe }}{% endif %}
+                    {% endif %}</b>
+                </span>
+                {% if measure.status == 'DEPARTMENT_REVIEW' %}
+                    <div id="review-url">
+                        {% if measure.review_token and measure.review_token_expires_in(config) > 0 %}
+                            {% set expires_in_days = measure.review_token_expires_in(config) %}
+                                <a href="{{ url_for('review.review_page', review_token=measure.review_token, _external=True) }}"  id='review-link-url'>Review link</a>
+                                expires in {{ expires_in_days }} {% if expires_in_days == 1 %}
+                                day{% else %}days{% endif %}<button id="copy-to-clipboard" class="button neutral">Copy link</button>
+                                <input id="review-link" value="{{ url_for('review.review_page', review_token=measure.review_token, _external=True) }}">
+                        {% else %}
+                            <span class="warning">Review link expired <button id="generate-review-url" class="button neutral">Renew</button></span>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </div>
+            <div class="right">
+                  {% if not new %}
+                      <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" name="preview">
+                        {% if measure.status == 'APPROVED' %}View{% else %}Preview this version{% endif %}
+                      </a>
+                  {% endif %}
+            </div>
+            <div class="actions right">
+                {% if measure.status == 'APPROVED' and measure.latest and current_user.can(CREATE_VERSION) %}
+                    <a class="button" href="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                        Edit / Create new version
+                    </a>
+                    {% if current_user.can(PUBLISH) %}
+                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                            Unpublish
+                        </a>
+                    {% endif %}
+
+                {%  elif measure.status == 'APPROVED' and not measure.latest%}
+
+                    {%  set latest = measure.latest_version() %}
+                    <div class="other-versions">
+
+                          {% if latest.status == 'DRAFT' or latest.status == 'INTERNAL_REVIEW' or latest.status == 'DEPARTMENT_REVIEW' %}
+                            <a href="{{ url_for('cms.edit_measure_page',
+                                                topic_uri=topic.uri,
+                                                subtopic_uri=subtopic.uri,
+                                                measure_uri=latest.uri,
+                                                version=latest.version) }}">Version {{ latest.version }}</a> of this page is in {{ latest.status | format_status | safe }}
+                        {% endif %}
+                        <a href="{{ url_for('cms.list_measure_page_versions',
+                                            topic_uri=topic.uri,
+                                            subtopic_uri=subtopic.uri,
+                                            measure_uri=latest.uri)}}">All versions</a>
+                    </div>
+
+                {%  elif measure.status == 'DRAFT' or new %}
+                     <button class="button" type="submit" name="save">
+                            Save
+                     </button>
+                {% endif %}
+
+                {% if "REJECT" in available_actions %}
+                    <a class="button warning"
+                       id="reject-measure"
+                       href="{{ url_for('cms.reject_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                        Reject
+                    </a>
+                {% endif %}
+
+                {% if status == 'REJECTED' or status == 'UNPUBLISHED' %}
+                    <a class="button"
+                        id="send-back-to-draft"
+                        href="{{ url_for('cms.send_page_to_draft', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                        Send back to draft
+                    </a>
+                {%  endif %}
+
+                {% if  "APPROVE" in available_actions %}
+                    {% if status == 'DRAFT' %}
+                        <button type="submit" class="button {% if next_approval_state == 'INTERNAL_REVIEW' %}neutral{%endif %}" name="save-and-review" id="save-and-review">
+                            {{ next_approval_state | format_approve_button | safe }}
+                        </button>
+                     {% elif next_approval_state == 'INTERNAL_REVIEW' %}
+                        <a class="button neutral" id="send-to-internal-review"
+                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                            {{ next_approval_state | format_approve_button | safe }}
+                        </a>
+                    {% elif next_approval_state == 'DEPARTMENT_REVIEW' %}
+                        <a class="button" id="send-to-department-review"
+                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                            {{ next_approval_state | format_approve_button | safe }}
+                        </a>
+                    {% elif next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
+                        <a class="button" id="send-to-approved"
+                           href="{{ url_for('cms.publish', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                            {{ next_approval_state | format_approve_button | safe }}
+                        </a>
+                    {% endif %}
+                {% endif %}
+
+            </div>
+        {% endcall %}
 
         <div class="grid-row">
             <div class="column-full">

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
+{% from "_shared/_status_banner_macro.html" import status_banner %}
 
-{% set breadcrumbs = 
+{% set breadcrumbs =
   [
     {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures", "event": "breadcrumb-homepage"},
     {"url": url_for("static_site.topic", topic_uri=topic_uri), "text": measure_page.parent.parent.title, "event": "breadcrumb-" + topic_uri},
@@ -15,7 +16,7 @@
 {% block googleAnalytics %}ga('set','contentGroup1','Measure');{% endblock %}
 
 {% set version = 'latest' if measure_page.has_no_later_published_versions() else measure_page.version %}
-  
+
 {% block headEnd %}
     {{ super() }}
 
@@ -47,7 +48,55 @@
                           subtopic_uri=subtopic_uri,
                           measure_uri=measure_page.uri,
                           version=version) }}"/>
-  
+
+
+  {% call status_banner() %}
+    <div class="version-info left">
+        <span class="info">Version&nbsp;<b>{% if new %}1.0{% else %}{{ measure_page.version }}{% endif %}</b></span>
+    </div>
+    <div class="centre">
+        <span class="info" id="status">Status:&nbsp;<b>
+            {% if measure_page.published == True and measure_page.status == "APPROVED" %}
+                Published
+            {% else %}
+                {% if new %}DRAFT{% else %}{{ measure_page.status | format_status | safe }}{% endif %}
+            {% endif %}</b>
+        </span>
+    </div>
+    <div class="right">
+      <span class="info">
+        {% if measure_page.latest_version() %}
+          <a href="{{ url_for('cms.edit_measure_page',
+         topic_uri=topic_uri,
+         subtopic_uri=subtopic_uri,
+         measure_uri=measure_page.uri,
+         version=measure_page.version) }}" class="button">Edit</a>
+        {% else %}
+          <a href="{{ url_for('cms.list_measure_page_versions',
+                topic_uri=topic_uri,
+                subtopic_uri=subtopic_uri,
+                measure_uri=measure_page.uri) }}" class="button">Edit</a>
+        {% endif %}
+      </span>
+      <span class="info">
+        {% if measure_page.latest_version() %}
+          <a href="{{ url_for('static_site.measure_page_markdown',
+           topic_uri=topic_uri,
+           subtopic_uri=subtopic_uri,
+           measure_uri=measure_page.uri,
+           version=measure_page.version) }}">Export</a>
+        {% else %}
+          <a href="{{ url_for('cms.list_measure_page_versions',
+                  topic_uri=topic_uri,
+                  subtopic_uri=subtopic_uri,
+                  measure_uri=measure_page.uri) }}">Export</a>
+        {% endif %}
+      </span>
+    </div>
+  {% endcall %}
+
+
+
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large" itemprop="headline">


### PR DESCRIPTION
This moves the "edit" and "export" links, from the header:

<img width="979" alt="screenshot 2018-11-15 at 11 47 26" src="https://user-images.githubusercontent.com/30665/48551056-501f4880-e8cc-11e8-8619-bdb9253dd8e9.png">

...to a status banner at the top of the page, in the same style as the one on the edit page:

<img width="1000" alt="screenshot 2018-11-15 at 11 47 48" src="https://user-images.githubusercontent.com/30665/48551089-63321880-e8cc-11e8-9070-201362f99520.png">

It also adds the status and version number, for a bit of additional context.

See https://trello.com/c/aFOMVdn1/1121-review-placement-of-edit-and-export-in-the-banner