### PR TITLE
Only use `session.add` for new objects

### DIFF
--- a/application/admin/views.py
+++ b/application/admin/views.py
@@ -61,7 +61,6 @@ def share_page_with_user(user_id):
         flash("User %s already has access to %s " % (user.email, page.title), "error")
     else:
         page.shared_with.append(user)
-        db.session.add(page)
         db.session.commit()
     return redirect(url_for("admin.user_by_id", user_id=user_id, _anchor="departmental-sharing"))
 
@@ -129,7 +128,6 @@ def deactivate_user(user_id):
     try:
         user = User.query.get(user_id)
         user.active = False
-        db.session.add(user)
         db.session.commit()
         flash("User account for: %s deactivated" % user.email)
         return redirect(url_for("admin.users"))
@@ -169,7 +167,6 @@ def make_admin_user(user_id):
         if user.is_rdu_user():
             user.user_type = TypeOfUser.ADMIN_USER
             user.capabilities = CAPABILITIES[TypeOfUser.ADMIN_USER]
-            db.session.add(user)
             db.session.commit()
             flash("User %s is now an admin user" % user.email)
         else:
@@ -190,7 +187,6 @@ def make_rdu_user(user_id):
     elif user.user_type == TypeOfUser.ADMIN_USER:
         user.user_type = TypeOfUser.RDU_USER
         user.capabilities = CAPABILITIES[TypeOfUser.RDU_USER]
-        db.session.add(user)
         db.session.commit()
         flash("User %s is now a standard RDU user" % user.email)
     else:

--- a/application/auth/views.py
+++ b/application/auth/views.py
@@ -77,7 +77,6 @@ def reset_password(token):
 
         user.password = hash_password(password)
 
-        db.session.add(user)
         db.session.commit()
 
         # TODO send email notification of password reset?

--- a/application/cms/classification_service.py
+++ b/application/cms/classification_service.py
@@ -88,7 +88,6 @@ class ClassificationService:
         classification.subfamily = subfamily_update
         classification.title = title_update
         classification.position = position_update
-        db.session.add(classification)
         db.session.commit()
 
     """
@@ -129,7 +128,6 @@ class ClassificationService:
         classification_value = self.get_value(value=value_string)
         if classification_value:
             classification_value.position = value_position
-            db.session.add(classification_value)
             db.session.commit()
             return classification_value
         return None
@@ -150,7 +148,6 @@ class ClassificationService:
         value = self.get_or_create_value(value_string=value_title)
         classification.ethnicities.append(value)
 
-        db.session.add(classification)
         db.session.commit()
         return classification
 
@@ -158,7 +155,6 @@ class ClassificationService:
         value = self.get_or_create_value(value_string=value_string)
         classification.parent_values.append(value)
 
-        db.session.add(classification)
         db.session.commit()
         return classification
 
@@ -166,7 +162,6 @@ class ClassificationService:
         for value_string in value_strings:
             value = self.get_or_create_value(value_string=value_string)
             classification.ethnicities.append(value)
-        db.session.add(classification)
         db.session.commit()
         return classification
 
@@ -174,7 +169,6 @@ class ClassificationService:
         for value_string in value_strings:
             value = self.get_or_create_value(value_string=value_string)
             classification.parent_values.append(value)
-        db.session.add(classification)
         db.session.commit()
         return classification
 
@@ -182,14 +176,12 @@ class ClassificationService:
         value = self.get_value(value=value_string)
 
         classification.ethnicities.remove(value)
-        db.session.add(classification)
         db.session.commit()
 
     def remove_parent_value_from_classification(self, classification, value_string):
         value = self.get_value(value=value_string)
 
         classification.parent_values.remove(value)
-        db.session.add(classification)
         db.session.commit()
 
     @staticmethod

--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -37,7 +37,6 @@ class DimensionService(Service):
             )
 
             page.dimensions.append(db_dimension)
-            db.session.add(page)
             db.session.commit()
 
             return page.get_dimension(db_dimension.guid)
@@ -88,7 +87,6 @@ class DimensionService(Service):
             try:
                 dimension = Dimension.query.filter_by(guid=item["guid"]).one()
                 dimension.position = item["index"]
-                db.session.add(dimension)
             except NoResultFound as e:
                 self.logger.exception(e)
                 raise DimensionNotFoundException()
@@ -181,7 +179,6 @@ class DimensionService(Service):
         if update_classification:
             dimension.update_dimension_classification_from_chart_or_table()
 
-        db.session.add(dimension)
         db.session.commit()
 
     def __set_table_dimension_classification_through_builder(self, dimension, data):
@@ -215,11 +212,10 @@ class DimensionService(Service):
         table.includes_unknown = classification.includes_unknown
 
         db.session.add(table)
-        db.session.flush()
+        db.session.flush()  # Flush to DB will generate PK if it's a newly-created instance
 
         dimension.table_id = table.id
 
-        db.session.add(dimension)
         db.session.commit()
 
     @staticmethod
@@ -275,11 +271,10 @@ class DimensionService(Service):
         chart.includes_unknown = classification.includes_unknown
 
         db.session.add(chart)
-        db.session.flush()
+        db.session.flush()  # Flush to DB will generate PK if it's a newly-created instance
 
         dimension.chart_id = chart.id
 
-        db.session.add(dimension)
         db.session.commit()
 
     @staticmethod

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -680,35 +680,23 @@ class Dimension(db.Model):
     # delete() ChartAndTableMixin so we can just do dimension.chart.delete() and dimension.table.delete()
     # without the need for the repeated code in the two methods below.
     def delete_chart(self):
+        db.session.delete(Chart.query.get(self.chart_id))
         self.chart = sqlalchemy.null()
         self.chart_source_data = sqlalchemy.null()
         self.chart_2_source_data = sqlalchemy.null()
-
-        chart_id = self.chart_id
         self.chart_id = None
 
-        db.session.add(self)
-        db.session.commit()
-
-        chart = Chart.query.get(chart_id)
-        db.session.delete(chart)
         db.session.commit()
 
         self.update_dimension_classification_from_chart_or_table()
 
     def delete_table(self):
+        db.session.delete(Table.query.get(self.table_id))
         self.table = sqlalchemy.null()
         self.table_source_data = sqlalchemy.null()
         self.table_2_source_data = sqlalchemy.null()
-
-        table_id = self.table_id
         self.table_id = None
 
-        db.session.add(self)
-        db.session.commit()
-
-        table = Table.query.get(table_id)
-        db.session.delete(table)
         db.session.commit()
 
         self.update_dimension_classification_from_chart_or_table()

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -64,7 +64,6 @@ class PageService(Service):
         previous_version = page.get_previous_version()
         if previous_version is not None:
             previous_version.latest = False
-            db.session.add(previous_version)
             db.session.commit()
 
         return page
@@ -116,7 +115,6 @@ class PageService(Service):
             page.updated_at = datetime.utcnow()
             page.last_updated_by = last_updated_by
 
-            db.session.add(page)
             db.session.commit()
 
             return page
@@ -240,7 +238,6 @@ class PageService(Service):
     def reject_page(self, page_guid, version):
         page = self.get_page_with_version(page_guid, version)
         message = page.reject()
-        db.session.add(page)
         db.session.commit()
         self.logger.info(message)
         return message
@@ -249,7 +246,6 @@ class PageService(Service):
         page = self.get_page_with_version(page_guid, version)
         message = page.unpublish()
         page.unpublished_by = unpublished_by
-        db.session.add(page)
         db.session.commit()
         self.logger.info(message)
         return (page, message)
@@ -286,11 +282,9 @@ class PageService(Service):
         page.latest = True
         message = 'page "{}" published on "{}"'.format(page.guid, page.publication_date.strftime("%Y-%m-%d"))
         self.logger.info(message)
-        db.session.add(page)
         previous_version = page.get_previous_version()
         if previous_version and previous_version.latest:
             previous_version.latest = False
-            db.session.add(previous_version)
         db.session.commit()
 
     def page_cannot_be_created(self, parent, uri):
@@ -367,7 +361,6 @@ class PageService(Service):
         previous_page = page.get_previous_version()
         if previous_page is not None:
             previous_page.latest = False
-            db.session.add(previous_page)
             db.session.commit()
 
         upload_service.copy_uploads(page, page_version, original_guid)
@@ -386,7 +379,6 @@ class PageService(Service):
         previous_version = page.get_previous_version()
         if previous_version:
             previous_version.latest = True
-            db.session.add(previous_version)
         db.session.delete(page)
         db.session.commit()
 
@@ -421,7 +413,6 @@ class PageService(Service):
             page.review_token = generate_review_token(page.guid, page.version)
         if page.status == "APPROVED":
             page.published_by = updated_by
-        db.session.add(page)
         db.session.commit()
         return message
 
@@ -470,7 +461,6 @@ class PageService(Service):
             page.published = False
             page.publication_date = None
             page.status = "UNPUBLISHED"
-            db.session.add(page)
             db.session.commit()
 
     @staticmethod

--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -154,7 +154,6 @@ class UploadService(Service):
             )
 
             page.uploads.append(db_upload)
-            db.session.add(page)
             db.session.commit()
 
         return db_upload
@@ -209,7 +208,6 @@ class UploadService(Service):
         upload.description = data["description"] if "description" in data else upload.title
         upload.title = new_title
 
-        db.session.add(upload)
         db.session.commit()
 
     @staticmethod

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1249,7 +1249,6 @@ def set_measure_order():
             pages = Page.query.filter_by(guid=p["guid"], parent_guid=p["subtopic"]).all()
             for page in pages:
                 page.position = p["position"]
-                db.session.add(page)
         db.session.commit()
         request_build()
         return json.dumps({"status": "OK", "status_code": 200}), 200

--- a/application/register/views.py
+++ b/application/register/views.py
@@ -44,7 +44,6 @@ def confirm_account(token):
         user.password = hash_password(password)
         user.confirmed_at = datetime.datetime.utcnow()
 
-        db.session.add(user)
         db.session.commit()
 
         return redirect(url_for("register.completed", user_email=user.email))

--- a/application/review/views.py
+++ b/application/review/views.py
@@ -45,7 +45,6 @@ def get_new_review_url(id, version):
         token = generate_review_token(id, version)
         page = Page.query.filter_by(guid=id, version=version).one()
         page.review_token = token
-        db.session.add(page)
         db.session.commit()
         url = url_for("review.review_page", review_token=page.review_token, _external=True)
         expires = page.review_token_expires_in(current_app.config)


### PR DESCRIPTION
 ## Summary
We don't need to use `db.session.add` for objects that already exist -
it's only used when creating new records. Objects returned from queries
are already in the session and changes to them are committed
automatically.