### PR TITLE
Add ordering to page service query

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -499,7 +499,11 @@ class PageService(Service):
 
     @staticmethod
     def get_pages_to_unpublish():
-        return MeasureVersion.query.filter_by(status="UNPUBLISH").all()
+        return (
+            MeasureVersion.query.filter_by(status="UNPUBLISH")
+            .order_by(MeasureVersion.title, desc(MeasureVersion.version))
+            .all()
+        )
 
     @staticmethod
     def mark_pages_unpublished(pages):


### PR DESCRIPTION
We currently query the database and use the returned records to power a
number of our views, but often expect those records to be ordered
consistently. Without an `order by` phrase, the returned order is
arbitrary. Given that we can afford the DB overhead of ordering all our
queries by default, let's do this until it becomes a problem (which
shouldn't be for a while, if ever).

 ## Ticket
https://trello.com/c/c7uMXeps