### PR TITLE
Data migration to remove the unused "Quality of Care" subtopic

### DIFF
--- a/scripts/data_migrations/2018-11-28_remove_quality_of_care_topic.sql
+++ b/scripts/data_migrations/2018-11-28_remove_quality_of_care_topic.sql
@@ -1,0 +1,94 @@
+BEGIN TRANSACTION;
+
+
+CREATE TEMPORARY TABLE qualityofcare_pages
+AS (
+    SELECT page.guid AS page_guid
+    FROM page
+    WHERE parent_guid = 'subtopic_qualityofcare'
+);
+
+
+CREATE TEMPORARY TABLE qualityofcare_charts
+AS (
+    SELECT dimension.chart_id
+    FROM dimension
+    WHERE dimension.page_id IN (
+        SELECT *
+        FROM qualityofcare_pages
+    )
+);
+
+
+CREATE TEMPORARY TABLE qualityofcare_tables
+AS (
+    SELECT dimension.table_id
+    FROM dimension
+    WHERE dimension.page_id IN (
+        SELECT *
+        FROM qualityofcare_pages
+    )
+);
+
+
+CREATE TEMPORARY TABLE qualityofcare_sources
+AS (
+    SELECT data_source.id
+    FROM data_source
+    JOIN data_source_in_page ON data_source_in_page.data_source_id = data_source.id
+    JOIN page ON data_source_in_page.page_guid = page.guid
+    AND data_source_in_page.page_version = page.version
+    WHERE data_source_in_page.page_guid IN (
+        SELECT *
+        FROM qualityofcare_pages
+    )
+);
+
+
+DELETE FROM dimension_chart
+WHERE dimension_chart.id IN (
+    SELECT *
+    FROM qualityofcare_charts
+);
+
+
+DELETE FROM dimension_table
+WHERE dimension_table.id IN (
+    SELECT *
+    FROM qualityofcare_tables
+);
+
+
+DELETE FROM data_source_in_page
+WHERE data_source_in_page.data_source_id IN (
+    SELECT *
+    FROM qualityofcare_sources
+);
+
+
+DELETE FROM data_source
+WHERE data_source.id IN (
+    SELECT *
+    FROM qualityofcare_sources
+);
+
+
+DELETE FROM dimension
+WHERE dimension.page_id IN (
+    SELECT *
+    FROM qualityofcare_pages
+);
+
+
+DELETE FROM page
+WHERE page.guid IN (
+    SELECT *
+    FROM qualityofcare_pages
+);
+
+
+DELETE FROM page
+WHERE page.guid = 'subtopic_qualityofcare';
+
+
+COMMIT;


### PR DESCRIPTION
For this ticket: https://trello.com/c/pxvkWRkp/1174-delete-quality-of-care-subtopic-1

I tried - I really tried hard - to figure out a way to read the IDs of orphaned charts, tables and data sources into array variables so the exact ones could be deleted, rather than a blanket cleaning up of orphans as we have here.  But try as I might I couldn't get `ANY(xxx_ids)` to work (where `xxx_ids` was the array variable declared and populated with a list of relevant IDs).

As it is I think just cleaning up all the orphans is OK here - the way things are we shouldn't have orphaned things.  But it could become problematic in future if we want to manage data sources separate from pages.

This has made me wonder slightly if we've done the right thing splitting out charts and tables from `dimension` though...