### PR TITLE
Write measures to new table

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -33,6 +33,7 @@ from application.cms.models import (
     Organisation,
     LowestLevelOfGeography,
     MeasureVersion,
+    Measure,
 )
 from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
@@ -1253,6 +1254,11 @@ def set_measure_order():
             pages = MeasureVersion.query.filter_by(guid=p["guid"], parent_guid=p["subtopic"]).all()
             for page in pages:
                 page.position = p["position"]
+
+            if pages:
+                measure = Measure.query.get(pages[0].measure_id)
+                measure.position = p["position"]
+
         db.session.commit()
         request_build()
         return json.dumps({"status": "OK", "status_code": 200}), 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,10 +185,20 @@ def stub_topic_page(db_session, stub_home_page):
         version="1.0",
     )
 
+    topic = Topic(
+        id=page.id,
+        slug=page.slug,
+        title=page.title,
+        description=page.description,
+        additional_description=page.additional_description,
+    )
+
     page.page_json = json.dumps({"guid": "topic_test", "title": "Test topic page"})
 
     db_session.session.add(page)
+    db_session.session.add(topic)
     db_session.session.commit()
+
     return page
 
 
@@ -206,11 +216,20 @@ def stub_subtopic_page(db_session, stub_topic_page):
         title="Test subtopic page",
         version="1.0",
     )
+    subtopic = Subtopic(
+        id=page.id,
+        slug=page.slug,
+        title=page.title,
+        position=page.position,
+        topic_id=Topic.query.get(stub_topic_page.id).id,
+    )
 
     page.page_json = json.dumps({"guid": "subtopic_example", "title": "Test subtopic page"})
 
     db_session.session.add(page)
+    db_session.session.add(subtopic)
     db_session.session.commit()
+
     return page
 
 
@@ -242,6 +261,7 @@ def stub_sandbox_topic_page(db_session):
         title="Test sandbox topic page",
         version="1.0",
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
 
     db_session.session.add(page)
     db_session.session.commit()
@@ -336,6 +356,9 @@ def stub_measure_page(
         lowest_level_of_geography=stub_geography,
         latest=True,
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
+    measure.subtopics = [Subtopic.query.get(stub_subtopic_page.id)]
+    page.measure_id = page.id  # Duplicating page ID for simplicity during migration to new data model
 
     for key, val in stub_measure_data.items():
         if key == "published_at":
@@ -345,7 +368,9 @@ def stub_measure_page(
     page.data_sources = [stub_data_source]
 
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
+
     return page
 
 
@@ -370,6 +395,9 @@ def stub_published_measure_page(
         lowest_level_of_geography=stub_geography,
         latest=True,
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
+    measure.subtopics = [Subtopic.query.get(stub_subtopic_page.id)]
+    page.measure_id = page.id  # Duplicating page ID for simplicity during migration to new data model
 
     for key, val in stub_measure_data.items():
         if key == "published_at":
@@ -379,7 +407,9 @@ def stub_published_measure_page(
     page.data_sources = [stub_data_source]
 
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
+
     return page
 
 
@@ -433,6 +463,10 @@ def stub_measure_page_one_of_three(
         lowest_level_of_geography=stub_geography,
         latest=False,
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
+    measure.subtopics = [Subtopic.query.get(stub_subtopic_page.id)]
+    page.measure_id = page.id  # Duplicating page ID for simplicity during migration to new data model
+
     for key, val in stub_measure_data.items():
         if key == "published_at":
             val = datetime.strptime(val, "%Y-%m-%d")
@@ -440,6 +474,7 @@ def stub_measure_page_one_of_three(
 
     page.data_sources = [stub_data_source]
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
     return page
 
@@ -465,6 +500,10 @@ def stub_measure_page_two_of_three(
         lowest_level_of_geography=stub_geography,
         latest=False,
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
+    measure.subtopics = [Subtopic.query.get(stub_subtopic_page.id)]
+    page.measure_id = page.id  # Duplicating page ID for simplicity during migration to new data model
+
     for key, val in stub_measure_data.items():
         if key == "published_at":
             val = datetime.strptime(val, "%Y-%m-%d")
@@ -472,7 +511,9 @@ def stub_measure_page_two_of_three(
 
     page.data_sources = [stub_data_source]
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
+
     return page
 
 
@@ -497,6 +538,10 @@ def stub_measure_page_three_of_three(
         lowest_level_of_geography=stub_geography,
         latest=True,
     )
+    measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
+    measure.subtopics = [Subtopic.query.get(stub_subtopic_page.id)]
+    page.measure_id = page.id  # Duplicating page ID for simplicity during migration to new data model
+
     for key, val in stub_measure_data.items():
         if key == "published_at":
             val = datetime.strptime(val, "%Y-%m-%d")
@@ -504,7 +549,9 @@ def stub_measure_page_three_of_three(
 
     page.data_sources = [stub_data_source]
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
+
     return page
 
 

--- a/tests/test_page_service.py
+++ b/tests/test_page_service.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime
 from application.cms.exceptions import PageExistsException, PageUnEditable, PageNotFoundException
-from application.cms.models import MeasureVersion, DimensionClassification
+from application.cms.models import MeasureVersion, DimensionClassification, Measure
 from application.cms.page_service import PageService
 
 page_service = PageService()
@@ -18,6 +18,21 @@ def test_create_page(db_session, stub_subtopic_page, test_app_editor):
 
     assert "Who cares" == created_page.title
     assert test_app_editor.email == test_app_editor.email
+
+
+def test_create_page_creates_measure_entry(db_session, stub_subtopic_page, test_app_editor):
+    created_page = page_service.create_page(
+        "measure",
+        stub_subtopic_page,
+        data={"title": "Who cares", "published_at": datetime.now().date()},
+        created_by=test_app_editor.email,
+        data_source_forms=[],
+    )
+
+    measure = Measure.query.get(created_page.measure_id)
+    assert measure.slug == created_page.slug
+    assert measure.position == created_page.position
+    assert measure.reference == created_page.internal_reference
 
 
 def test_create_page_with_title_and_slug_already_exists_under_subtopic_raises_exception(


### PR DESCRIPTION
 ## Summary
When we create new measures in the `MeasureVersion` table, we need to
also create a duplicate record in the new `Measure` table so that data
stays in sync until we switch over to the new data model.

The cases covered are:

* Creating a new measure
* Changing the (sub)topic of a measure.
* Re-ordering a measure within a subtopic.

 ## Ticket
https://trello.com/c/7KTt19fW/1237