### PR TITLE
Deleting things should require a POST request

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,7 +1,9 @@
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
 from sqlalchemy import MetaData
 
+csrf = CSRFProtect()
 db = SQLAlchemy(
     # Our ideal naming convention
     metadata=MetaData(

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -694,10 +694,11 @@ class Dimension(db.Model):
 
     # TODO: Refactor Dimension so that all chart and table data lives in dimension_chart and dimension_table
     # Once the chart and table data is moved out into dimension_chart and dimension_table models we can add
-    # delete() ChartAndTableMixin so we can just do dimension.chart.delete() and dimension.table.delete()
+    # delete() to the ChartAndTableMixin so we can just do dimension.chart.delete() and dimension.table.delete()
     # without the need for the repeated code in the two methods below.
     def delete_chart(self):
-        db.session.delete(Chart.query.get(self.chart_id))
+        if self.chart_id:
+            db.session.delete(Chart.query.get(self.chart_id))
         self.chart = sqlalchemy.null()
         self.chart_source_data = sqlalchemy.null()
         self.chart_2_source_data = sqlalchemy.null()
@@ -708,7 +709,8 @@ class Dimension(db.Model):
         self.update_dimension_classification_from_chart_or_table()
 
     def delete_table(self):
-        db.session.delete(Table.query.get(self.table_id))
+        if self.table_id:
+            db.session.delete(Table.query.get(self.table_id))
         self.table = sqlalchemy.null()
         self.table_source_data = sqlalchemy.null()
         self.table_2_source_data = sqlalchemy.null()

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -198,7 +198,7 @@ def edit_upload(topic_uri, subtopic_uri, measure_uri, version, upload_guid):
     return render_template("cms/edit_upload.html", **context)
 
 
-@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete", methods=["POST"])
 @login_required
 @user_has_access
 def delete_dimension(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -970,7 +970,9 @@ def save_chart_to_page(topic_uri, subtopic_uri, measure_uri, version, dimension_
     return jsonify({"success": True})
 
 
-@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-chart")
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-chart", methods=["POST"]
+)
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
@@ -1024,7 +1026,9 @@ def save_table_to_page(topic_uri, subtopic_uri, measure_uri, version, dimension_
     return jsonify({"success": True})
 
 
-@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-table")
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-table", methods=["POST"]
+)
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -128,7 +128,7 @@ def create_measure_page(topic_uri, subtopic_uri):
 
 
 @cms_blueprint.route(
-    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/uploads/<upload_guid>/delete", methods=["GET"]
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/uploads/<upload_guid>/delete", methods=["POST"]
 )
 @login_required
 @user_has_access

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -139,7 +139,7 @@ def delete_upload(topic_uri, subtopic_uri, measure_uri, version, upload_guid):
 
     upload_service.delete_upload_obj(measure_page, upload_object)
 
-    message = "Deleted upload {}".format(upload_object.title)
+    message = "Deleted upload ‘{}’".format(upload_object.title)
     current_app.logger.info(message)
     flash(message, "info")
 
@@ -208,7 +208,7 @@ def delete_dimension(topic_uri, subtopic_uri, measure_uri, version, dimension_gu
 
     dimension_service.delete_dimension(measure_page, dimension_object.guid)
 
-    message = "Deleted dimension {}".format(dimension_object.title)
+    message = "Deleted dimension ‘{}’".format(dimension_object.title)
     current_app.logger.info(message)
     flash(message, "info")
 
@@ -983,7 +983,7 @@ def delete_chart(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
 
     dimension_object.delete_chart()
 
-    message = 'Deleted chart from dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
+    message = "Deleted chart from dimension ‘{}’ of measure ‘{}’".format(dimension_object.title, measure_page.title)
     current_app.logger.info(message)
     flash(message, "info")
 
@@ -1039,7 +1039,7 @@ def delete_table(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
 
     dimension_object.delete_table()
 
-    message = 'Deleted table from dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
+    message = "Deleted table from dimension ‘{}’ of measure ‘{}’".format(dimension_object.title, measure_page.title)
     current_app.logger.info(message)
     flash(message, "info")
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -7,10 +7,9 @@ from jinja2.ext import do as jinja_do
 
 from flask import Flask, render_template, request, send_from_directory
 from flask_security import SQLAlchemyUserDatastore, Security, current_user
-from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
 
-from application import db, mail
+from application import csrf, db, mail
 from application.auth.models import User
 from application.data.standardisers.ethnicity_classification_finder_builder import (
     ethnicity_classification_finder_from_file,
@@ -48,8 +47,6 @@ from application.static_site.filters import (
     slugify_value,
     first_bullet,
 )
-
-csrf = CSRFProtect()
 
 
 def create_app(config_object):

--- a/application/factory.py
+++ b/application/factory.py
@@ -7,6 +7,7 @@ from jinja2.ext import do as jinja_do
 
 from flask import Flask, render_template, request, send_from_directory
 from flask_security import SQLAlchemyUserDatastore, Security, current_user
+from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
 
 from application import db, mail
@@ -48,6 +49,8 @@ from application.static_site.filters import (
     first_bullet,
 )
 
+csrf = CSRFProtect()
+
 
 def create_app(config_object):
     from application.static_site import static_site_blueprint
@@ -76,6 +79,7 @@ def create_app(config_object):
     app.file_service = FileService()
     app.file_service.init_app(app)
 
+    csrf.init_app(app)
     page_service.init_app(app)
     upload_service.init_app(app)
     scanner_service.init_app(app)

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -22,6 +22,7 @@
                 </h1>
                 <h2>Add user</h2>
                 <form action="{{ url_for('admin.add_user') }}" method="POST">
+                    {{ form.csrf_token }}
                     {{ render_field(form.email) }}
                     <div class="form-group">
                         <fieldset class="inline">
@@ -46,7 +47,7 @@
 
                         </fieldset>
                     </div>
-                    {{ form.csrf_token }}
+
                     <button type="submit" class="button" name="add">Add user</button>
                 </form>
             </div>

--- a/application/templates/admin/user.html
+++ b/application/templates/admin/user.html
@@ -59,6 +59,7 @@
         <div class="column-half">
             <h2 class="heading-medium">Share measures</h2>
             <form id="share-page" action="{{ url_for('admin.share_page_with_user', user_id=user.id) }}" method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <label for="measures-picker">Measures</label>
                 <div id="measure-autocomplete-container"></div>
                 <div class="form-group">

--- a/application/templates/auth/forgot_password.html
+++ b/application/templates/auth/forgot_password.html
@@ -16,12 +16,12 @@
                 Password reset links are only valid for 24 hours.
             </p>
             <form action="{{ url_for('auth.forgot_password') }}" method="POST">
+                {{ form.csrf_token }}
                 {{ render_field(form.email,
                                 label_class='form-label-bold',
                                 hint='Enter the email address you login with') }}
 
                 <button type="submit" class="button" name="send-reset-email">Send reset email</button>
-                {{ form.csrf_token }}
             </form>
         </div>
     </div>

--- a/application/templates/auth/reset_password.html
+++ b/application/templates/auth/reset_password.html
@@ -12,10 +12,10 @@
             <h1 class='heading-large'>Set a new password</h1>
 
             <form action="{{ url_for('auth.reset_password', token=token) }}" method="POST">
+                {{ form.csrf_token }}
                 {{ render_field(form.password) }}
                 {{ render_field(form.confirm_password) }}
                 <button type="submit" class="button" name="update-password">Update password</button>
-                {{ form.csrf_token }}
             </form>
         </div>
     </div>

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -27,6 +27,7 @@
             </p>
             <form method="POST"
                   action="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
+                {{ form.csrf_token }}
                 <div class="version-type">New version type:</div>
                 {% for version in form.version_type %}
                     <div class="input-radio">
@@ -34,7 +35,6 @@
                     </div>
                 {% endfor %}
                 <button class="button">Create new version in draft</button>
-                {{ form.csrf_token }}
             </form>
         </div>
 

--- a/application/templates/cms/delete_page.html
+++ b/application/templates/cms/delete_page.html
@@ -21,11 +21,10 @@
       </h1>
 
       <form method="POST" action="{{ url_for('cms.delete_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure_page.uri, version=measure_page.version) }}">
-
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <div class="form-group">
           <button class="button delete">Yes, delete</button>
         </div>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       </form>
 
       <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure_page.uri, version=measure_page.version) }}">No, return</a>

--- a/application/templates/cms/delete_page.html
+++ b/application/templates/cms/delete_page.html
@@ -25,7 +25,7 @@
         <div class="form-group">
           <button class="button delete">Yes, delete</button>
         </div>
-
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       </form>
 
       <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure_page.uri, version=measure_page.version) }}">No, return</a>

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -34,6 +34,7 @@
                         Update
                     </button>
                     {% endif %}
+                </form>
 
                     <div id="charts">
                         <h2 class="heading-medium">Charts & Tables</h2>

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -50,7 +50,7 @@
                                     <td>
                                     {% if 'UPDATE' in  measure.available_actions() %}
                                         <form action="{{ url_for('cms.delete_chart', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}" method="post">
-                                            {{ form.csrf_token() }}
+                                            {{ form.csrf_token }}
                                             <button id="delete_chart" class="link">delete</button>
                                         </form>
                                     {% endif %}
@@ -68,7 +68,7 @@
                                     <td>
                                         {% if 'UPDATE' in  measure.available_actions() %}
                                         <form action="{{ url_for('cms.delete_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}" method="post">
-                                            {{ form.csrf_token() }}
+                                            {{ form.csrf_token }}
                                             <button id="delete_table" class="link">delete</button>
                                         </form>
                                         {% endif %}

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -47,8 +47,13 @@
                                            href="{{ url_for('cms.chartbuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
-                                    <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_chart"
-                                                                                            href="{{ url_for('cms.delete_chart', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">delete</a>{% endif %}
+                                    <td>
+                                    {% if 'UPDATE' in  measure.available_actions() %}
+                                        <form action="{{ url_for('cms.delete_chart', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}" method="post">
+                                            {{ form.csrf_token() }}
+                                            <button id="delete_chart" class="link">delete</button>
+                                        </form>
+                                    {% endif %}
                                     </td>
                                 </tr>
                             {% endif %}
@@ -60,8 +65,13 @@
                                            href="{{ url_for('cms.tablebuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
-                                    <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_table"
-                                                                                            href="{{ url_for('cms.delete_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">delete</a>{% endif %}
+                                    <td>
+                                        {% if 'UPDATE' in  measure.available_actions() %}
+                                        <form action="{{ url_for('cms.delete_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}" method="post">
+                                            {{ form.csrf_token() }}
+                                            <button id="delete_table" class="link">delete</button>
+                                        </form>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endif %}

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -16,7 +16,7 @@
 
 {% block content %}
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri) }}{% else %}{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}{% endif %}">
-
+        {{ form.csrf_token }}
         {% call status_banner() %}
             <div class="version-info left">
                 <span class="info">Version&nbsp;<b>{{ measure.version }}</b></span>
@@ -162,6 +162,7 @@
                     </div>
             </div>
         </div>
+
         <div class="grid-row">
             <div class="column-two-thirds">
 
@@ -172,8 +173,6 @@
                 {{ form.lowest_level_of_geography_id(disabled=form_disabled) }}
             </div>
         </div>
-
-
 
         <div class="grid-row">
           <div class="column-two-thirds">
@@ -191,6 +190,7 @@
             </div>
           </div>
         </div>
+
         <div class="grid-row">
             <div class="column-two-thirds">
                     <h3 class="heading-medium">Commentary</h3>
@@ -226,10 +226,10 @@
 
                     {{ form.internal_reference(disabled=form_disabled, diffs=diffs, class_='short') }}
 
+            </div>
         </div>
-    </div>
-     {{ form.csrf_token }}
     </form>
+
      <div class="grid-row">
         <div class="column-full">
             <h3 class="heading-medium">Dimensions</h3>
@@ -317,8 +317,8 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <form id="measure-action-section__copy_measure_form-{{ measure.guid }}" method="POST" action="{{ url_for('cms.copy_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
-                <button class="button copy-button" type="submit">Create a copy of this measure</button>
                 {{ form.csrf_token }}
+                <button class="button copy-button" type="submit">Create a copy of this measure</button>
             </form>
         </div>
     </div>

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -248,7 +248,7 @@
                                         {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td>{% if 'UPDATE' in available_actions %}
                                     <form action="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}" method="post">
-                                        {{ form.csrf_token() }}
+                                        {{ form.csrf_token }}
                                         <button class="link">delete</button>
                                     </form>
                                     {% endif %}
@@ -294,7 +294,7 @@
                                     <td>
                                         {% if 'UPDATE' in available_actions %}
                                             <form action="{{ url_for('cms.delete_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload_guid=upload.guid ) }}" method="post">
-                                                {{ form.csrf_token() }}
+                                                {{ form.csrf_token }}
                                                 <button class="link">delete</button>
                                             </form>
                                         {% endif %}

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -248,6 +248,7 @@
                                         {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td>{% if 'UPDATE' in available_actions %}
                                     <form action="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}" method="post">
+                                        {{ form.csrf_token() }}
                                         <button class="link">delete</button>
                                     </form>
                                     {% endif %}
@@ -293,6 +294,7 @@
                                     <td>
                                         {% if 'UPDATE' in available_actions %}
                                             <form action="{{ url_for('cms.delete_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload_guid=upload.guid ) }}" method="post">
+                                                {{ form.csrf_token() }}
                                                 <button class="link">delete</button>
                                             </form>
                                         {% endif %}

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -228,6 +228,8 @@
 
         </div>
     </div>
+     {{ form.csrf_token }}
+    </form>
      <div class="grid-row">
         <div class="column-full">
             <h3 class="heading-medium">Dimensions</h3>
@@ -245,7 +247,10 @@
                                     <a href="{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">
                                         {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td>{% if 'UPDATE' in available_actions %}
-                                    <a href="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">delete</a>{% endif %}
+                                    <form action="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}" method="post">
+                                        <button class="link">delete</button>
+                                    </form>
+                                    {% endif %}
                                 </td>
                                 <td class="move-controls">
                                     {% if 'UPDATE' in available_actions %}
@@ -268,8 +273,7 @@
                 {% endif %}
         </div>
     </div>
-     {{ form.csrf_token }}
-    </form>
+
         <div class="grid-row">
             <div class="column-two-thirds">
 

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -268,6 +268,8 @@
                 {% endif %}
         </div>
     </div>
+     {{ form.csrf_token }}
+    </form>
         <div class="grid-row">
             <div class="column-two-thirds">
 
@@ -286,7 +288,9 @@
                                     </td>
                                     <td>
                                         {% if 'UPDATE' in available_actions %}
-                                            <a href="{{ url_for('cms.delete_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload_guid=upload.guid ) }}">delete</a>
+                                            <form action="{{ url_for('cms.delete_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload_guid=upload.guid ) }}" method="post">
+                                                <button class="link">delete</button>
+                                            </form>
                                         {% endif %}
                                     </td>
                                 </tr>
@@ -302,8 +306,6 @@
 
             </div>
         </div>
-     {{ form.csrf_token }}
-    </form>
 
     {% if current_user.can(COPY_MEASURE) %}
     <div class="grid-row">

--- a/application/templates/register/set_account_password.html
+++ b/application/templates/register/set_account_password.html
@@ -16,9 +16,9 @@
                 <h2>Set password</h2>
                 <p>Your user name: {{ user.email }}</p>
                 <form class="form"  action="{{url_for('register.confirm_account', token=token)}}" method="POST">
+                    {{ form.csrf_token }}
                     {{ render_field(form.password) }}
                     {{ render_field(form.confirm_password) }}
-                    {{ form.csrf_token }}
                     <button type="submit" class="button" name="set">Set password</button>
                 </form>
             </div>

--- a/application/templates/security/login_user.html
+++ b/application/templates/security/login_user.html
@@ -29,7 +29,7 @@
                 <h1 class='heading-large'>Login</h1>
 
                 <form action="{{ url_for('security.login') }}" method="post">
-
+                    {{ login_user_form.csrf_token }}
 
                     <label for="email">Email</label>
                     {{ login_user_form.email }}
@@ -38,7 +38,6 @@
                     {{ login_user_form.password(autocomplete='off') }}
 
                     <button type="submit" class="button" name="login">Login</button>
-                    {{ login_user_form.csrf_token }}
 
                     {{ login_user_form.next }}
                 </form>

--- a/application/templates/static_site/_newsletter-sign-up.html
+++ b/application/templates/static_site/_newsletter-sign-up.html
@@ -7,7 +7,7 @@
         <p>We send out monthly updates on new and updated pages, and policy activity.</p>
 
         <form action="{{ config.NEWSLETTER_SUBSCRIBE_URL }}" method="post">
-
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <div class="form-group email">
             <label class="form-label" for="newsletter-email">Email address</label>
             <input id="newsletter-email" type="email" class="form-control" name="EMAIL" />

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -719,7 +719,7 @@ def test_dept_user_should_not_be_able_to_delete_upload_if_page_not_shared(
 
     assert resp.status_code == 403
 
-    resp = test_app_client.get(
+    resp = test_app_client.post(
         url_for(
             "cms.delete_upload",
             topic_uri=stub_measure_page.parent.parent.uri,
@@ -793,7 +793,7 @@ def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(
 
     assert resp.status_code == 403
 
-    resp = test_app_client.get(
+    resp = test_app_client.post(
         url_for(
             "cms.delete_dimension",
             topic_uri=stub_page_with_dimension.parent.parent.uri,

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -33,8 +33,6 @@ from bs4 import BeautifulSoup
         "/cms/topic-name/subtopic-name/measure/v2.0/dimension/create-chart",
         "/cms/topic-name/subtopic-name/measure/v2.0/dimension/create-chart/advanced",
         "/cms/topic-name/subtopic-name/measure/v2.0/dimension/create-table",
-        "/cms/topic-name/subtopic-name/measure/v2.0/dimension/delete-chart",
-        "/cms/topic-name/subtopic-name/measure/v2.0/dimension/delete-table",
         "/cms/topic-name/subtopic-name/measure/versions",
         "/cms/topic-name/subtopic-name/measure/v2.0/delete",
         "/cms/topic-name/subtopic-name/measure/v2.0/new-version",

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -20,7 +20,6 @@ from bs4 import BeautifulSoup
         "/admin/site-build",
         "/cms/topic-name/subtopic-name/measure/new",
         "/cms/topic-name/subtopic-name/measure/v2.0/uploads/upload/edit",
-        "/cms/topic-name/subtopic-name/measure/v2.0/dimension/delete",
         "/cms/topic-name/subtopic-name/measure/v2.0/edit",
         "/cms/topic-name/subtopic-name/measure/v2.0/upload",
         "/cms/topic-name/subtopic-name/measure/v2.0/send-to-review",


### PR DESCRIPTION
This converts two 'delete' actions, for dimensions and uploads, from GET requests to POSTs, which makes them a bit safer.