### PR TITLE
Add CSRF tokens to JS ajax

### DIFF
--- a/application/src/js/cms/__setup_ajax_csrf.js
+++ b/application/src/js/cms/__setup_ajax_csrf.js
@@ -1,0 +1,5 @@
+$.ajaxSetup({
+    beforeSend: function (xhr) {
+        xhr.setRequestHeader("X-CSRFToken", user_csrf_token);
+    }
+});

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -121,6 +121,8 @@
         <script type="text/javascript" src="/static/javascripts/{{ 'all.js' | version_filter }}"></script>
 
         {% if not static_mode %}
+            <script>var user_csrf_token = "{{ csrf_token() }}"</script>
+
             <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'charts.js' | version_filter }}"></script>
 
             <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'cms.js' | version_filter }}"></script>


### PR DESCRIPTION
 ## Summary
We've enforced CSRF protection around all POST requests, but forgot to
add CSRF tokens to ajax calls, which meant that most of our JavaScript
functionality stopped working (including re-ordering measures within a
subtopic, and creating charts/tables).

This patch adds CSRF tokens back to all of the Ajax calls. This ajax
setup method will not catch add the header for any calls that happen
before the setup - but I don't think we have any.