### PR TITLE
 Incorporate all migration changes

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -3,12 +3,13 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import MetaData
 
 db = SQLAlchemy(
+    # Our ideal naming convention
     metadata=MetaData(
         naming_convention={
-            "ix": "ix_%(column_0_N_label)s",
-            "uq": "uix_%(table_name)s_%(column_0_N_name)s",
+            "ix": "ix_%(column_0N_label)s",
+            "uq": "uix_%(table_name)s_%(column_0_name)s",
             "ck": "ck_%(constraint_name)s",
-            "fk": "%(table_name)s_%(column_0_N_name)s_fkey",
+            "fk": "%(table_name)s_%(column_0_name)s_fkey",
             "pk": "%(table_name)s_pkey",
         }
     )

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,5 +1,16 @@
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import MetaData
 
-db = SQLAlchemy()
+db = SQLAlchemy(
+    metadata=MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_N_label)s",
+            "uq": "uix_%(table_name)s_%(column_0_N_name)s",
+            "ck": "ck_%(constraint_name)s",
+            "fk": "%(table_name)s_%(column_0_N_name)s_fkey",
+            "pk": "%(table_name)s_pkey",
+        }
+    )
+)
 mail = Mail()

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -7,7 +7,7 @@ db = SQLAlchemy(
     metadata=MetaData(
         naming_convention={
             "ix": "ix_%(column_0N_label)s",
-            "uq": "uix_%(table_name)s_%(column_0_name)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
             "ck": "ck_%(constraint_name)s",
             "fk": "%(table_name)s_%(column_0_name)s_fkey",
             "pk": "%(table_name)s_pkey",

--- a/application/auth/models.py
+++ b/application/auth/models.py
@@ -1,6 +1,7 @@
 import enum
 
 from flask_security import UserMixin
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY
 from application import db
 from sqlalchemy.ext.mutable import MutableList
@@ -47,12 +48,14 @@ class User(db.Model, RoleFreeUserMixin):
     __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(255), unique=True)
+    email = db.Column(db.String(255))
     password = db.Column(db.String(255))
     active = db.Column(db.Boolean(), default=False)
     confirmed_at = db.Column(db.DateTime())
     user_type = db.Column(db.Enum(TypeOfUser, name="type_of_user_types"), nullable=False)
     capabilities = db.Column(MutableList.as_mutable(ARRAY(db.String)), default=[])
+
+    __table_args__ = (UniqueConstraint(email, name="users_email_key"),)
 
     def user_name(self):
         return self.email.split("@")[0]

--- a/application/auth/models.py
+++ b/application/auth/models.py
@@ -55,7 +55,7 @@ class User(db.Model, RoleFreeUserMixin):
     user_type = db.Column(db.Enum(TypeOfUser, name="type_of_user_types"), nullable=False)
     capabilities = db.Column(MutableList.as_mutable(ARRAY(db.String)), default=[])
 
-    __table_args__ = (UniqueConstraint(email, name="users_email_key"),)
+    __table_args__ = (UniqueConstraint(email, name="uq_users_email"),)
 
     def user_name(self):
         return self.email.split("@")[0]

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -851,9 +851,9 @@ class DimensionClassification(db.Model):
     dimension_guid = db.Column(db.String(255), primary_key=True)
     classification_id = db.Column("classification_id", db.Integer, primary_key=True)
 
-    includes_parents = db.Column(db.Boolean)
-    includes_all = db.Column(db.Boolean)
-    includes_unknown = db.Column(db.Boolean)
+    includes_parents = db.Column(db.Boolean, nullable=False)
+    includes_all = db.Column(db.Boolean, nullable=False)
+    includes_unknown = db.Column(db.Boolean, nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(["dimension_guid"], [Dimension.guid]),
@@ -867,9 +867,9 @@ class ChartAndTableMixin(object):
 
     id = db.Column(db.Integer, primary_key=True)
     classification_id = db.Column("classification_id", db.Integer, nullable=False)
-    includes_parents = db.Column(db.Boolean)
-    includes_all = db.Column(db.Boolean)
-    includes_unknown = db.Column(db.Boolean)
+    includes_parents = db.Column(db.Boolean, nullable=False)
+    includes_all = db.Column(db.Boolean, nullable=False)
+    includes_unknown = db.Column(db.Boolean, nullable=False)
 
     @classmethod
     def get_by_id(cls, id):

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -185,9 +185,9 @@ class DataSourceInPage(db.Model):
     page_version = db.Column(db.String(255), primary_key=True)
 
     __table_args__ = (
-        ForeignKeyConstraint([data_source_id], ["data_source.id"], name="data_source_in_page_data_source_id_fkey"),
+        ForeignKeyConstraint(["data_source_id"], ["data_source.id"], name="data_source_in_page_data_source_id_fkey"),
         ForeignKeyConstraint(
-            [page_guid, page_version], ["page.guid", "page.version"], name="data_source_in_page_page_guid_fkey"
+            ["page_guid", "page_version"], ["page.guid", "page.version"], name="data_source_in_page_page_guid_fkey"
         ),
     )
 
@@ -264,7 +264,7 @@ class Page(db.Model):
 
     __table_args__ = (
         PrimaryKeyConstraint("guid", "version", name="page_guid_version_pk"),
-        ForeignKeyConstraint([parent_guid, parent_version], ["page.guid", "page.version"]),
+        ForeignKeyConstraint(["parent_guid", "parent_version"], ["page.guid", "page.version"]),
         UniqueConstraint("guid", "version", name="uix_page_guid_version"),
         Index("ix_page_type_uri", page_type, uri),
         {},
@@ -596,7 +596,7 @@ class Dimension(db.Model):
     dimension_chart = relationship("Chart")
     dimension_table = relationship("Table")
 
-    __table_args__ = (ForeignKeyConstraint([page_id, page_version], [Page.guid, Page.version]), {})
+    __table_args__ = (ForeignKeyConstraint(["page_id", "page_version"], [Page.guid, Page.version]), {})
 
     classification_links = db.relationship(
         "DimensionClassification", backref="dimension", lazy="dynamic", cascade="all,delete"
@@ -771,7 +771,7 @@ class Upload(db.Model):
     page_id = db.Column(db.String(255), nullable=False)
     page_version = db.Column(db.String(), nullable=False)
 
-    __table_args__ = (ForeignKeyConstraint([page_id, page_version], [Page.guid, Page.version]), {})
+    __table_args__ = (ForeignKeyConstraint(["page_id", "page_version"], [Page.guid, Page.version]), {})
 
     def extension(self):
         return self.file_name.split(".")[-1]
@@ -856,8 +856,8 @@ class DimensionClassification(db.Model):
     includes_unknown = db.Column(db.Boolean)
 
     __table_args__ = (
-        ForeignKeyConstraint([dimension_guid], [Dimension.guid]),
-        ForeignKeyConstraint([classification_id], [Classification.id]),
+        ForeignKeyConstraint(["dimension_guid"], [Dimension.guid]),
+        ForeignKeyConstraint(["classification_id"], [Classification.id]),
         {},
     )
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -265,7 +265,7 @@ class Page(db.Model):
     __table_args__ = (
         PrimaryKeyConstraint("guid", "version", name="page_guid_version_pk"),
         ForeignKeyConstraint(["parent_guid", "parent_version"], ["page.guid", "page.version"]),
-        UniqueConstraint("guid", "version", name="uix_page_guid_version"),
+        UniqueConstraint("guid", "version", name="uq_page_guid_version"),
         Index("ix_page_type_uri", page_type, uri),
         {},
     )

--- a/migrations/versions/2018_10_31_separation_data_sources_from_page_table_separate_data_sources_from_the_page_.py
+++ b/migrations/versions/2018_10_31_separation_data_sources_from_page_table_separate_data_sources_from_the_page_.py
@@ -44,7 +44,6 @@ def upgrade():
         sa.Column("page_guid", sa.String(length=255), nullable=False),
         sa.Column("page_version", sa.String(length=255), nullable=False),
         sa.ForeignKeyConstraint(["data_source_id"], ["data_source.id"]),
-        sa.ForeignKeyConstraint(["data_source_id"], ["data_source.id"]),
         sa.ForeignKeyConstraint(["page_guid", "page_version"], ["page.guid", "page.version"]),
         sa.PrimaryKeyConstraint(
             "data_source_id", "page_guid", "page_version", name="data_source_id_page_guid_version_pk"

--- a/migrations/versions/2018_12_03_fix_migrations.py
+++ b/migrations/versions/2018_12_03_fix_migrations.py
@@ -1,0 +1,50 @@
+"""fix migrations by incorporating outstanding changes
+
+Revision ID: 2018_12_03_fix_migrations
+Revises: 2018_11_28_drop_contact_details
+Create Date: 2018-12-03 10:51:52.822365
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2018_12_03_fix_migrations"
+down_revision = "2018_11_28_drop_contact_details"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_foreign_key(
+        "data_source_frequency_of_release_id_fkey",
+        "data_source",
+        "frequency_of_release",
+        ["frequency_of_release_id"],
+        ["id"],
+    )
+    op.alter_column("dimension_chart", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False)
+    op.alter_column("dimension_table", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False)
+    op.alter_column(
+        "ethnicity_in_classification", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False
+    )
+    op.alter_column("ethnicity_in_classification", "ethnicity_id", existing_type=sa.INTEGER(), nullable=False)
+    op.alter_column(
+        "parent_ethnicity_in_classification", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False
+    )
+    op.alter_column("parent_ethnicity_in_classification", "ethnicity_id", existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("parent_ethnicity_in_classification", "ethnicity_id", existing_type=sa.INTEGER(), nullable=True)
+    op.alter_column(
+        "parent_ethnicity_in_classification", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True
+    )
+    op.alter_column("ethnicity_in_classification", "ethnicity_id", existing_type=sa.INTEGER(), nullable=True)
+    op.alter_column(
+        "ethnicity_in_classification", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True
+    )
+    op.alter_column("dimension_table", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.alter_column("dimension_chart", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.drop_constraint("data_source_frequency_of_release_id_fkey", "data_source", type_="foreignkey")

--- a/migrations/versions/2018_12_03_remove_duplicate_fkey.py
+++ b/migrations/versions/2018_12_03_remove_duplicate_fkey.py
@@ -1,0 +1,34 @@
+"""Remove duplicated foreign key on data_source_in_page
+
+Revision ID: 2018_12_03_remove_duplicate_fkey
+Revises: 2018_12_03_fix_migrations
+Create Date: 2018-11-05 09:05:59.517656
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2018_12_03_remove_duplicate_fkey"
+down_revision = "2018_12_03_fix_migrations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    res = conn.execute(
+        "SELECT constraint_name "
+        "FROM information_schema.table_constraints "
+        "WHERE table_name='data_source_in_page' AND constraint_name = 'data_source_in_page_data_source_id_fkey1';"
+    )
+
+    if len(res.fetchall()) > 0:
+        op.drop_constraint("data_source_in_page_data_source_id_fkey1", "data_source_in_page", type_="foreignkey")
+
+
+def downgrade():
+    op.create_foreign_key(
+        "data_source_in_page_data_source_id_fkey1", "data_source_in_page", "data_source", ["data_source_id"], ["id"]
+    )

--- a/migrations/versions/2018_12_05_fix_page_constraint.py
+++ b/migrations/versions/2018_12_05_fix_page_constraint.py
@@ -1,0 +1,26 @@
+"""Rename from uix -> uq to follow naming convention
+
+Revision ID: 2018_12_05_fix_page_constraint
+Revises: 2018_12_05_fix_user_constraint
+Create Date: 2018-12-05 18:43:24.009236
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2018_12_05_fix_page_constraint"
+down_revision = "2018_12_05_fix_user_constraint"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint("uq_page_guid_version", "page", ["guid", "version"])
+    op.drop_constraint("uix_page_guid_version", "page", type_="unique")
+
+
+def downgrade():
+    op.create_unique_constraint("uix_page_guid_version", "page", ["guid", "version"])
+    op.drop_constraint("uq_page_guid_version", "page", type_="unique")

--- a/migrations/versions/2018_12_05_fix_user_constraint.py
+++ b/migrations/versions/2018_12_05_fix_user_constraint.py
@@ -1,0 +1,26 @@
+"""Rename unique constraint on users email address
+
+Revision ID: 2018_12_05_fix_user_constraint
+Revises: 2018_12_03_remove_duplicate_fkey
+Create Date: 2018-12-05 18:29:33.749269
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2018_12_05_fix_user_constraint"
+down_revision = "2018_12_03_remove_duplicate_fkey"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint("uq_users_email", "users", ["email"])
+    op.drop_constraint("users_email_key", "users", type_="unique")
+
+
+def downgrade():
+    op.create_unique_constraint("users_email_key", "users", ["email"])
+    op.drop_constraint("uq_users_email", "users", type_="unique")

--- a/migrations/versions/2018_12_05_not_nullable_fields.py
+++ b/migrations/versions/2018_12_05_not_nullable_fields.py
@@ -1,0 +1,40 @@
+"""Make more fields in classification tables not nullable
+
+Revision ID: 2018_12_05_not_nullable_fields
+Revises: 2018_12_05_fix_page_constraint
+Create Date: 2018-12-05 18:47:41.680614
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2018_12_05_not_nullable_fields"
+down_revision = "2018_12_05_fix_page_constraint"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("dimension_categorisation", "includes_all", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_categorisation", "includes_parents", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_categorisation", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "includes_all", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "includes_parents", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "includes_all", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "includes_parents", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("dimension_table", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_table", "includes_parents", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_table", "includes_all", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_chart", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_chart", "includes_parents", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_chart", "includes_all", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_categorisation", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_categorisation", "includes_parents", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_categorisation", "includes_all", existing_type=sa.BOOLEAN(), nullable=True)

--- a/migrations/versions/e553b195fe90_.py
+++ b/migrations/versions/e553b195fe90_.py
@@ -81,7 +81,7 @@ def upgrade():
     sa.Column('password', sa.String(length=255), nullable=True),
     sa.Column('active', sa.Boolean(), nullable=True),
     sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('email')
+    sa.UniqueConstraint('email', name="users_email_key")
     )
     op.create_table('db_dimension',
     sa.Column('guid', sa.String(length=255), nullable=False),


### PR DESCRIPTION
 ## Summary
Whenever I generate a migration at the moment I'm getting a lot of
changes beyond the scope of what I have actually intended to apply. It
looks like we've somehow missed a few things in previous migrations.
This patch is a quick assessment of the migration that alembic wants to
apply, and a few tweaks to the models as I think are in line with what
we want, to make it so that new migrations will only contain the changes
actually added by a developer.

This also adds a default naming convention for sqlalchemy, which will allow it to deterministically generate names for (e.g.) indices if we forget to specify one. This means alembic can cleanly generate upgrades/downgrades where we've forgotten to include a name.