### PR TITLE
 Add flake8 code linting checks

### DIFF
--- a/application/admin/forms.py
+++ b/application/admin/forms.py
@@ -3,7 +3,7 @@ import os
 import ast
 
 from flask_wtf import FlaskForm
-from wtforms import ValidationError, RadioField, SelectField
+from wtforms import ValidationError, RadioField
 from wtforms.fields.html5 import EmailField
 from wtforms.validators import Length, DataRequired, Email
 

--- a/application/auth/views.py
+++ b/application/auth/views.py
@@ -1,6 +1,5 @@
 import passwordmeter
 from flask import render_template, flash, redirect, url_for, current_app, abort, session
-from flask_login import logout_user
 from flask_mail import Message
 from flask_security.decorators import anonymous_user_required
 from flask_security.utils import hash_password

--- a/application/cms/classification_service.py
+++ b/application/cms/classification_service.py
@@ -7,7 +7,7 @@ from application.cms.exceptions import ClassificationNotFoundException
 
 from application.cms.models import Classification, Ethnicity, DimensionClassification
 
-from application.utils import setup_module_logging, get_bool
+from application.utils import setup_module_logging
 
 logger = logging.Logger(__name__)
 
@@ -39,7 +39,7 @@ class ClassificationService:
 
         try:
             classification = self.get_classification_by_id(id_str)
-        except ClassificationNotFoundException as e:
+        except ClassificationNotFoundException:
             classification = Classification(
                 id=id_str, title=title, subfamily=subfamily, long_title=classification_long_title, position=position
             )
@@ -76,7 +76,7 @@ class ClassificationService:
     def get_classification_by_id(classification_id):
         try:
             return Classification.query.filter_by(id=classification_id).one()
-        except NoResultFound as e:
+        except NoResultFound:
             raise ClassificationNotFoundException("Classification with id %s not found" % classification_id)
 
     @staticmethod

--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -108,7 +108,7 @@ class DimensionService(Service):
     def get_dimension_with_guid(guid):
         try:
             return Dimension.query.filter_by(guid=guid).one()
-        except NoResultFound as e:
+        except NoResultFound:
             raise DimensionNotFoundException()
 
     @staticmethod
@@ -116,10 +116,10 @@ class DimensionService(Service):
         try:
             Dimension.query.filter_by(page=page, title=title).one()
             return False
-        except NoResultFound as e:
+        except NoResultFound:
             return True
 
-    def update_dimension(self, dimension, data, update_classification=False):
+    def update_dimension(self, dimension, data, update_classification=False):  # noqa: C901 (complexity)
         dimension.title = data["title"] if "title" in data else dimension.title
         dimension.time_period = data["time_period"] if "time_period" in data else dimension.time_period
         dimension.summary = data["summary"] if "summary" in data else dimension.summary

--- a/application/cms/form_fields.py
+++ b/application/cms/form_fields.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 from flask import render_template
 from markupsafe import Markup
-from wtforms.fields import SelectMultipleField, RadioField, StringField, SelectField
+from wtforms.fields import SelectMultipleField, RadioField, StringField
 from wtforms.widgets import HTMLString, html_params
 
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -7,17 +7,7 @@ from typing import Optional, Iterable
 from dictalchemy import DictableModel
 import sqlalchemy
 from bidict import bidict
-from sqlalchemy import (
-    inspect,
-    ForeignKeyConstraint,
-    PrimaryKeyConstraint,
-    UniqueConstraint,
-    ForeignKey,
-    not_,
-    Index,
-    asc,
-    text,
-)
+from sqlalchemy import inspect, ForeignKeyConstraint, UniqueConstraint, ForeignKey, not_, Index, asc, text
 from sqlalchemy.dialects.postgresql import JSON, ARRAY
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.exc import NoResultFound
@@ -376,14 +366,14 @@ class MeasureVersion(db.Model):
         try:
             dimension = Dimension.query.filter_by(guid=guid, page=self).one()
             return dimension
-        except NoResultFound as e:
+        except NoResultFound:
             raise DimensionNotFoundException
 
     def get_upload(self, guid):
         try:
             upload = Upload.query.filter_by(guid=guid).one()
             return upload
-        except NoResultFound as e:
+        except NoResultFound:
             raise UploadNotFoundException
 
     def publish_status(self, numerical=False):
@@ -581,7 +571,8 @@ class Dimension(db.Model):
     __tablename__ = "dimension"
 
     # This is a database expression to get the current timestamp in UTC.
-    # Possibly specific to PostgreSQL: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT
+    # Possibly specific to PostgreSQL:
+    #   https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT
     __SQL_CURRENT_UTC_TIME = "timezone('utc', CURRENT_TIMESTAMP)"
 
     guid = db.Column(db.String(255), primary_key=True)
@@ -916,7 +907,12 @@ class ChartAndTableMixin(object):
         return new_object
 
     def __str__(self):
-        return f"{self.id} {self.classification_id} includes_parents:{self.includes_parents} includes_all:{self.includes_all} includes_unknown:{self.includes_unknown}"
+        return (
+            f"{self.id} {self.classification_id} "
+            f"includes_parents:{self.includes_parents} "
+            f"includes_all:{self.includes_all} "
+            f"includes_unknown:{self.includes_unknown}"
+        )
 
 
 class Chart(db.Model, ChartAndTableMixin):

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -24,13 +24,11 @@ from application.cms.models import (
     Subtopic,
     Topic,
     publish_status,
-    TypeOfData,
-    UKCountry,
     DataSource,
 )
 from application.cms.service import Service
 from application.cms.upload_service import upload_service
-from application.utils import generate_review_token, create_guid, get_bool
+from application.utils import generate_review_token, create_guid
 
 
 class PageService(Service):
@@ -564,7 +562,7 @@ class PageService(Service):
     def _set_main_fields(self, page, data):
         try:
             self.set_lowest_level_of_geography(page, data)
-        except NoResultFound as e:
+        except NoResultFound:
             message = "There was an error setting lowest level of geography"
             self.logger.exception(message)
             raise PageUnEditable(message)

--- a/application/cms/scanner_service.py
+++ b/application/cms/scanner_service.py
@@ -1,5 +1,4 @@
 import enum
-import json
 
 import requests
 

--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -215,7 +215,7 @@ class UploadService(Service):
         try:
             Upload.query.filter_by(page=page, title=title).one()
             return False
-        except NoResultFound as e:
+        except NoResultFound:
             return True
 
 

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -240,7 +240,9 @@ def _diff_updates(form, page):
     return diffs
 
 
-@cms_blueprint.route("/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit", methods=["GET", "POST"])
+@cms_blueprint.route(  # noqa: C901 (complexity)
+    "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit", methods=["GET", "POST"]
+)
 @login_required
 @user_has_access
 def edit_measure_page(topic_slug, subtopic_slug, measure_slug, version):
@@ -632,7 +634,6 @@ def create_dimension(topic_slug, subtopic_slug, measure_slug, version):
         topic_slug, subtopic_slug, measure_slug, version
     )
 
-    form = DimensionForm()
     if request.method == "POST":
         return _post_create_dimension(topic_slug, subtopic_slug, measure_slug, version)
     else:
@@ -645,7 +646,6 @@ def _post_create_dimension(topic_slug, subtopic_slug, measure_slug, version):
     )
     form = DimensionForm(request.form)
 
-    messages = []
     if form.validate():
         try:
             dimension = dimension_service.create_dimension(
@@ -1112,7 +1112,7 @@ def set_dimension_order(topic, subtopic, measure):
     try:
         dimension_service.set_dimension_positions(dimensions)
         return json.dumps({"status": "OK", "status_code": 200}), 200
-    except Exception as e:
+    except Exception:
         return json.dumps({"status": "INTERNAL SERVER ERROR", "status_code": 500}), 500
 
 
@@ -1202,7 +1202,7 @@ def new_version(topic_slug, subtopic_slug, measure_slug, version):
                     version=page.version,
                 )
             )
-        except UpdateAlreadyExists as e:
+        except UpdateAlreadyExists:
             message = "Version %s of page %s is already being updated" % (version, measure_slug)
             flash(message, "error")
             return redirect(

--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -4,12 +4,7 @@ from datetime import date, timedelta
 
 from flask import url_for
 from slugify import slugify
-from sqlalchemy import not_
 from trello.exceptions import TokenError
-
-from itertools import groupby
-
-from operator import itemgetter
 
 from application.cms.classification_service import classification_service
 from application.cms.models import MeasureVersion, LowestLevelOfGeography

--- a/application/data/charts.py
+++ b/application/data/charts.py
@@ -21,7 +21,7 @@ class ChartObjectDataBuilder:
         else:
             return None
 
-    @staticmethod
+    @staticmethod  # noqa: C901 (complexity)
     def upgrade_v1_to_v2(chart_object, chart_settings):
 
         v2 = ChartObjectDataBuilder.get_v2_chart_type(chart_settings)
@@ -280,7 +280,6 @@ class PanelLineChartObjectDataBuilder:
 
             rows = []
             for panel in panels:
-                panel_name = panel["title"]["text"]
                 panel_rows = LineChartObjectDataBuilder.build(panel)["data"][1:]
                 for row in panel_rows:
                     rows = rows + [row]

--- a/application/data/standardisers/ethnicity_classification_finder_builder.py
+++ b/application/data/standardisers/ethnicity_classification_finder_builder.py
@@ -88,11 +88,6 @@ def ethnicity_classification_collection_from_classification_list(classifications
 
 
 def ethnicity_classification_from_data(id, name, data_rows, long_name=None):
-    if long_name is None:
-        classification_long_name = name
-    else:
-        classification_long_name = long_name
-
     classification = EthnicityClassification(id=id, name=name, long_name=name)
     for row in data_rows:
         standard_value = row[EthnicityClassificationDataColumn.STANDARD_VALUE]

--- a/application/data/standardisers/ethnicity_dictionary_lookup.py
+++ b/application/data/standardisers/ethnicity_dictionary_lookup.py
@@ -10,7 +10,7 @@ class EthnicityDictionaryLookup:
 
     It adds extra fields using a lookup csv with two primary keys Ethnicity and Ethnicity Type.
     This needs to be kept up to date with appropriate values for data being used on the platform
-    
+
     By default this can be found in application/data/static/standardisers/dictionary_lookup.csv
     """
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -103,7 +103,7 @@ def create_app(config_object):
     Security(app, user_datastore)
 
     if os.environ.get("SENTRY_DSN") is not None:
-        sentry = Sentry(app, dsn=os.environ["SENTRY_DSN"])
+        Sentry(app, dsn=os.environ["SENTRY_DSN"])
 
     app.register_blueprint(cms_blueprint)
     app.register_blueprint(static_site_blueprint)

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -1,21 +1,20 @@
 #! /usr/bin/env python
-from datetime import datetime
 import glob
 import os
 import shutil
 import subprocess
+from datetime import datetime
 from uuid import uuid4
 
 from flask import current_app, render_template
 from git import Repo
 from slugify import slugify
 
-from application.data.dimensions import DimensionObjectBuilder
 from application.cms.models import MeasureVersion
 from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
+from application.data.dimensions import DimensionObjectBuilder
 from application.utils import get_csv_data_for_download, write_dimension_csv, write_dimension_tabular_csv
-
 
 BUILD_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S.%f"
 
@@ -107,7 +106,7 @@ def build_and_upload_error_pages(application):
 
         print("Deploy site (error pages) to S3: ", application.config["DEPLOY_SITE"])
         if application.config["DEPLOY_SITE"]:
-            from application.sitebuilder.build_service import s3_deployer, _upload_dir_to_s3
+            from application.sitebuilder.build_service import _upload_dir_to_s3
             from application.cms.file_service import S3FileSystem
 
             s3 = S3FileSystem(

--- a/application/sitebuilder/models.py
+++ b/application/sitebuilder/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import enum
 
 from sqlalchemy import PrimaryKeyConstraint
-from sqlalchemy.dialects.postgresql import ENUM, UUID
+from sqlalchemy.dialects.postgresql import UUID
 from application import db
 
 

--- a/application/static_site/filters.py
+++ b/application/static_site/filters.py
@@ -24,8 +24,10 @@ def value_filter(value):
 
     icon_html = {
         "N/A": '<span class="not-applicable">N/A<sup>*</sup></span>',
-        "?": __missing_data_icon("sample-too-small")
-        + __icon_explanation("withheld because a small sample size makes it unreliable"),
+        "?": (
+            __missing_data_icon("sample-too-small")
+            + __icon_explanation("withheld because a small sample size makes it unreliable")
+        ),
         "!": __missing_data_icon("confidential") + __icon_explanation("withheld to protect confidentiality"),
         "-": __missing_data_icon("not-collected") + __icon_explanation("not collected"),
     }
@@ -95,7 +97,7 @@ def version_filter(context, file_name):
         with open(manifest_path) as m:
             manifest = json.load(m)
             return manifest.get(file_name, file_name)
-    except Exception as e:
+    except Exception:
         return file_name
 
 

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -184,7 +184,7 @@ def measure_page_file_download(topic_slug, subtopic_slug, measure_slug, version,
 
         return send_file(outfile.name, as_attachment=True, mimetype="text/csv", attachment_filename=filename)
 
-    except (UploadNotFoundException, FileNotFoundError, ClientError) as e:
+    except (UploadNotFoundException, FileNotFoundError, ClientError):
         abort(404)
 
 
@@ -210,7 +210,7 @@ def dimension_file_download(topic_slug, subtopic_slug, measure_slug, version, di
         response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
         return response
 
-    except DimensionNotFoundException as e:
+    except DimensionNotFoundException:
         abort(404)
 
 
@@ -236,7 +236,7 @@ def dimension_file_table_download(topic_slug, subtopic_slug, measure_slug, versi
         response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
         return response
 
-    except DimensionNotFoundException as e:
+    except DimensionNotFoundException:
         abort(404)
 
 

--- a/application/utils.py
+++ b/application/utils.py
@@ -1,20 +1,18 @@
 import csv
 import hashlib
 import json
-import sys
-import os
 import logging
-from datetime import date
+import os
+import sys
 import time
-
-from flask import has_request_context, current_app
-from flask_mail import Message
+from datetime import date
 from functools import wraps
-
 from io import StringIO
-from flask import abort, current_app, url_for, render_template, flash
+
+from flask import abort, current_app, flash, has_request_context, render_template, url_for
 from flask_login import current_user
-from itsdangerous import TimestampSigner, SignatureExpired, URLSafeTimedSerializer
+from flask_mail import Message
+from itsdangerous import SignatureExpired, TimestampSigner, URLSafeTimedSerializer
 from slugify import slugify
 
 from application import mail
@@ -87,7 +85,7 @@ def get_csv_data_for_download(filename):
             for row in reader:
                 rows.append(row)
 
-    except UnicodeDecodeError as e:
+    except UnicodeDecodeError:
         rows = []  # Reset rows to be empty before attempting to read the file again, to avoid duplication
         with open(filename, "r", encoding="iso-8859-1") as f:
             reader = csv.reader(f, delimiter=",")

--- a/manage.py
+++ b/manage.py
@@ -143,8 +143,8 @@ def pull_prod_data(default_user_password=None):
     db.session.execute(
         """
         UPDATE users
-        SET email = ROUND(RANDOM() * 1000000000000)::TEXT || '@anon.invalid', 
-            password = NULL, 
+        SET email = ROUND(RANDOM() * 1000000000000)::TEXT || '@anon.invalid',
+            password = NULL,
             active = FALSE
         """
     )

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -11,16 +11,16 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
-logger = logging.getLogger('alembic.env')
+logger = logging.getLogger("alembic.env")
 
 # add your model's MetaData object here
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from flask import current_app
-config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
-target_metadata = current_app.extensions['migrate'].db.metadata
+from flask import current_app  # noqa: E402
+
+config.set_main_option("sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI"))
+target_metadata = current_app.extensions["migrate"].db.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -56,7 +56,7 @@ def run_migrations_offline():
     """
     # Running offline we can't inspect the DB to find views to exclude, so get the list from config
     global exclude_list
-    exclude_list = config.get_section('alembic:exclude').get('views', '').split(',')
+    exclude_list = config.get_section("alembic:exclude").get("views", "").split(",")
     url = config.get_main_option("sqlalchemy.url")
     context.configure(url=url, include_object=include_object)
 
@@ -76,30 +76,33 @@ def run_migrations_online():
     # when there are no changes to the schema
     # reference: http://alembic.readthedocs.org/en/latest/cookbook.html
     def process_revision_directives(context, revision, directives):
-        if getattr(config.cmd_opts, 'autogenerate', False):
+        if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
             if script.upgrade_ops.is_empty():
                 directives[:] = []
-                logger.info('No changes in schema detected.')
+                logger.info("No changes in schema detected.")
 
-    engine = engine_from_config(config.get_section(config.config_ini_section),
-                                prefix='sqlalchemy.',
-                                poolclass=pool.NullPool)
+    engine = engine_from_config(
+        config.get_section(config.config_ini_section), prefix="sqlalchemy.", poolclass=pool.NullPool
+    )
 
     _set_exclude_list(engine)
 
     connection = engine.connect()
-    context.configure(connection=connection,
-                      target_metadata=target_metadata,
-                      process_revision_directives=process_revision_directives,
-                      include_object = include_object,
-                      **current_app.extensions['migrate'].configure_args)
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        process_revision_directives=process_revision_directives,
+        include_object=include_object,
+        **current_app.extensions["migrate"].configure_args
+    )
 
     try:
         with context.begin_transaction():
             context.run_migrations()
     finally:
         connection.close()
+
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,7 @@ black==18.9b0
 coverage==4.5.1       # Required by pytest-cov
 coveralls==1.5.1
 Faker==0.9.2
+flake8==3.6.0
 glob2==0.6
 pluggy==0.6.0         # Required by pytest
 py==1.7.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,6 +28,9 @@ display_result $? 3 "JS tests"
 black --check .
 display_result $? 1 "Code style check"
 
+flake8 .
+display_result $? 4 "Python code lint check"
+
 npx gulp
 display_result $? 2 "Frontend asset build check"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,17 @@ exclude =
   # Ignore python files from project Node dependencies
   ./node_modules,
 
-  # Exclude specific historical migrations that don't meet flake8 standards.
+  # Exclude specific historical structural migrations that don't meet flake8 standards.
   ./migrations/versions/{,04625e2d6e60_.py,0c148005cc7b_.py,120c0d4099da_.py,20180227_add_latest_flag_to_page_.py,201812201054_rename_uri_to_slug.py,2018_03_22_user_model_refactor_.py,2018_04_11_add_sandbox_topic.py,2018_04_20_data_src_refactor.py,2018_04_25_migrate_geog_view.py,2018_05_04_coalesce_contacts.py,2018_05_14_share_pages.py,2018_07_03_del_dept_source_text.py,2018_07_28_redirects.py,2018_09_25_add_long_title.py,2018_10_02_chart_and_table.py,2018_10_03_rename_categorisations.py,2018_10_04_code_is_id_for_classification.py,2018_10_05_chart_table_fkeys.py,2018_10_15_index_page_type_uri.py,2018_11_12_dimension_timestamps.py,2018_11_14_ban_dimension_timestamp_nulls.py,2018_11_28_remove_contact_details_remove_contact_detail_fields_from_page_.py,2018_12_03_remove_duplicate_fkey.py,2018_12_05_fix_page_constraint.py,2018_12_05_fix_user_constraint.py,2018_12_10_uk_countries_enum.py,37bdbcac8251_.py,5382560efddb_.py,6fa486580023_.py,719c68424583_.py,8cf04343f0d7_.py,addb446d684c_.py,c64c6f6fb763_.py,cbdc988a7df4_.py,da52de5e4530_.py,e0248cc6bf14_.py,e553b195fe90_.py,migrate_views.py,2018_05_17_unify_uris.py,b73de66d0469_.py,01b5b95b092d_.py,},
 
+  # Exclude specific historical data migrations that don't meet flake8 standards.
+  ./scripts/data_migrations/2018-10-31_migrate-data-sources.py,
+  ./scripts/oneoff/find_dimensions_with_transposed_table_cells.py,
+
 max-complexity = 10
+ignore =
+  # Whitespace before colon (e.g. in sequence slicing)
+  E203,
+
+  # Line-breaks before binary operators (these are good things as per most PEP8 discussion)
+  W503,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,19 @@
 [pycodestyle]
 max-line-length = 120
+
+[flake8]
+max-line-length = 120
+exclude =
+  # Ignore all dotted-files/directories in the base of the project
+  ./.*,
+
+  # Ignore cached python bytecode files
+  __pycache__,
+
+  # Ignore python files from project Node dependencies
+  ./node_modules,
+
+  # Exclude specific historical migrations that don't meet flake8 standards.
+  ./migrations/versions/{,04625e2d6e60_.py,0c148005cc7b_.py,120c0d4099da_.py,20180227_add_latest_flag_to_page_.py,201812201054_rename_uri_to_slug.py,2018_03_22_user_model_refactor_.py,2018_04_11_add_sandbox_topic.py,2018_04_20_data_src_refactor.py,2018_04_25_migrate_geog_view.py,2018_05_04_coalesce_contacts.py,2018_05_14_share_pages.py,2018_07_03_del_dept_source_text.py,2018_07_28_redirects.py,2018_09_25_add_long_title.py,2018_10_02_chart_and_table.py,2018_10_03_rename_categorisations.py,2018_10_04_code_is_id_for_classification.py,2018_10_05_chart_table_fkeys.py,2018_10_15_index_page_type_uri.py,2018_11_12_dimension_timestamps.py,2018_11_14_ban_dimension_timestamp_nulls.py,2018_11_28_remove_contact_details_remove_contact_detail_fields_from_page_.py,2018_12_03_remove_duplicate_fkey.py,2018_12_05_fix_page_constraint.py,2018_12_05_fix_user_constraint.py,2018_12_10_uk_countries_enum.py,37bdbcac8251_.py,5382560efddb_.py,6fa486580023_.py,719c68424583_.py,8cf04343f0d7_.py,addb446d684c_.py,c64c6f6fb763_.py,cbdc988a7df4_.py,da52de5e4530_.py,e0248cc6bf14_.py,e553b195fe90_.py,migrate_views.py,2018_05_17_unify_uris.py,b73de66d0469_.py,01b5b95b092d_.py,},
+
+max-complexity = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 import os
 
@@ -7,16 +8,32 @@ from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager
 import pytest
 import requests_mock
+import sqlalchemy
 
 from application import db as app_db
-from application.auth.models import *
-from application.data.standardisers.ethnicity_dictionary_lookup import EthnicityDictionaryLookup
-from application.cms.models import *
+from application.auth.models import User, TypeOfUser, CAPABILITIES
 from application.cms.classification_service import ClassificationService
+from application.cms.models import (
+    Chart,
+    Classification,
+    DataSource,
+    Dimension,
+    FrequencyOfRelease,
+    LowestLevelOfGeography,
+    Measure,
+    MeasureVersion,
+    Organisation,
+    Subtopic,
+    Table,
+    Topic,
+    TypeOfStatistic,
+    Upload,
+)
+from application.cms.page_service import PageService
 from application.cms.scanner_service import ScannerService
 from application.cms.upload_service import UploadService
-from application.cms.page_service import PageService
 from application.config import TestConfig
+from application.data.standardisers.ethnicity_dictionary_lookup import EthnicityDictionaryLookup
 from application.factory import create_app
 from manage import refresh_materialized_views
 from tests.test_data.chart_and_table import simple_table, grouped_table, single_series_bar_chart, multi_series_bar_chart
@@ -264,6 +281,7 @@ def stub_sandbox_topic_page(db_session):
     measure = Measure(id=page.id, slug=page.slug, position=page.position, reference=page.internal_reference)
 
     db_session.session.add(page)
+    db_session.session.add(measure)
     db_session.session.commit()
     return page
 
@@ -732,7 +750,7 @@ def stub_page_with_single_series_bar_chart(db_session, stub_measure_page):
 
 
 @pytest.fixture(scope="function")
-def stub_page_with_single_series_bar_chart(db_session, stub_measure_page):
+def stub_page_with_multi_series_bar_chart(db_session, stub_measure_page):
     db_dimension = Dimension(
         guid="stub_dimension",
         title="stub dimension",

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -414,7 +414,6 @@ class MeasureEditPage(BasePage):
         element.send_keys(value)
 
     def set_auto_complete_field(self, locator, value):
-        body = self.driver.find_element_by_tag_name("body")
         element = self.wait_for_element(locator)
 
         element.send_keys(Keys.CONTROL + "a")

--- a/tests/functional/test_chart_builder.py
+++ b/tests/functional/test_chart_builder.py
@@ -9,18 +9,16 @@ from tests.functional.data_sets import (
     granular_with_parent_data,
 )
 from tests.functional.pages import (
-    LogInPage,
     HomePage,
     TopicPage,
     MeasureEditPage,
-    MeasureCreatePage,
     DimensionAddPage,
     DimensionEditPage,
     ChartBuilderPage,
     MinimalRandomMeasure,
     MinimalRandomDimension,
 )
-from tests.functional.utils import spaceless, go_to_page, assert_page_contains, create_measure, login, shuffle_table
+from tests.functional.utils import spaceless, create_measure, login, shuffle_table
 
 pytestmark = pytest.mark.usefixtures("app", "db_session", "stub_measure_page")
 

--- a/tests/functional/test_cms_delete_v1_measure.py
+++ b/tests/functional/test_cms_delete_v1_measure.py
@@ -1,18 +1,8 @@
 import pytest
 
 from application.cms.page_service import PageService
-from flask import current_app
 
-from tests.functional.pages import (
-    LogInPage,
-    HomePage,
-    CmsIndexPage,
-    TopicPage,
-    SubtopicPage,
-    MeasureEditPage,
-    MeasureCreatePage,
-    RandomMeasure,
-)
+from tests.functional.pages import LogInPage, HomePage, TopicPage, MeasureEditPage, MeasureCreatePage, RandomMeasure
 
 pytestmark = pytest.mark.usefixtures("app", "db_session", "stub_measure_page")
 

--- a/tests/functional/test_cms_measure_lifecycle.py
+++ b/tests/functional/test_cms_measure_lifecycle.py
@@ -1,17 +1,10 @@
 import pytest
 
-from flask import current_app
-
 from tests.functional.utils import (
     EXPECTED_STATUSES,
-    assert_page_correct,
-    assert_page_status,
-    assert_page_details,
     create_measure_starting_at_topic_page,
     navigate_to_topic_page,
-    navigate_to_preview_page,
     navigate_to_edit_page,
-    navigate_to_view_form,
     login,
 )
 

--- a/tests/functional/test_cms_reject_measure.py
+++ b/tests/functional/test_cms_reject_measure.py
@@ -1,17 +1,9 @@
 import pytest
 
-from flask import current_app
-
 from tests.functional.utils import (
     EXPECTED_STATUSES,
-    assert_page_correct,
-    assert_page_status,
-    assert_page_details,
     create_measure_starting_at_topic_page,
     navigate_to_topic_page,
-    navigate_to_preview_page,
-    navigate_to_edit_page,
-    navigate_to_view_form,
     login,
 )
 
@@ -76,7 +68,7 @@ def test_can_reject_a_measure_in_review_as_editor(
     assert measure_edit_page.get_status() == EXPECTED_STATUSES["department_review"]
 
     # WHEN we reject the measure again
-    review_link = measure_edit_page.click_reject()
+    measure_edit_page.click_reject()
 
     # THEN the status should be rejected
     driver.implicitly_wait(2)

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tests.functional.pages import HomePage
 
 

--- a/tests/functional/test_table_builder.py
+++ b/tests/functional/test_table_builder.py
@@ -277,7 +277,8 @@ def run_complex_table_by_column_scenario(table_builder_page, driver):
     table_builder_page.wait_for_seconds(1)
 
     """
-    AND a complex table exists with ethnicities across the columns, gender on the left, and sub-columns of value and gender.
+    AND a complex table exists with ethnicities across the columns, gender on the left, and sub-columns of value
+    and gender.
     """
     assert table_builder_page.table_headers() == ["", "Asian", "Black", "Mixed", "White", "Other"]
     assert table_builder_page.table_secondary_headers() == [

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -157,13 +157,6 @@ def create_measure(driver, live_server, page, topic, subtopic):
     create_measure_page.click_save()
 
 
-def login(driver, live_server, test_app_editor):
-    login_page = LogInPage(driver, live_server)
-    login_page.get()
-    if login_page.is_current():
-        login_page.login(test_app_editor.email, test_app_editor.password)
-
-
 def shuffle_table(table):
     table_body = table[1:]
     shuffle(table_body)

--- a/tests/test_build_static_site.py
+++ b/tests/test_build_static_site.py
@@ -17,19 +17,19 @@ def test_static_site_build(
     stub_page_with_dimension_and_chart_and_table,
 ):
     """
-    A basic test for the core flow of the static site builder. This patches/mocks a few of the key integrations to 
+    A basic test for the core flow of the static site builder. This patches/mocks a few of the key integrations to
     help prevent calling out to external services accidentally, and where possible, includes two levels of failsafes.
     1) We change the application config to not push/deploy the site
     2) We mock out the push_site, so that even if the config setting fails, this test will raise an error.
-    
+
     Unfortunately, due to circular dependencies between build/build_service, it's not easy to mock out `deploy_site`.
     So we mock out the S3FileSystem, which is initialized within `deloy_site`. This will throw an error if invoked.
-    
+
     `create_versioned_assets` is mocked out because that function is only needed to generate css/js, which is tested
     in a separate step outside of pytest.
-    
+
     `write_html` is mocked out so that we don't need to be able to write to a filesystem.
-    
+
     We should look at expanding test coverage of the static site builder eventually, but such a task should probably
     also include refactoring the site builder to be more modular, less tightly-coupled, and more easy to test.
     """

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -123,7 +123,10 @@ def test_remove_value_from_classification_removes_value(db_session):
 def test_add_parent_value_to_classification_appends_new_parent(db_session):
     # given a setup with one classification
     people = ["Tom", "Frankie", "Caroline", "Adam", "Cath", "Marcus", "Sylvia", "Katerina"]
-    rdu = classification_service.create_classification_with_values("G1", "Teams", "Race Disparity Unit", values=people)
+
+    # Create classifications (also commits them to the database).
+    classification_service.create_classification_with_values("G1", "Teams", "Race Disparity Unit", values=people)
+
     rdu_by_tribe = classification_service.create_classification_with_values(
         "G2", "Teams", "Race Disparity Unit by Tribe", values=people
     )

--- a/tests/test_csv_builder.py
+++ b/tests/test_csv_builder.py
@@ -100,6 +100,7 @@ def test_table_object_data_builder_does_build_data_from_grouped_table(stub_group
         ["Women", "White", "12.8", "0.128"],
         ["Women", "Other", "10.0", "0.100"],
     ]
+    assert data == expected_data
 
 
 def test_table_object_table_builder_does_build_headings_from_grouped_table(stub_grouped_table_object):

--- a/tests/test_data/table_convert.py
+++ b/tests/test_data/table_convert.py
@@ -176,7 +176,10 @@ def v1_settings_ethnicity_as_rows():
                     "sort_values": [86, 87, 90, 91, 92, 90],
                 },
             ],
-            "header": "Percentage of pupils going into sustained education, employment or training after key stage 4, by ethnicity over time",
+            "header": (
+                "Percentage of pupils going into sustained education, employment or training after key stage 4, "
+                "by ethnicity over time",
+            ),
             "subtitle": "",
             "footer": "",
             "groups": [
@@ -3981,7 +3984,10 @@ def v1_settings_ethnicity_as_rows():
                 ],
             ],
             "tableOptions": {
-                "table_title": "Percentage of pupils going into sustained education, employment or training after key stage 4, by ethnicity over time",
+                "table_title": (
+                    "Percentage of pupils going into sustained education, employment or training after key stage 4, "
+                    "by ethnicity over time",
+                ),
                 "table_subtitle": "",
                 "table_footer": "",
                 "table_category_column": "Standard Ethnicity",

--- a/tests/test_dimension_service.py
+++ b/tests/test_dimension_service.py
@@ -1,5 +1,5 @@
 from application.cms.dimension_service import DimensionService
-from application.cms.models import Chart, Dimension, DimensionClassification, Table
+from application.cms.models import Chart, Dimension, DimensionClassification
 from application import db
 from datetime import datetime
 
@@ -103,9 +103,9 @@ def test_update_dimension_does_not_call_update_dimension_classification_by_defau
     updated_dimension = stub_measure_page.dimensions[0]
     assert updated_dimension.dimension_classification is not None
     assert updated_dimension.dimension_classification.classification_id == "5A"
-    assert updated_dimension.dimension_classification.includes_parents == False
-    assert updated_dimension.dimension_classification.includes_all == True
-    assert updated_dimension.dimension_classification.includes_unknown == True
+    assert updated_dimension.dimension_classification.includes_parents is False
+    assert updated_dimension.dimension_classification.includes_all is True
+    assert updated_dimension.dimension_classification.includes_unknown is True
 
 
 def test_update_dimension_does_call_update_dimension_classification_if_told_to(
@@ -284,9 +284,9 @@ def test_adding_table_with_custom_data_classification(stub_measure_page, two_cla
     # And the dimension itself should have the same metadata values as there’s no chart
     assert dimension.dimension_classification is not None
     assert dimension.dimension_classification.classification_id == "2A"
-    assert dimension.dimension_classification.includes_parents == True
-    assert dimension.dimension_classification.includes_all == True
-    assert dimension.dimension_classification.includes_unknown == True
+    assert dimension.dimension_classification.includes_parents is True
+    assert dimension.dimension_classification.includes_all is True
+    assert dimension.dimension_classification.includes_unknown is True
 
 
 def test_adding_chart_with_custom_data_classification(stub_measure_page, two_classifications_2A_5A):
@@ -330,9 +330,9 @@ def test_adding_chart_with_custom_data_classification(stub_measure_page, two_cla
     # And the dimension itself should have the same metadata values as there’s no table
     assert dimension.dimension_classification is not None
     assert dimension.dimension_classification.classification_id == "2A"
-    assert dimension.dimension_classification.includes_parents == True
-    assert dimension.dimension_classification.includes_all == True
-    assert dimension.dimension_classification.includes_unknown == True
+    assert dimension.dimension_classification.includes_parents is True
+    assert dimension.dimension_classification.includes_all is True
+    assert dimension.dimension_classification.includes_unknown is True
 
 
 def test_adding_table_with_custom_data_and_existing_more_detailed_chart(stub_measure_page, two_classifications_2A_5A):
@@ -392,9 +392,9 @@ def test_adding_table_with_custom_data_and_existing_more_detailed_chart(stub_mea
     # And the dimension itself should have the same metadata as the chart
     assert dimension.dimension_classification is not None
     assert dimension.dimension_classification.classification_id == "5A"
-    assert dimension.dimension_classification.includes_parents == True
-    assert dimension.dimension_classification.includes_all == False
-    assert dimension.dimension_classification.includes_unknown == False
+    assert dimension.dimension_classification.includes_parents is True
+    assert dimension.dimension_classification.includes_all is False
+    assert dimension.dimension_classification.includes_unknown is False
 
 
 def test_adding_table_with_custom_data_and_existing_less_detailed_chart(stub_measure_page, two_classifications_2A_5A):
@@ -454,9 +454,9 @@ def test_adding_table_with_custom_data_and_existing_less_detailed_chart(stub_mea
     # And the dimension itself should have the same metadata as the newly saved table
     assert dimension.dimension_classification is not None
     assert dimension.dimension_classification.classification_id == "5A"
-    assert dimension.dimension_classification.includes_parents == False
-    assert dimension.dimension_classification.includes_all == True
-    assert dimension.dimension_classification.includes_unknown == True
+    assert dimension.dimension_classification.includes_parents is False
+    assert dimension.dimension_classification.includes_all is True
+    assert dimension.dimension_classification.includes_unknown is True
 
 
 def test_add_or_update_dimensions_to_measure_page_preserves_order(stub_measure_page):

--- a/tests/test_measure_pages.py
+++ b/tests/test_measure_pages.py
@@ -9,7 +9,7 @@ class TestMeasurePage:
     Unfortunately, without a refactor of how dimensions are passed into the measure page template, we aren't
     able to test how the static site renders these links. The static site builder passes in a specially-formatted
     set of dimensions that aren't available in 'static-mode style requests' to the CMS.
-    
+
     Tech improvement ticket: https://trello.com/c/U4rMSk0w/70
     """
 
@@ -79,6 +79,6 @@ class TestMeasurePage:
         resp = test_app_client.get("/test/example/test-measure-page/latest", follow_redirects=False)
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
-        data_links = page.findAll("a", href=True, text=re.compile("Test measure page data\s+-\s+Spreadsheet"))
+        data_links = page.findAll("a", href=True, text=re.compile(r"Test measure page data\s+-\s+Spreadsheet"))
         assert len(data_links) == 1
         assert data_links[0].attrs["href"] == expected_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,4 @@
-from unittest import mock
-
-from flask import session, request, current_app, flash, get_flashed_messages, url_for, render_template
+from flask import session, request, current_app, flash, render_template
 from flask_wtf import FlaskForm
 from lxml import html
 import pytest


### PR DESCRIPTION
We currently have `black` which auto formats our code to a pretty good
state, but another tool, `flake8`, provides further (configurable)
checks that closely align with the PEP8 standard. These two tools can be
complementary, and `flake8` catches a lot of possibly-bad things that
`black` ignores/can't.

Our flake8 code linting rules highlighted one bug (a test that didn't
make any assertions), and a number of other code smells (e.g. unused
imports/variables, wildcard imports, etc).

Fix the following flake8 violations:
```
./manage.py:146:78: W291 trailing whitespace
./manage.py:147:29: W291 trailing whitespace
./migrations/env.py:20:1: E402 module level import not at top of file
./migrations/env.py:95:37: E251 unexpected spaces around keyword / parameter equals
./migrations/env.py:95:39: E251 unexpected spaces around keyword / parameter equals
./migrations/env.py:104:1: E305 expected 2 blank lines after class or function definition, found 1
./tests/test_utils.py:1:1: F401 'unittest.mock' imported but unused
./tests/test_utils.py:3:1: F401 'flask.get_flashed_messages' imported but unused
./tests/test_utils.py:3:1: F401 'flask.url_for' imported but unused
./tests/conftest.py:12:1: F403 'from application.auth.models import *' used; unable to detect undefined names
./tests/conftest.py:14:1: F403 'from application.cms.models import *' used; unable to detect undefined names
./tests/conftest.py:78:12: F405 'User' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:79:22: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:80:25: F405 'CAPABILITIES' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:80:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:88:12: F405 'User' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:89:22: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:90:25: F405 'CAPABILITIES' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:90:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:116:28: F405 'sqlalchemy' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:127:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:132:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:137:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:142:38: F405 'TypeOfUser' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:166:12: F405 'User' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:168:25: F405 'CAPABILITIES' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:176:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:188:13: F405 'Topic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:207:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:219:16: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:224:18: F405 'Topic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:238:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:255:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:264:5: F841 local variable 'measure' is assigned to but never used
./tests/conftest.py:264:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:273:17: F405 'FrequencyOfRelease' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:281:12: F405 'Organisation' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:290:17: F405 'LowestLevelOfGeography' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:298:25: F405 'TypeOfStatistic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:306:20: F405 'Organisation' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:320:19: F405 'DataSource' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:343:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:359:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:360:26: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:365:19: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:381:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:398:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:399:26: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:404:19: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:439:25: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:451:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:466:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:467:26: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:472:19: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:486:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:503:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:504:26: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:509:19: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:524:12: F405 'MeasureVersion' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:541:15: F405 'Measure' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:542:26: F405 'Subtopic' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:547:19: F405 'datetime' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:589:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:606:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:613:16: F405 'Chart' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:639:16: F405 'Table' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:663:14: F405 'Upload' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:682:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:700:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:718:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:734:1: F811 redefinition of unused 'stub_page_with_single_series_bar_chart' from line 716
./tests/conftest.py:736:20: F405 'Dimension' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/conftest.py:764:25: F405 'Classification' may be undefined, or defined from star imports: application.auth.models, application.cms.models
./tests/test_measure_pages.py:12:1: W293 blank line contains whitespace
./tests/test_measure_pages.py:82:32: W605 invalid escape sequence '\s'
./tests/test_measure_pages.py:82:36: W605 invalid escape sequence '\s'
./tests/test_dimension_service.py:2:1: F401 'application.cms.models.Table' imported but unused
./tests/test_dimension_service.py:106:72: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
./tests/test_dimension_service.py:107:68: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:108:72: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:287:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:288:60: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:289:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:333:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:334:60: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:335:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:395:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:396:60: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
./tests/test_dimension_service.py:397:64: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
./tests/test_dimension_service.py:457:64: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
./tests/test_dimension_service.py:458:60: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_dimension_service.py:459:64: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./tests/test_csv_builder.py:97:5: F841 local variable 'expected_data' is assigned to but never used
./tests/test_classification_service.py:126:5: F841 local variable 'rdu' is assigned to but never used
./tests/test_build_static_site.py:20:115: W291 trailing whitespace
./tests/test_build_static_site.py:24:1: W293 blank line contains whitespace
./tests/test_build_static_site.py:27:1: W293 blank line contains whitespace
./tests/test_build_static_site.py:30:1: W293 blank line contains whitespace
./tests/test_build_static_site.py:32:1: W293 blank line contains whitespace
./tests/test_data/table_convert.py:179:121: E501 line too long (142 > 120 characters)
./tests/test_data/table_convert.py:3984:121: E501 line too long (151 > 120 characters)
./tests/functional/test_cms_measure_lifecycle.py:3:1: F401 'flask.current_app' imported but unused
./tests/functional/test_cms_measure_lifecycle.py:5:1: F401 'tests.functional.utils.assert_page_correct' imported but unused
./tests/functional/test_cms_measure_lifecycle.py:5:1: F401 'tests.functional.utils.assert_page_status' imported but unused
./tests/functional/test_cms_measure_lifecycle.py:5:1: F401 'tests.functional.utils.assert_page_details' imported but unused
./tests/functional/test_cms_measure_lifecycle.py:5:1: F401 'tests.functional.utils.navigate_to_preview_page' imported but unused
./tests/functional/test_cms_measure_lifecycle.py:5:1: F401 'tests.functional.utils.navigate_to_view_form' imported but unused
./tests/functional/test_cms_reject_measure.py:3:1: F401 'flask.current_app' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.assert_page_correct' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.assert_page_status' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.assert_page_details' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.navigate_to_preview_page' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.navigate_to_edit_page' imported but unused
./tests/functional/test_cms_reject_measure.py:5:1: F401 'tests.functional.utils.navigate_to_view_form' imported but unused
./tests/functional/test_cms_reject_measure.py:79:5: F841 local variable 'review_link' is assigned to but never used
./tests/functional/test_search.py:1:1: F401 'pytest' imported but unused
./tests/functional/test_table_builder.py:280:121: E501 line too long (124 > 120 characters)
./tests/functional/test_cms_delete_v1_measure.py:4:1: F401 'flask.current_app' imported but unused
./tests/functional/test_cms_delete_v1_measure.py:6:1: F401 'tests.functional.pages.CmsIndexPage' imported but unused
./tests/functional/test_cms_delete_v1_measure.py:6:1: F401 'tests.functional.pages.SubtopicPage' imported but unused
./tests/functional/pages.py:417:9: F841 local variable 'body' is assigned to but never used
./tests/functional/utils.py:160:1: F811 redefinition of unused 'login' from line 130
./tests/functional/test_chart_builder.py:11:1: F401 'tests.functional.pages.LogInPage' imported but unused
./tests/functional/test_chart_builder.py:11:1: F401 'tests.functional.pages.MeasureCreatePage' imported but unused
./tests/functional/test_chart_builder.py:23:1: F401 'tests.functional.utils.go_to_page' imported but unused
./tests/functional/test_chart_builder.py:23:1: F401 'tests.functional.utils.assert_page_contains' imported but unused
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:7:1: E402 module level import not at top of file
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:8:1: E402 module level import not at top of file
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:9:1: E402 module level import not at top of file
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:10:1: E402 module level import not at top of file
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:10:1: F401 'application.cms.models.Page' imported but unused
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:64:25: F821 undefined name 'MeasureVersion'
./scripts/data_migrations/2018-10-31_migrate-data-sources.py:64:53: F821 undefined name 'MeasureVersion'
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:12:1: F401 'pprint' imported but unused
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:17:1: E402 module level import not at top of file
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:19:1: E402 module level import not at top of file
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:20:1: E402 module level import not at top of file
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:21:1: E402 module level import not at top of file
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:65:1: C901 'get_ethnicity_and_category_column_idx' is too complex (13)
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:78:13: F841 local variable 'ethnicity_header_index' is assigned to but never used
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:79:13: F841 local variable 'subgroup_header_index' is assigned to but never used
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:88:121: E501 line too long (123 > 120 characters)
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:119:121: E501 line too long (123 > 120 characters)
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:135:1: C901 'find_inconsistent_grouped_table_dimensions' is too complex (13)
./scripts/oneoff/find_dimensions_with_transposed_table_cells.py:191:121: E501 line too long (144 > 120 characters)
./application/factory.py:106:9: F841 local variable 'sentry' is assigned to but never used
./application/utils.py:15:1: F811 redefinition of unused 'current_app' from line 10
./application/utils.py:90:5: F841 local variable 'e' is assigned to but never used
./application/sitebuilder/build.py:110:13: F401 'application.sitebuilder.build_service.s3_deployer' imported but unused
./application/sitebuilder/build.py:340:65: E203 whitespace before ':'
./application/sitebuilder/build.py:378:65: E203 whitespace before ':'
./application/sitebuilder/models.py:5:1: F401 'sqlalchemy.dialects.postgresql.ENUM' imported but unused
./application/auth/views.py:3:1: F401 'flask_login.logout_user' imported but unused
./application/admin/forms.py:6:1: F401 'wtforms.SelectField' imported but unused
./application/static_site/filters.py:98:5: F841 local variable 'e' is assigned to but never used
./application/static_site/views.py:187:5: F841 local variable 'e' is assigned to but never used
./application/static_site/views.py:213:5: F841 local variable 'e' is assigned to but never used
./application/static_site/views.py:239:5: F841 local variable 'e' is assigned to but never used
./application/dashboard/data_helpers.py:7:1: F401 'sqlalchemy.not_' imported but unused
./application/dashboard/data_helpers.py:10:1: F401 'itertools.groupby' imported but unused
./application/dashboard/data_helpers.py:12:1: F401 'operator.itemgetter' imported but unused
./application/dashboard/data_helpers.py:466:51: E203 whitespace before ':'
./application/cms/dimension_service.py:111:9: F841 local variable 'e' is assigned to but never used
./application/cms/dimension_service.py:119:9: F841 local variable 'e' is assigned to but never used
./application/cms/dimension_service.py:122:5: C901 'DimensionService.update_dimension' is too complex (16)
./application/cms/file_service.py:134:39: E203 whitespace before ':'
./application/cms/models.py:10:1: F401 'sqlalchemy.PrimaryKeyConstraint' imported but unused
./application/cms/models.py:379:9: F841 local variable 'e' is assigned to but never used
./application/cms/models.py:386:9: F841 local variable 'e' is assigned to but never used
./application/cms/models.py:584:121: E501 line too long (133 > 120 characters)
./application/cms/models.py:919:121: E501 line too long (167 > 120 characters)
./application/cms/classification_service.py:10:1: F401 'application.utils.get_bool' imported but unused
./application/cms/classification_service.py:42:9: F841 local variable 'e' is assigned to but never used
./application/cms/classification_service.py:79:9: F841 local variable 'e' is assigned to but never used
./application/cms/form_fields.py:11:1: F401 'wtforms.fields.SelectField' imported but unused
./application/cms/page_service.py:20:1: F401 'application.cms.models.TypeOfData' imported but unused
./application/cms/page_service.py:20:1: F401 'application.cms.models.UKCountry' imported but unused
./application/cms/page_service.py:33:1: F401 'application.utils.get_bool' imported but unused
./application/cms/page_service.py:567:9: F841 local variable 'e' is assigned to but never used
./application/cms/scanner_service.py:2:1: F401 'json' imported but unused
./application/cms/upload_service.py:218:9: F841 local variable 'e' is assigned to but never used
./application/cms/views.py:243:1: C901 'edit_measure_page' is too complex (14)
./application/cms/views.py:635:5: F841 local variable 'form' is assigned to but never used
./application/cms/views.py:648:5: F841 local variable 'messages' is assigned to but never used
./application/cms/views.py:1115:5: F841 local variable 'e' is assigned to but never used
./application/cms/views.py:1205:9: F841 local variable 'e' is assigned to but never used
./application/data/charts.py:24:5: C901 'ChartObjectDataBuilder.upgrade_v1_to_v2' is too complex (12)
./application/data/charts.py:283:17: F841 local variable 'panel_name' is assigned to but never used
./application/data/ethnicity_classification_synchroniser.py:28:62: E203 whitespace before ':'
./application/data/standardisers/ethnicity_dictionary_lookup.py:13:1: W293 blank line contains whitespace
./application/data/standardisers/ethnicity_classification_finder_builder.py:94:9: F841 local variable 'classification_long_name' is assigned to but never used
```