### PR TITLE
Catch a NoResultFound from query on Page

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -215,7 +215,7 @@ class PageService(Service):
             ).one()
             dimension_object = measure_page.get_dimension(dimension_guid) if dimension_guid else None
             upload_object = measure_page.get_upload(upload_guid) if upload_guid else None
-        except PageNotFoundException:
+        except (NoResultFound, PageNotFoundException):
             self.logger.exception("Page id: {} not found".format(measure_uri))
             raise InvalidPageHierarchy
         except UploadNotFoundException:


### PR DESCRIPTION
Previously this method used `get_page_by_uri_and_type` for all page
types, and that raises a PageNotFoundException. Now we are querying the
model directly here for measure pages there's the possibility of a
NoResultFound from the call to `.one()` - we have seen this recently in
the case where the uri for a new measure changes (because the title of
the page is updated), but the user has tried to access the old URL
(possibly via the back button on the browser).

This *does* raise the question of whether having infinitely changeable
uris for new measure pages is 100% a good thing.  On balance it's
probably better than being stuck with the first thing that gets typed
into the Title field though.