### PR TITLE
Drop and restore entire database to match remote

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -132,7 +132,12 @@ def pull_prod_data(default_user_password=None):
 
     print("Anonymising users...")
     db.session.execute(
-        "UPDATE users set email = round(random() * 1000000000000)::text || '@anon.invalid', password = null, active = false"  # noqa
+        """
+    UPDATE users
+    SET email = ROUND(RANDOM() * 1000000000000)::TEXT || '@anon.invalid', 
+        password = NULL, 
+        active = FALSE
+    """
     )
     db.session.commit()
 

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,8 @@ from concurrent.futures import ThreadPoolExecutor
 import sys
 
 import os
-from flask_migrate import Migrate, MigrateCommand
+
+from flask_migrate import Migrate, MigrateCommand, upgrade
 from flask_script import Manager, Server
 from flask_security import SQLAlchemyUserDatastore
 from flask_security.utils import hash_password
@@ -153,6 +154,9 @@ def pull_prod_data(default_user_password=None):
         print("Creating default users...")
         _create_default_users_with_password(default_user_password)
 
+    print("Upgrading database from local migrations...")
+    upgrade()
+
     if os.environ.get("PROD_UPLOAD_BUCKET_NAME"):
         #  Copy upload files from production to the upload bucket for the current environment
         import boto3
@@ -161,10 +165,10 @@ def pull_prod_data(default_user_password=None):
         source = s3.Bucket(os.environ.get("PROD_UPLOAD_BUCKET_NAME"))
         destination = s3.Bucket(os.environ.get("S3_UPLOAD_BUCKET_NAME"))
 
+        print(f"Copying upload files from bucket {source.name}")
+
         # Clear out destination folder
         destination.objects.all().delete()
-
-        print(f"Copying upload files from bucket {source.name}")
 
         def download_key(source_bucket_name, key_name):
             print(f"  Copying file {key_name}")

--- a/manage.py
+++ b/manage.py
@@ -125,8 +125,6 @@ def pull_prod_data(default_user_password=None):
         if tbl.name not in inspect(db.engine).get_view_names():
             db.engine.execute(tbl.delete())
 
-    db.session.execute("DELETE FROM alembic_version")
-
     db.session.commit()
 
     command = "pg_restore -d %s %s" % (app.config["SQLALCHEMY_DATABASE_URI"], out_file)

--- a/scripts/get_data.sh
+++ b/scripts/get_data.sh
@@ -8,4 +8,4 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
-pg_dump --no-acl --no-owner --data-only -Fc -T alembic_version -d $1 > $2
+pg_dump --no-acl --no-owner -Fc -d $1 > $2

--- a/scripts/get_data.sh
+++ b/scripts/get_data.sh
@@ -8,4 +8,4 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
-pg_dump --no-acl --no-owner --data-only -Fc -d $1 > $2
+pg_dump --no-acl --no-owner --data-only -Fc -T alembic_version -d $1 > $2


### PR DESCRIPTION
See discussion on https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/pull/876 for context.

The original idea here was to exclude the `alembic_version` from any messing about during `pull_prod_data` so that it woul still accurately represent the structure of the database.

But if the structure of the DB isn't the same in both places then ther's a (strong) chance that the data copying will fail, as we've seen befoe in Dev and Staging if they are a migration ahead of Prod when the overnight job runs.

So as we're no longer excluding any tables from the data copying it's better to copy the whole thing -including structure - to avoid any problems with different versions.

After pulling the remote database and adding default users this now runs `db upgrade` to ensure that the new version is compatible with any updated code locally.