### PR TITLE
Use `npx` to locate correct npm bin

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -465,7 +465,7 @@ def clear_up(build_dir):
 
 
 def create_versioned_assets(build_dir):
-    subprocess.run(["gulp", "make"])
+    subprocess.run(["npx", "gulp", "make"])
     static_dir = os.path.join(build_dir, get_static_dir())
     if os.path.exists(static_dir):
         shutil.rmtree(static_dir)


### PR DESCRIPTION
 ## Summary
`gulp` by itself fails to run locally for me, as I don't force
`./node_modules/.bin` into my path. `npx` is the recommended way to
ensure that you are using the correctly-scoped set of node binaries on
any system and is part of the core ecosystem, so it feels sensible to
use this when we call out to system processes during the build.

NPX: https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner