### PR TITLE
Remove breadcrumb event support

### DIFF
--- a/application/templates/_shared/_breadcrumb.html
+++ b/application/templates/_shared/_breadcrumb.html
@@ -7,7 +7,7 @@
             {% if breadcrumbs %}
               {% for breadcrumb in breadcrumbs %}
               <li>
-                  <a href="{{ breadcrumb.url }}"{% if breadcrumb.event %} data-event="{{ breadcrumb.event }}"{% endif %}>{{ breadcrumb.text }}</a>
+                  <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
               </li>
               {% endfor %}
             {% else %}


### PR DESCRIPTION
 ## Summary
We no longer have any breadcrumb events, so let's remove the template
fragment which supports that functionality.