### PR TITLE
Don't get measure pages by URI alone

### DIFF
--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -115,7 +115,7 @@ def measure_page_markdown(topic_uri, subtopic_uri, measure_uri, version):
         if version == "latest":
             measure_page = page_service.get_latest_version(topic_uri, subtopic_uri, measure_uri)
         else:
-            measure_page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version)
+            *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
     except PageNotFoundException:
         abort(404)
     if current_user.is_departmental_user():
@@ -140,7 +140,7 @@ def measure_page(topic_uri, subtopic_uri, measure_uri, version):
         if version == "latest":
             measure_page = page_service.get_latest_version(topic_uri, subtopic_uri, measure_uri)
         else:
-            measure_page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version)
+            *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
     except PageNotFoundException:
         abort(404)
 
@@ -169,8 +169,8 @@ def measure_page(topic_uri, subtopic_uri, measure_uri, version):
 @static_site_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/downloads/<filename>")
 def measure_page_file_download(topic_uri, subtopic_uri, measure_uri, version, filename):
     try:
-        page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version)
-        upload_obj = upload_service.get_upload(page, filename)
+        *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
+        upload_obj = upload_service.get_upload(measure_page, filename)
         downloaded_file = upload_service.get_measure_download(upload_obj, filename, "source")
         content = get_csv_data_for_download(downloaded_file)
         if os.path.exists(downloaded_file):
@@ -191,8 +191,10 @@ def measure_page_file_download(topic_uri, subtopic_uri, measure_uri, version, fi
 @static_site_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/dimension/<dimension_guid>/download")
 def dimension_file_download(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     try:
-        page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version)
-        dimension_obj = DimensionObjectBuilder.build(page.get_dimension(dimension_guid))
+        *_, dimension = page_service.get_measure_page_hierarchy(
+            topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
+        )
+        dimension_obj = DimensionObjectBuilder.build(dimension)
 
         data = write_dimension_csv(dimension=dimension_obj)
         response = make_response(data)
@@ -215,8 +217,10 @@ def dimension_file_download(topic_uri, subtopic_uri, measure_uri, version, dimen
 )
 def dimension_file_table_download(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     try:
-        page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version)
-        dimension_obj = DimensionObjectBuilder.build(page.get_dimension(dimension_guid))
+        *_, dimension = page_service.get_measure_page_hierarchy(
+            topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
+        )
+        dimension_obj = DimensionObjectBuilder.build(dimension)
 
         data = write_dimension_tabular_csv(dimension=dimension_obj)
         response = make_response(data)

--- a/tests/test_page_service.py
+++ b/tests/test_page_service.py
@@ -449,3 +449,17 @@ def test_create_copy_of_page(stub_measure_page, mock_rdu_user):
     assert first_copy_guid != second_copy.guid
     assert second_copy.title == f"COPY OF {first_copy_title}"
     assert second_copy.uri == f"{first_copy_uri}-copy"
+
+
+def test_get_page_by_uri_and_type_only_allows_certain_types(stub_topic_page, stub_subtopic_page, stub_measure_page):
+    with pytest.raises(NotImplementedError):
+        page_service.get_page_by_uri_and_type("", "homepage")
+
+    with pytest.raises(NotImplementedError):
+        page_service.get_page_by_uri_and_type("test-measure-page", "measure")
+
+    page1 = page_service.get_page_by_uri_and_type("test", "topic")
+    assert page1 == stub_topic_page
+
+    page2 = page_service.get_page_by_uri_and_type("example", "subtopic")
+    assert page2 == stub_subtopic_page


### PR DESCRIPTION
Suboptimally fixes this bug: https://trello.com/c/he5gO4z3/1195-get-page-by-uri-or-type-is-broken-for-pages-with-same-title-in-different-subtopics

The "full" fix will come when we have a "sitemap" table with unique URIs. Maybe.

This changes things so that we always get measure pages using the site hierarchy, rather than just ignoring topic and subtopic parameters as we've been doing up until now in some places  :see_no_evil: :hear_no_evil:

The fundamentaly broken `get_page_by_uri_and_type` is now locked down to topic and subtopic pages - which could potentially still be created with duplicate URIs - but are under dev control and less likely to proliferate.

With the changes in place here we can "safely" create pages with the same title and URI in different subtopics and not have the site break.