### PR TITLE
Remove more jQuery

### DIFF
--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -641,7 +641,13 @@ $(document).ready(function () {
 
     function selectChartType(chart_type) {
         $('#chart_type_selector').val(chart_type);
-        $('.chart-option-group').hide();
+
+        var chartOptionGroupDivs = document.getElementsByClassName('chart-option-group')
+
+        for (var i = 0; i < chartOptionGroupDivs.length; i++) {
+            chartOptionGroupDivs[i].classList.add('hidden')
+        }
+
         if (chart_type !== 'none') {
             document.getElementById(chart_type + '_options').classList.remove('hidden')
             document.getElementById('chart_format_options').classList.remove('hidden')
@@ -738,9 +744,9 @@ $(document).ready(function () {
     // Show-hide NUMBER-FORMAT__OTHER panel
     $('#number_format').change(function () {
         if ($(this).val() === 'other') {
-            document.getElementById('other_number_format').show()
+            document.getElementById('other_number_format').classList.remove('hidden')
         } else {
-            document.getElementById('other_number_format').hide()
+            document.getElementById('other_number_format').classList.add('hidden')
         }
         preview();
     });

--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -35,11 +35,10 @@ var current_settings = null;
 $(document).ready(function () {
 
     // add events to buttons
-    $('#preview').click(preview);
-    $('#confirm-data').click(setChartData);
-    $('#edit-data').click(editChartData);
-    $('#cancel-edit-data').click(cancelEditData);
-    $('#save').click(saveChart);
+    document.getElementById('confirm-data').addEventListener('click', setChartData)
+    document.getElementById('edit-data').addEventListener('click', editChartData)
+    document.getElementById('cancel-edit-data').addEventListener('click', cancelEditData)
+    document.getElementById('save').addEventListener('click', saveChart)
 
     /*
     Events from the DATA ENTRY PANEL
@@ -53,7 +52,7 @@ $(document).ready(function () {
         });
         $('#data-panel').hide();
         $('#edit-panel').show();
-        $('#builder-title').html('Format and view chart');
+        document.getElementById('builder-title').textContent = 'Format and view chart'
     }
 
     function editChartData(evt) {
@@ -61,14 +60,14 @@ $(document).ready(function () {
         current_settings = getChartPageSettings();
         $('#data-panel').show();
         $('#edit-panel').hide();
-        $('#builder-title').html('Create a chart');
+        document.getElementById('builder-title').textContent = 'Create a chart'
     }
 
     function cancelEditData(evt) {
         $('#data_text_area').val(current_data);
         $('#data-panel').hide();
         $('#edit-panel').show();
-        document.getElementById('builder-title').innerHTML = 'Format and view chart';
+        document.getElementById('builder-title').textContent = 'Format and view chart'
     }
 
 
@@ -86,7 +85,8 @@ $(document).ready(function () {
         if (chart_data.length > 0) {
             message = chart_data.length - 1 + ' rows by ' + chart_data[0].length + ' columns'
         }
-        $('#data-description').html(message);
+
+        document.getElementById('data-description').innerHTML = message;
 
         // update options in drop-downs
         var headers = chart_data[0];
@@ -154,24 +154,22 @@ $(document).ready(function () {
         var listWithNone = dropdownHtmlWithDefault(headers, '[None]');
         var listWithRequired = dropdownHtmlWithDefault(headers, 'Please select');
 
-        $('#line__x-axis_column').html(listWithRequired);
+        document.getElementById('line__x-axis_column').innerHTML = listWithRequired
 
-        $('#grouped-bar__bar_column').html(listWithRequired);
-        $('#grouped-bar__bar_order').html(listWithNone);
-        $('#grouped-bar__groups_column').html(listWithRequired);
-        $('#grouped-bar__groups_order').html(listWithNone);
+        document.getElementById('grouped-bar__bar_column').innerHTML = listWithRequired
+        document.getElementById('grouped-bar__groups_column').innerHTML = listWithRequired
 
-        $('#component__bar_column').html(listWithRequired);
-        $('#component__bar_order').html(listWithNone);
-        $('#component__section_column').html(listWithRequired);
-        $('#component__section_order').html(listWithNone);
+        document.getElementById('component__bar_column').innerHTML = listWithRequired
+        document.getElementById('component__bar_order').innerHTML = listWithNone
+        document.getElementById('component__section_column').innerHTML = listWithRequired
+        document.getElementById('component__section_order').innerHTML = listWithNone
 
-        $('#panel-bar__panel_column').html(listWithRequired);
-        $('#panel-bar__panel_order').html(listWithNone);
-        $('#panel-bar__bar_column').html(listWithRequired);
-        $('#panel-bar__bar_order').html(listWithNone);
+        document.getElementById('panel-bar__panel_column').innerHTML = listWithRequired
+        document.getElementById('panel-bar__panel_order').innerHTML = listWithNone
+        document.getElementById('panel-bar__bar_column').innerHTML = listWithRequired
+        document.getElementById('panel-bar__bar_order').innerHTML = listWithNone
 
-        $('#panel-line__x-axis_column').html(listWithRequired);
+        document.getElementById('panel-line__x-axis_column').innerHTML = listWithRequired
     }
 
     function selectDropdown(dropdown_id, value) {
@@ -201,7 +199,7 @@ $(document).ready(function () {
                 html = html + '<option value="' + preset_id + '" >' + preset_name + '</option>';
             }
         }
-        $('#ethnicity_settings').html(html);
+        document.getElementById('ethnicity_settings').innerHTML = html
     }
 
     function strippedHeaders(headers) {
@@ -291,9 +289,6 @@ $(document).ready(function () {
 
         var chartObject = buildChartObject();
         if (chartObject) {
-            if (chartObject.title && chartObject.title.text) {
-                $('#title-container').html('<h3 class="heading-small">' + chartObject.title.text + '</h3>');
-            }
             chartObject.title = '';
             drawChart('container', chartObject);
 

--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -50,23 +50,23 @@ $(document).ready(function () {
             }
             preview()
         });
-        $('#data-panel').hide();
-        $('#edit-panel').show();
+        document.getElementById('data-panel').classList.add('hidden')
+        document.getElementById('edit-panel').classList.remove('hidden')
         document.getElementById('builder-title').textContent = 'Format and view chart'
     }
 
     function editChartData(evt) {
         current_data = $('#data_text_area').val();
         current_settings = getChartPageSettings();
-        $('#data-panel').show();
-        $('#edit-panel').hide();
+        document.getElementById('data-panel').classList.remove('hidden')
+        document.getElementById('edit-panel').classList.add('hidden')
         document.getElementById('builder-title').textContent = 'Create a chart'
     }
 
     function cancelEditData(evt) {
         $('#data_text_area').val(current_data);
-        $('#data-panel').hide();
-        $('#edit-panel').show();
+        document.getElementById('data-panel').classList.add('hidden')
+        document.getElementById('edit-panel').classList.remove('hidden')
         document.getElementById('builder-title').textContent = 'Format and view chart'
     }
 
@@ -108,8 +108,8 @@ $(document).ready(function () {
                 populateEthnicityPresets(presets);
 
                 // show the presets (step 2) and chart type (step 3) section
-                $('#ethnicity_settings_section').show();
-                $('#select_chart_type').show();
+                document.getElementById('ethnicity_settings_section').classList.remove('hidden')
+                document.getElementById('select_chart_type').classList.remove('hidden')
 
                 // any further processing
                 if (on_success) {
@@ -182,9 +182,9 @@ $(document).ready(function () {
 
     function showHideCustomEthnicityPanel() {
         if($('#ethnicity_settings').val() === 'custom') {
-            $('#custom_classification__panel').show()
+            document.getElementById('custom_classification__panel').classList.remove('hidden')
         } else {
-            $('#custom_classification__panel').hide()
+            document.getElementById('custom_classification__panel').classList.remove('hidden')
         }
     }
 
@@ -239,40 +239,43 @@ $(document).ready(function () {
     }
 
     function displayTips(tips) {
-        $('#tips_container').show();
-        $('#preview_container').hide();
+        document.getElementById('tips_container').classList.remove('hidden')
+        document.getElementById('preview_container').classList.add('hidden')
 
-        $("#notes_container").hide();
-        $("#errors_container").hide();
+        document.getElementById('notes_container').classList.add('hidden')
+        document.getElementById('errors_container').classList.add('hidden')
 
-        $("#tip-list").children().hide();
+        var tip_list = document.getElementById('tip-list')
+        for (var i = 0; i < tip_list.children.length; i++) {
+            tip_list.children[i].classList.add('hidden')
+        }
 
         if (tipsOfType(tips, MISSING_FIELD_ERROR).length > 0) {
-            $("#notes_container").show();
+            document.getElementById('notes_container').classList.remove('hidden')
         }
         if (tipsOfType(tips, ETHNICITY_ERROR).length > 0) {
-            $("#errors_container").show();
-            $('#tip__ethnicity-column').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__ethnicity-column').classList.remove('hidden')
         }
         if (tipsOfType(tips, VALUE_ERROR).length > 0) {
-            $("#errors_container").show();
-            $('#tip__value-column').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__value-column').classList.remove('hidden')
         }
         if (tipsOfType(tips, RECTANGLE_ERROR).length > 0) {
-            $("#errors_container").show();
-            $('#tip__rectangular-data').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__rectangular-data').classList.remove('hidden')
         }
         if (tipsOfType(tips, DATA_ERROR_COMPLEX_DATA).length > 0) {
-            $("#errors_container").show();
-            $('#tip__complex-data').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__complex-data').classList.remove('hidden')
         }
         if (tipsOfType(tips, DATA_ERROR_DUPLICATION).length > 0) {
-            $("#errors_container").show();
-            $('#tip__duplicate-data').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__duplicate-data').classList.remove('hidden')
         }
         if (tipsOfType(tips, DATA_ERROR_MISSING_DATA).length > 0) {
-            $("#errors_container").show();
-            $('#tip__missing-data').show();
+            document.getElementById('errors_container').classList.remove('hidden')
+            document.getElementById('tip__missing-data').classList.remove('hidden')
         }
 
     }
@@ -284,15 +287,15 @@ $(document).ready(function () {
     }
 
     function displayChart() {
-        $('#tips_container').hide();
-        $('#preview_container').show();
+        document.getElementById('tips_container').classList.add('hidden')
+        document.getElementById('preview_container').classList.remove('hidden')
 
         var chartObject = buildChartObject();
         if (chartObject) {
             chartObject.title = '';
             drawChart('container', chartObject);
 
-            $('#save_section').show();
+            document.getElementById('save_section').classList.remove('hidden')
         }
 
         document.getElementById('chart_title').dispatchEvent(new Event("input"));
@@ -640,10 +643,9 @@ $(document).ready(function () {
         $('#chart_type_selector').val(chart_type);
         $('.chart-option-group').hide();
         if (chart_type !== 'none') {
-            $('#' + chart_type + "_options").show();
-            $('#chart_format_options').show();
+            document.getElementById(chart_type + '_options').classList.remove('hidden')
+            document.getElementById('chart_format_options').classList.remove('hidden')
         }
-        $('#preview_section').show();
     }
 
     function selectPreset(preset) {
@@ -683,11 +685,11 @@ $(document).ready(function () {
     // GROUPED-BAR events
     $('#grouped-bar__data_style').change(function () {
         if ($(this).val() === "ethnicity_as_group") {
-            $('#grouped-bar__ethnicity_is_group').show();
-            $('#grouped-bar__ethnicity_is_bar').hide();
+            document.getElementById('grouped-bar__ethnicity_is_group').classList.remove('hidden')
+            document.getElementById('grouped-bar__ethnicity_is_bar').classList.add('hidden')
         } else {
-            $('#grouped-bar__ethnicity_is_group').hide();
-            $('#grouped-bar__ethnicity_is_bar').show();
+            document.getElementById('grouped-bar__ethnicity_is_group').classList.add('hidden')
+            document.getElementById('grouped-bar__ethnicity_is_bar').classList.remove('hidden')
         }
         preview();
     });
@@ -700,11 +702,11 @@ $(document).ready(function () {
     // COMPONENT events
     $('#component__data_style').change(function () {
         if ($(this).val() === "ethnicity_as_bar") {
-            $('#component__ethnicity_is_bar').show();
-            $('#component__ethnicity_is_sections').hide();
+            document.getElementById('component__ethnicity_is_bar').classList.remove('hidden')
+            document.getElementById('component__ethnicity_is_sections').classList.add('hidden')
         } else {
-            $('#component__ethnicity_is_bar').hide();
-            $('#component__ethnicity_is_sections').show();
+            document.getElementById('component__ethnicity_is_bar').classList.add('hidden')
+            document.getElementById('component__ethnicity_is_sections').classList.remove('hidden')
         }
         preview();
     });
@@ -716,11 +718,11 @@ $(document).ready(function () {
     // PANEL-BAR events
     $('#panel-bar__data_style').change(function () {
         if ($(this).val() === "ethnicity_as_panel_bars") {
-            $('#panel-bar__ethnicity_as_bar').show();
-            $('#panel-bar__ethnicity_as_panels').hide();
+            document.getElementById('panel-bar__ethnicity_as_bar').classList.remove('hidden')
+            document.getElementById('panel-bar__ethnicity_as_panels').classList.add('hidden')
         } else {
-            $('#panel-bar__ethnicity_as_bar').hide();
-            $('#panel-bar__ethnicity_as_panels').show();
+            document.getElementById('panel-bar__ethnicity_as_bar').classList.add('hidden')
+            document.getElementById('panel-bar__ethnicity_as_panels').classList.remove('hidden')
         }
         preview();
     });
@@ -736,9 +738,9 @@ $(document).ready(function () {
     // Show-hide NUMBER-FORMAT__OTHER panel
     $('#number_format').change(function () {
         if ($(this).val() === 'other') {
-            $('#other_number_format').show()
+            document.getElementById('other_number_format').show()
         } else {
-            $('#other_number_format').hide()
+            document.getElementById('other_number_format').hide()
         }
         preview();
     });
@@ -752,8 +754,8 @@ $(document).ready(function () {
             $('#data_text_area').val(data_text);
 
             handleNewData(function () {
-                $('#data-panel').hide();
-                $('#edit-panel').show();
+                document.getElementById('data-panel').classList.add('hidden')
+                document.getElementById('edit-panel').classList.remove('hidden')
                 setupChartbuilderWithSettings(settings);
                 preview()
             })
@@ -784,12 +786,12 @@ $(document).ready(function () {
                 $('#grouped-bar__data_style').val(dataStyle);
                 if (dataStyle === 'ethnicity_as_group') {
                     $('#grouped-bar__bar_column').val(settings.chartOptions.bar_column);
-                    $('#grouped-bar__ethnicity_is_group').show();
-                    $('#grouped-bar__ethnicity_is_bar').hide();
+                    document.getElementById('grouped-bar__ethnicity_is_group').classList.remove('hidden')
+                    document.getElementById('grouped-bar__ethnicity_is_bar').classList.add('hidden')
                 } else {
                     $('#grouped-bar__groups_column').val(settings.chartOptions.group_column);
-                    $('#grouped-bar__ethnicity_is_group').hide();
-                    $('#grouped-bar__ethnicity_is_bar').show();
+                    document.getElementById('grouped-bar__ethnicity_is_group').classList.add('hidden')
+                    document.getElementById('grouped-bar__ethnicity_is_bar').classList.remove('hidden')
                 }
                 break;
             case 'component_chart':
@@ -798,13 +800,13 @@ $(document).ready(function () {
                 if (dataStyle === 'ethnicity_as_sections') {
                     $('#component__bar_column').val(settings.chartOptions.bar_column);
                     $('#component__bar_order').val(settings.chartOptions.bar_order);
-                    $('#component__ethnicity_is_sections').show();
-                    $('#component__ethnicity_is_bar').hide();
+                    document.getElementById('component__ethnicity_is_sections').classList.remove('hidden')
+                    document.getElementById('component__ethnicity_is_bar').classList.add('hidden')
                 } else {
                     $('#component__section_column').val(settings.chartOptions.section_column);
                     $('#component__section_order').val(settings.chartOptions.section_order);
-                    $('#component__ethnicity_is_sections').hide();
-                    $('#component__ethnicity_is_bar').show();
+                    document.getElementById('component__ethnicity_is_sections').classList.add('hidden')
+                    document.getElementById('component__ethnicity_is_bar').classList.remove('hidden')
                 }
                 break;
             case 'panel_bar_chart':
@@ -813,13 +815,13 @@ $(document).ready(function () {
                 if (dataStyle === 'ethnicity_as_panels') {
                     $('#panel-bar__bar_column').val(settings.chartOptions.bar_column);
                     $('#panel-bar__bar_order').val(settings.chartOptions.bar_order);
-                    $('#panel-bar__ethnicity_as_bar').hide();
-                    $('#panel-bar__ethnicity_as_panels').show();
+                    document.getElementById('panel-bar__ethnicity_as_bar').classList.add('hidden')
+                    document.getElementById('panel-bar__ethnicity_as_panels').classList.remove('hidden')
                 } else {
                     $('#panel-bar__panel_column').val(settings.chartOptions.panel_column);
                     $('#panel-bar__panel_order').val(settings.chartOptions.panel_order);
-                    $('#panel-bar__ethnicity_as_bar').show();
-                    $('#panel-bar__ethnicity_as_panels').hide();
+                    document.getElementById('panel-bar__ethnicity_as_bar').classList.remove('hidden')
+                    document.getElementById('panel-bar__ethnicity_as_panels').classList.add('hidden')
                 }
                 break;
             case 'panel_line_chart':
@@ -835,7 +837,7 @@ $(document).ready(function () {
         $('#number_format_min').val(settings.chartFormat.number_format_min);
         $('#number_format_max').val(settings.chartFormat.number_format_max);
         if (settings.chartFormat.number_format === 'other') {
-            $('#other_number_format').show();
+            document.getElementById('other_number_format').classList.remove('hidden')
         }
     }
 

--- a/application/templates/cms/create_chart_2.html
+++ b/application/templates/cms/create_chart_2.html
@@ -36,7 +36,7 @@
         DATA ENTRY PANEL
         This panel appears on create or when editing data
 #}
-        <div id="data-panel" class="data-panel"{% if dimension.chart_2_source_data %} style="display:none"{% endif %}>
+        <div id="data-panel" class="data-panel {% if dimension.chart_2_source_data %}hidden{% endif %}">
             <div class="column-full">
                 <h2 class="heading-medium no-top-border builder-section-number">Data</h2>
 
@@ -61,7 +61,7 @@
             </div>
         </div>
 
-        <div id="edit-panel" class="edit-panel"{% if not dimension.chart_2_source_data %} style="display:none"{% endif %}>
+        <div id="edit-panel" class="edit-panel {% if not dimension.chart_2_source_data %}hidden{% endif %}">
             <div class='column-one-third'>
                 {#
                     DATA DISPLAY
@@ -103,7 +103,7 @@
                     CHART TYPE
                     Option list to pick a chart type
                  #}
-                <div id="select_chart_type" class="chart-builder-section grid-row" style="display:none">
+                <div id="select_chart_type" class="chart-builder-section grid-row hidden">
                     <label for="chart_type_selector">
                         <h2 class="heading-medium builder-section-number">Select chart type</h2>
                     </label>
@@ -133,8 +133,7 @@
                     it knows about parent-child relationships
                     simple bar charts require no settings at all
                 #}
-                <div id="bar_chart_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="bar_chart_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Bar chart options</h2>
                     <p>No settings needed</p>
                 </div>
@@ -145,8 +144,7 @@
                     Here you require two columns to set up the charts
                     Ethnicity must be one of the two
                 #}
-                <div id="grouped_bar_chart_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="grouped_bar_chart_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Grouped bar chart options</h2>
                     <p>Use ethnicity for sub-groups if your data only includes 2 ethnic groups (for example, White and Other).</p>
                     <form>
@@ -175,8 +173,7 @@
                         {#
                             Style 2  - Ethnicity for sub-groups
                         #}
-                        <div class="indented-option-block grid-row" id="grouped-bar__ethnicity_is_bar"
-                             style="display:none">
+                        <div class="indented-option-block grid-row hidden" id="grouped-bar__ethnicity_is_bar">
                             <div class="form-group">
                                 <label for="grouped-bar__groups_column">Major grouping</label>
                                 <select id="grouped-bar__groups_column" class="form-control"
@@ -194,8 +191,7 @@
                     Here you require two columns to set up the charts
                     Ethnicity must be one of the two
                 #}
-                <div id="panel_bar_chart_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="panel_bar_chart_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Panel chart options</h2>
                     <p>Most of the time you should use ethnicity for bars.</p>
                     <p>Only use ethnicity for panels if you’re comparing outcomes within an ethnic group, rather than between groups.</p>
@@ -235,8 +231,7 @@
                         {#
                             Style 2 - Ethnicity for the panels
                         #}
-                        <div class="indented-option-block grid-row" id="panel-bar__ethnicity_as_panels"
-                             style="display:none">
+                        <div class="indented-option-block grid-row hidden" id="panel-bar__ethnicity_as_panels">
                             <div class="form-group">
                                 <label for="panel-bar__bar_column">Bars</label>
                                 <select id="panel-bar__bar_column" class="form-control"
@@ -259,8 +254,7 @@
                     LINE CHARTS _______________________________
                     Must have ETHNICITY as their series - we only need to set a column for the x-axis
                 #}
-                <div id="line_graph_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="line_graph_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Line chart options</h2>
                     <form>
                         <div>
@@ -277,8 +271,7 @@
                     Are not more complex than regular line charts
                     Must have ETHNICITY as their panels - we only need to set a column for the x-axis
                 #}
-                <div id="panel_line_chart_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="panel_line_chart_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Panel line chart options</h2>
                     <form>
 
@@ -296,8 +289,7 @@
                     Here you require two columns to set up the charts
                     Ethnicity must be one of the two
                 #}
-                <div id="component_chart_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="component_chart_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Component chart options</h2>
                     <form>
                         {#
@@ -334,8 +326,7 @@
                         {#
                             Style 2 - Ethnicity for the sections
                         #}
-                        <div class="indented-option-block grid-row" id="component__ethnicity_is_sections"
-                             style="display:none">
+                        <div class="indented-option-block grid-row hidden" id="component__ethnicity_is_sections">
                             <div class="form-group">
                                 <label for="component__bar_column">Bars</label>
                                 <select id="component__bar_column" class="form-control"
@@ -354,8 +345,7 @@
                     </form>
                 </div>
 
-                <div id="chart_format_options" class="chart-builder-section chart-option-group grid-row"
-                     style="display:none">
+                <div id="chart_format_options" class="chart-builder-section chart-option-group grid-row hidden">
                     <h2 class="heading-medium builder-section-number">Chart format options</h2>
                     <form>
                         <div class="form-group">
@@ -366,7 +356,7 @@
                                 <option value="percent">Percentage (%)</option>
                                 <option value="other">Other</option>
                             </select>
-                            <div id="other_number_format" class="form-group" style="display:none">
+                            <div id="other_number_format" class="form-group hidden">
                                 <label for="number_format_prefix">Prefix (for example, £)</label>
                                 <input id="number_format_prefix" {% if form_disabled %}disabled="disabled"{% endif %}>
                                 <label for="number_format_suffix">Suffix (for example, %)</label>
@@ -384,22 +374,22 @@
             <div class="column-two-thirds">
 
 
-                <div id="tips_container" style="display:none">
-                    <div id="notes_container" style="display:none">
+                <div id="tips_container" class="hidden">
+                    <div id="notes_container" class="hidden">
                         <h2 class="heading-medium">Note</h2>
                         <ul>
                             <li class="tip" id="tip__required-settings">Please complete all required settings</li>
                         </ul>
                     </div>
-                    <div id="errors_container" style="display:none">
+                    <div id="errors_container" class="hidden">
                         <h2 class="heading-medium">Error</h2>
                         <ul id="tip-list">
-                            <li class="tip" id="tip__ethnicity-column" style="display:none">Your data is missing an ethnicity column</li>
-                            <li class="tip" id="tip__value-column" style="display:none">Your data is missing a value column</li>
-                            <li class="tip" id="tip__rectangular-data" style="display:none">Your data is not a table</li>
-                            <li class="tip" id="tip__complex-data" style="display:none">Your data has some repeating values, so please choose either grouped bar chart, component bar chart, panel bar chart or panel line chart</li>
-                            <li class="tip" id="tip__duplicate-data" style="display:none">There are rows duplicated in your data</li>
-                            <li class="tip" id="tip__missing-data" style="display:none">There are rows missing from your data</li>
+                            <li class="tip hidden" id="tip__ethnicity-column">Your data is missing an ethnicity column</li>
+                            <li class="tip hidden" id="tip__value-column">Your data is missing a value column</li>
+                            <li class="tip hidden" id="tip__rectangular-data">Your data is not a table</li>
+                            <li class="tip hidden" id="tip__complex-data">Your data has some repeating values, so please choose either grouped bar chart, component bar chart, panel bar chart or panel line chart</li>
+                            <li class="tip hidden" id="tip__duplicate-data">There are rows duplicated in your data</li>
+                            <li class="tip hidden" id="tip__missing-data">There are rows missing from your data</li>
                         </ul>
                     </div>
                 </div>
@@ -417,7 +407,7 @@
 
                     {% if 'UPDATE' in measure.available_actions() %}
                     <br>
-                    <div id="save_section" class="chart-builder-section" class="hidden">
+                    <div id="save_section" class="chart-builder-section hidden">
                         <div>
                             <button class="button" id="save">Save</button>
                         </div>


### PR DESCRIPTION
This is another incremental step towards removing jQuery, this time focused upon "Chartbuilder 2", and the `.click()`, `.html()`, `.hide()` and `.show()` jQuery functions.