### PR TITLE
Add more affordance for expandability

### DIFF
--- a/application/src/sass/_measures_by_week.scss
+++ b/application/src/sass/_measures_by_week.scss
@@ -11,12 +11,50 @@
     border-bottom-color: #005EA5;
   }
 
+  .week th,
+  .week td {
+    cursor: pointer;
+    -webkit-user-select: none; /* Chrome all / Safari all */
+    -moz-user-select: none; /* Firefox all */
+    -ms-user-select: none; /* IE 10+ */
+    user-select: none; /* Likely future */
+  }
+
+  .week.empty th,
+  .week.empty td {
+    cursor: inherit;
+  }
+
   .week td,
   .week th,
   tbody.collapsed .week:hover td,
   tbody.collapsed .week:hover th {
     background-color: #e6e6e6;
     border-bottom-color: #e6e6e6;
+  }
+
+  tbody .week td:last-child {
+    position: relative;
+  }
+
+  tbody .week td:last-child:after {
+    position: absolute;
+    right: 10px;
+    font-size: 19px;
+    font-weight: bold;
+    color: $grey-1;
+  }
+
+  tbody .week.empty td:last-child:after {
+    display: none;
+  }
+
+  tbody .week td:last-child:after {
+    content: '–';
+  }
+
+  tbody.collapsed .week td:last-child:after {
+    content: '+';
   }
 
   tbody.collapsed .week td,
@@ -27,11 +65,11 @@
   }
 
   .week th {
-    cursor: pointer;
-    -webkit-user-select: none; /* Chrome all / Safari all */
-    -moz-user-select: none; /* Firefox all */
-    -ms-user-select: none; /* IE 10+ */
-    user-select: none; /* Likely future */
+    color: $govuk-blue;
+  }
+
+  .week.empty th {
+    color: $black;
   }
 
   .week.empty th {


### PR DESCRIPTION
This makes it more obvious that some rows can be expanded by:

* making the dates blue
* Adding a + or - icon to the right
* Making the pointer cursor extend to the whole row.

See https://trello.com/c/Uwbx67Ti/1001-show-ui-that-indicates-you-can-expand-published-pages-section-week-beginning-date-rows