### PR TITLE
Bugfix: rename class to not conflict

### DIFF
--- a/application/src/sass/_updated_badge.scss
+++ b/application/src/sass/_updated_badge.scss
@@ -1,5 +1,5 @@
 /* This is used as a status indicator for things that have been updated. */
-.updated {
+.updated-badge {
   background-color: $secondary-text-colour;
   color: $white;
   padding: 2px 6px;

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -201,7 +201,7 @@
                                 <td>{{ dimension.title }}</td>
                                 <td>
                                     {% if dimension.page.version != '1.0' and dimension.updated_at != dimension.page.updated_at %}
-                                        <span class="updated">Updated</span>
+                                        <span class="updated-badge">Updated</span>
                                     {% endif %}
                                 </td>
                                 <td>


### PR DESCRIPTION
This fixes a minor styling bug (which I introduced), which is currently styling the updated date on the bottom of the pages to have a grey background:

<img width="675" alt="screenshot 2018-12-05 at 16 50 13" src="https://user-images.githubusercontent.com/30665/49529445-ef24d800-f8ad-11e8-80a0-3702a5bca601.png">

...because of a CSS naming conflict. 🤦‍♂️ 