### PR TITLE
Trim whitespace from around values in chart/table data

### DIFF
--- a/application/src/js/charts/rd-data-tools.js
+++ b/application/src/js/charts/rd-data-tools.js
@@ -160,12 +160,18 @@ function uniqueDataInColumnMaintainOrder(data, index) {
 
 
 function textToData(textData) {
-    var cleanData = textData.trim();
-    if (cleanData.search('\t') >= 0) {
-        return _.map(cleanData.split('\n'), function (line) { return line.split('\t') });
-    } else {
-        return _.map(cleanData.split('\n'), function (line) { return line.split('|') });
+    var delimiter = '\t'
+    // Super-undocumented feature that means users could enter pipe-delimited data rather than tab-delimited
+    if (textData.search(delimiter) < 0) {
+        delimiter = '|'
     }
+
+    splitLineAndTrimEachItem = function (line) {
+        return _.map(line.split(delimiter), function (item) {return item.trim()});
+    }
+
+    var lines = textData.trim().split('\n');
+    return _.map(lines, splitLineAndTrimEachItem);
 }
 
 var ETHNICITY_ERROR = 'Ethnicity column error';

--- a/test/test-data-tools.js
+++ b/test/test-data-tools.js
@@ -301,6 +301,15 @@ describe('rd-data-tools', function () {
             expect(values[0]).to.deep.equal(["a", "b|anomaly", "c"]);
             expect(values[1]).to.deep.equal(["d|anomaly", "e", "f"]);
         });
+
+        it('should trim whitespace from around data items after splitting', function () {
+            var text = "   Header 1   \t  Header    2  \tHeader 3\n" + " Data   1  \t Data 2    \tData   3   \n  ";
+            var values = dataTools.textToData(text);
+
+            assert.equal(values.length, 2);
+            expect(values[0]).to.deep.equal(["Header 1", "Header    2", "Header 3"]);
+            expect(values[1]).to.deep.equal(["Data   1", "Data 2", "Data   3"]);
+        });
     });
 
     describe('#hasHeader', function () {


### PR DESCRIPTION
For this ticket: https://trello.com/c/coBLC4Yq/1185-chart-and-table-builder-should-strip-whitespace-around-values-in-pasted-data-1

We had an issue recently where analysts couldn't get a chart to build
from what looked like perfectly fine data.

The issue was a trailing space on two of the ethnicity values, which
meant that Chartbuilder didn't think there were enough rows for all
ethnicities.

The change here trims whitespace from around each data item after the
line has been split, which will prevent this issue happening again in
future.