### PR TITLE
Use POST instead of GET to log out

### DIFF
--- a/application/auth/views.py
+++ b/application/auth/views.py
@@ -1,5 +1,6 @@
 import passwordmeter
-from flask import render_template, flash, redirect, url_for, current_app, abort
+from flask import render_template, flash, redirect, url_for, current_app, abort, session
+from flask_login import logout_user
 from flask_mail import Message
 from flask_security.decorators import anonymous_user_required
 from flask_security.utils import hash_password
@@ -84,3 +85,11 @@ def reset_password(token):
         return render_template("auth/password_updated.html", form=form, token=token, user=user)
 
     return render_template("auth/reset_password.html", form=form, token=token, user=user)
+
+
+@auth_blueprint.route("/logout", methods=["POST"])
+def logout():
+    session.clear()
+    from flask_security.views import logout as security_logout_view
+
+    return security_logout_view()

--- a/application/src/sass/cms/_banner.scss
+++ b/application/src/sass/cms/_banner.scss
@@ -14,8 +14,8 @@ This serves the dual purposes of reminding publishers that they're looking at a 
   padding: 5px 10px;
 }
 
-.cms-banner a {
-  color: inherit;
+.cms-banner a, button.link {
+  color: inherit !important;
 }
 
 .cms-banner .application-name {

--- a/application/src/sass/cms/_banner.scss
+++ b/application/src/sass/cms/_banner.scss
@@ -14,8 +14,8 @@ This serves the dual purposes of reminding publishers that they're looking at a 
   padding: 5px 10px;
 }
 
-.cms-banner a, button.link {
-  color: inherit !important;
+.cms-banner a, .cms-banner button.link {
+  color: inherit;
 }
 
 .cms-banner .application-name {

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -20,7 +20,10 @@
         </div>
         <div class="right">
           {% if current_user.is_authenticated %}
-            <a href="{{ url_for('security.logout') }}">Sign out</a>
+          <form action="{{ url_for('auth.logout') }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <button class="link" name="logout">Sign out</button>
+          </form>
           {% endif %}
         </div>
       </div>

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -9,7 +9,7 @@ class LoginPageLocators:
 
 
 class NavigationLocators:
-    LOG_OUT_LINK = (By.NAME, "logout")
+    LOG_OUT_LINK = (By.XPATH, "//button[text()='Sign out']")
 
 
 class HeaderLocators:

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -9,7 +9,7 @@ class LoginPageLocators:
 
 
 class NavigationLocators:
-    LOG_OUT_LINK = (By.LINK_TEXT, "Sign out")
+    LOG_OUT_LINK = (By.NAME, "logout")
 
 
 class HeaderLocators:

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -78,3 +78,20 @@ def test_unsuccessful_login_returns_to_login_page(test_app_client):
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert page.h1.string.strip() == "Login"
+
+
+def test_should_redirect_to_homepage_on_logout(test_app_client, mock_logged_in_rdu_user):
+    res = test_app_client.post("/auth/logout")
+    assert res.status_code == 302
+    assert res.location == url_for("static_site.index", _external=True)
+
+
+def test_should_expire_session_vars_on_logout(test_app_client, mock_logged_in_rdu_user):
+
+    with test_app_client.session_transaction() as session:
+        session["session_data"] = "Secret stuff"
+
+    test_app_client.post("/auth/logout")
+
+    with test_app_client.session_transaction() as session:
+        assert session.get("session_data") is None


### PR DESCRIPTION
In the spirit of keeping PRs small, here's the next step towards doing the POST-not-GET ticket.

As Flask-Security only supports GET for logout this adds a new logout()
route in auth/views that calls logout_user() from a POSTed request.

Because POSTs require CSRF token protection it means that people can't
be logged out by a link elsewhere (eg a malicious email or website).