### PR TITLE
Lock build process to one at a time

### DIFF
--- a/application/sitebuilder/models.py
+++ b/application/sitebuilder/models.py
@@ -1,8 +1,17 @@
 from datetime import datetime
+import enum
 
 from sqlalchemy import PrimaryKeyConstraint
 from sqlalchemy.dialects.postgresql import ENUM, UUID
 from application import db
+
+
+class BuildStatus(enum.Enum):
+    PENDING = "PENDING"
+    STARTED = "STARTED"
+    DONE = "DONE"
+    SUPERSEDED = "SUPERSEDED"
+    FAILED = "FAILED"
 
 
 class Build(db.Model):
@@ -12,11 +21,7 @@ class Build(db.Model):
 
     id = db.Column(UUID, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
-    status = db.Column(
-        ENUM("PENDING", "STARTED", "DONE", "SUPERSEDED", "FAILED", name="build_status"),
-        default="PENDING",
-        nullable=False,
-    )
+    status = db.Column(db.Enum(BuildStatus, name="build_status"), default=BuildStatus.PENDING, nullable=False)
     succeeded_at = db.Column(db.DateTime, nullable=True)
     failure_reason = db.Column(db.String, nullable=True)
     failed_at = db.Column(db.DateTime, nullable=True)

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,7 @@ from application.config import Config, DevConfig
 from application.data.ethnicity_classification_synchroniser import EthnicityClassificationSynchroniser
 from application.factory import create_app
 from application.redirects.models import *
-from application.sitebuilder.models import *
+from application.sitebuilder.models import Build, BuildStatus
 from application.sitebuilder.build import build_and_upload_error_pages
 from application.utils import create_and_send_activation_email, send_email, TimedExecution
 
@@ -268,7 +268,9 @@ def report_stalled_build():
     stalled = (
         db.session.query(Build)
         .filter(
-            Build.status == "STARTED", func.DATE(Build.created_at) == date.today(), Build.created_at <= half_an_hour_ago
+            Build.status == BuildStatus.STARTED,
+            func.DATE(Build.created_at) == date.today(),
+            Build.created_at <= half_an_hour_ago,
         )
         .order_by(desc(Build.created_at))
         .first()
@@ -323,7 +325,7 @@ def drop_and_create_materialized_views():
 def acknowledge_build_issue(build_id):
     try:
         build = db.session.query(Build).filter(Build.id == build_id).one()
-        build.status = "SUPERSEDED"
+        build.status = BuildStatus.SUPERSEDED
         db.session.add(build)
         db.session.commit()
         print("Build id", build_id, "set to superseded")


### PR DESCRIPTION
 ## Summary
At the moment, we can have multiple processes building the static site
at the same time (in theory). Given that these write to the same S3
bucket, there are some race conditions that could result in an undefined
state at the end. This patch allows only one process to be building the
site at a time, which reduces this risk.

We might want to remove this if/when we start uploading builds to
separate S3 buckets and switching over for more atomic releases. But for
now, it should do the job.

 ## Ticket
https://trello.com/c/ZiEltV8m/1206