### PR TITLE
Change relationships to use `back_populates` instead of `backref`

### DIFF
--- a/application/auth/models.py
+++ b/application/auth/models.py
@@ -55,6 +55,16 @@ class User(db.Model, RoleFreeUserMixin):
     user_type = db.Column(db.Enum(TypeOfUser, name="type_of_user_types"), nullable=False)
     capabilities = db.Column(MutableList.as_mutable(ARRAY(db.String)), default=[])
 
+    # relationships
+    pages = db.relationship(
+        "MeasureVersion",
+        lazy=True,
+        secondary="user_measure",
+        primaryjoin="User.id == user_measure.columns.user_id",
+        secondaryjoin="MeasureVersion.id == user_measure.columns.measure_id",
+        back_populates="shared_with",
+    )
+
     __table_args__ = (UniqueConstraint(email, name="uq_users_email"),)
 
     def user_name(self):


### PR DESCRIPTION
When declaring relationships between models in SQLAlchemy, one can
either use 'backref' or 'back_populates'. `backref` allows the
relationship to be fully-realised by only declaring it on one of the
models, whereas `back_populates` requires entries on both models to set
up bi-directional population/access of the related model.

We think it's more explicit, and therefore quicker to reason about, if
you can look at a single model and see all of its relationships, so we
are switching over to use `back_populates` by default.

The main exception to this is the `parent` relationship on the
`MeasureVersion` table (which will eventually disappear), as this is a
relationship to the same table, so using `back_populates` would need us
to declare the relationship twice.

 ## Ticket
https://trello.com/c/GM3GAlys