### PR TITLE
BUGFIX: Replicated lines at top of data file when downloaded

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -527,6 +527,8 @@
                 </a>
                 {% if file.description %}
                   <p>{{ file.description }}</p>
+                {% else %}
+                  <br />
                 {% endif %}
               {% endif %}
             {% endfor %}

--- a/application/utils.py
+++ b/application/utils.py
@@ -87,6 +87,7 @@ def get_csv_data_for_download(filename):
                 rows.append(row)
 
     except UnicodeDecodeError as e:
+        rows = []  # Reset rows to be empty before attempting to read the file again, to avoid duplication
         with open(filename, "r", encoding="iso-8859-1") as f:
             reader = csv.reader(f, delimiter=",")
             for row in reader:


### PR DESCRIPTION

BUGFIX: Duplicate rows at top of download file

We have seen an issue where the first 67 rows of a download file were
duplicated in the download.

It turns out that when downloading the file and reading row-by-row there
was no "UnicodeDecodeError" until line 68, where there was a `£` sign
for the first time.

Because the first 67 had successfully been read in to the `rows` array
as UTF-8, they were duplicated when re-reading the file as ISO-8859-1.

The simple fix here is to make sure the rows array is reset before
starting over.