### PR TITLE
BUGFIX: Can't send new version 1.0 for review

### DIFF
--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -173,21 +173,19 @@
 
                 {{ form.lowest_level_of_geography_id(disabled=form_disabled) }}
             </div>
-            {% if not new %}
-                <div class="column-one-third edit-summary">
-                    <div>
-                        <ul class="button-group{% if measure.version == '1.0' %} hidden{% endif %}">
-                            <li>
-                                {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
-                            </li>
-                            <li>
-                                {{ form.internal_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
-                            </li>
+            <div class="column-one-third edit-summary">
+                <div>
+                    <ul class="button-group{% if new or measure.version == '1.0' %} hidden{% endif %}">
+                        <li>
+                            {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
+                        </li>
+                        <li>
+                            {{ form.internal_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
+                        </li>
 
-                        </ul>
-                    </div>
+                    </ul>
                 </div>
-            {% endif %}
+            </div>
         </div>
 
      <div class="grid-row">

--- a/scripts/data_migrations/2018-12-17_update_empty_external_notes_unpublished_version_1.sql
+++ b/scripts/data_migrations/2018-12-17_update_empty_external_notes_unpublished_version_1.sql
@@ -1,0 +1,5 @@
+UPDATE page
+SET external_edit_summary = 'First published'
+WHERE version = '1.0'
+AND published IS FALSE
+AND (TRIM(external_edit_summary) = '' OR external_edit_summary IS NULL);


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/490SpESU/1251-bug-cant-publish-10-version

The external_edit_summary is required, and is set when new measures are
created (as "First published").  However, because the field is not
rendered at all in the template (not even as hidden) this default value
is overwritten with None when the page is first saved.  And then the
page can't be sent for review because external_edit_summary is empty,
and it can't be set by the user because the box doesn't exist in the
page for 1.0 measures.

This fixes things by always including the form fields for edit notes in
the page, but hidden for 1.0 measures.

The associated data migration here will backfill the required field for
any measures currently created that have had their external_edit_summary
overwritten already.