### PR TITLE
Use FactoryBoy to generate test data

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -320,6 +320,7 @@ class MeasureVersion(db.Model):
         remote_side=[id, guid, version],
         backref=db.backref("children", order_by="MeasureVersion.position"),
     )
+    measure = db.relationship("Measure", back_populates="versions")
     lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="pages")
     uploads = db.relationship("Upload", back_populates="page", lazy="dynamic", cascade="all,delete")
     dimensions = db.relationship(
@@ -1040,6 +1041,7 @@ class Measure(db.Model):
 
     # relationships
     subtopics = db.relationship("Subtopic", secondary="subtopic_measure", back_populates="measures")
+    versions = db.relationship("MeasureVersion", back_populates="measure")
 
     # Departmental users can only access measures that have been shared with them, as defined by this relationship
     # TODO: Uncomment this and use back_populates (relationship declared both sides) once user_measure table exists

--- a/doc/decisions/0003-test-with-factory-boy.md
+++ b/doc/decisions/0003-test-with-factory-boy.md
@@ -1,0 +1,35 @@
+# 3. Test with Factory Boy
+
+Date: 23/01/2019
+
+## Status
+
+Accepted
+
+## Context
+
+When testing our code, we often need to have certain data in our database, whether it be a measure version so that we can view a measure page, or a user with a specific role so that we can test the site logged in as that role. A lot of our database models are related and therefore depend on related models to also exist and be in a specific state. Getting the correct data into our database can be fiddly and error-prone.
+
+## Decision
+
+Use Factory Boy to generate model instances for tests.
+
+Pros
+----
+* More explicit about the data/conditions under test.
+* Fewer fixtures to maintain.
+* Easier/faster to write new tests that require a specific database state.
+
+Cons
+----
+* Effort to understand how FactoryBoy works and how we've implemented it in our codebase.
+* Potentially slower tests if we are careless with how we use the factories, as some factories generate a lot of additional instances which may not be required for the tests.
+
+## Alternatives
+
+1) Extend our existing suite of test fixtures with additional varieties. In order to meet all of our needs, we would probably have to write a lot of additional fixtures with similar names, increasing duplication and making it harder to understand what is available. It's possible that the same fixture could be created multiple times with different names. We would also still be making assertions about data that is described in fixtures rather than explicitly configured in the test.
+2) Instantiate all required data within the test. This would lead to a huge amount of repetitive code, as well as lots of boilerplate code at the start of each test which would increase maintenance costs and decrease readability.
+
+## Consequences
+
+* Developers need to remember to update factories whenever they make a change to the model.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@ attrs==18.1.0         # Required by pytest
 black==18.9b0         # Automatic code formatting (must also update `.pre-commit-config.yml` if this changes)
 coverage==4.5.1       # Required by pytest-cov
 coveralls==1.5.1
+factory-boy==2.11.1
 Faker==0.9.2
 flake8==3.6.0
 glob2==0.6

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,3 +11,52 @@ Some of our fixtures are applied automatically to all tests. Important examples 
 * A full database migration runs at the start of each test session [see `conftest:db_migration`].
 * Before **every** test, all records from the database are removed (EXCEPT materialized views, which need to be refreshed on an as-needed basis within the test that needs them) [see `conftest:db_session`].
 * All network requests via the `requests` library are mocked out to raise exceptions, with the aim of preventing (most) requests from reaching out to the Internet [see `conftest:requests_mocker`]
+
+# Factory Boy
+We use [Factory Boy](https://factoryboy.readthedocs.io/en/latest/introduction.html) to generate realistic model instances to test against. This replaces, in most places, the use of [pytest fixtures](https://docs.pytest.org/en/latest/fixture.html), and going forward should be the preferred way of generating test data. Using the existing factories should have a relatively small learning curve beyond knowing the interface exposed by our models. If the models change, the corresponding factories should be updated as well, in which case it is expected that you'll need to spend some time becoming familiar with how Factory Boy works.
+
+Using these factories should be fairly intuitive once you're familiar with our models - you simply instantiate the factory and pass in parameters as keywords using the model attributes. The attributes of related models can be set during instantiation by separating with a double underscore (see examples below). Any arguments not specified will be filled in with random realistic data by the factory. Most of the factories mirror our models exactly, with some minor exceptions. Given the related nature of a lot of our models, and their dependecy on other models, using one factory may mean that multiple records are created across different tables.
+
+The main principle used when defining our factories is that relationships of the factory that are farther away from MeasureVersion should be created. Referring to our Data Model will help appreciate the implications of this, but it should suffice to say that the MeasureVersion is considered the "centre" of the current model. Instantiating a MeasureVersion, therefore, creates many related records, whereas instantiating a Measure will create far fewer.
+
+For example:
+* MeasureFactory will create a Measure, as well as a related Subtopic and Topic.
+* ClassificationFactory will create a Classification, as well as some Ethnicities, and links to those ethnicities as
+  parent and child values.
+* A MeasureVersionFactory will create a Measure, Subtopic, Topic, Upload, Lowest Level of Geography, etc etc.
+
+Notably, the default MeasureVersionFactory does _not_ create any dimensions by default. An alternative factory,
+MeasureVersionWithDimensionFactory, exists to do this, as creating a Dimension requires instantiating a lot of extra
+models, so does not feel like an appropriate or useful default.
+
+Example usage:
+* Creating a measure:
+    ```
+    measure = MeasureFactory()
+    ```
+    Instantiates a Measure, with related Subtopic and Topic. All of these records contain random, unspecified data.
+* Creating a measure version:
+    ```
+    measure_version = MeasureVersionFactory(status='DRAFT')
+    ```
+    This will create a MeasureVersion populated in the 'DRAFT' state, with all other data randomly-generated, with associated users, Measure, Subtopic, Topic, Upload, Data Source, Level of Geography, but **not** a Dimension.
+* Creating a measure version with a dimension:
+    ```
+    measure_version = MeasureVersionWithDimensionFactory(status='PUBLISHED', dimensions__title='My dimension')
+    ```
+    This creates a MeasureVersion in the 'PUBLISHED' state, with all other data randomly-generated, with all associated records **including** one Dimension, and that Dimension's title will be 'My dimension'.
+* Creating a dimension:
+    ```
+    dimension = DimensionFactory(summary="Dimension summary", dimension_chart=None)
+    ```
+    This will create a Dimension with the given summary, no associated Chart, and all other data randomly-generated. It **will not** generate a MeasureVersion by default. A dimension is not valid without an associated MeasureVersion, so one will need to be created and the dimension attached to it before a database commit will succeed.
+* Creating a dimension and attaching it to an existing MeasureVersion:
+    ```
+    dimension = DimensionFactory(page=measure_version)
+    ```
+    Creates a Dimension and sets up the `page` relationship to point to an existing MeasureVersion.
+* Creating a Classification:
+    ```
+    classification = ClassificationFactory()
+    ```
+    This will create a random Classification, a set of Ethnicities (chosen from bird, cat, dog, and specific breeds of those), and some child and parent links between Classification and Ethnicity.

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -4,12 +4,10 @@ from flask import url_for
 from application.auth.models import User, TypeOfUser
 from application.utils import generate_token
 
+from tests.models import UserFactory
 
-def test_standard_user_cannot_view_admin_urls(test_app_client, mock_rdu_user):
 
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_rdu_user.id
-
+def test_standard_user_cannot_view_admin_urls(test_app_client, mock_logged_in_rdu_user):
     resp = test_app_client.get(url_for("admin.index"), follow_redirects=True)
 
     assert resp.status == "403 FORBIDDEN"
@@ -20,7 +18,7 @@ def test_standard_user_cannot_view_admin_urls(test_app_client, mock_rdu_user):
     assert resp.status == "403 FORBIDDEN"
     assert resp.status_code == 403
 
-    resp = test_app_client.get(url_for("admin.user_by_id", user_id=mock_rdu_user.id), follow_redirects=True)
+    resp = test_app_client.get(url_for("admin.user_by_id", user_id=mock_logged_in_rdu_user.id), follow_redirects=True)
 
     assert resp.status == "403 FORBIDDEN"
     assert resp.status_code == 403
@@ -30,7 +28,9 @@ def test_standard_user_cannot_view_admin_urls(test_app_client, mock_rdu_user):
     assert resp.status == "403 FORBIDDEN"
     assert resp.status_code == 403
 
-    resp = test_app_client.get(url_for("admin.deactivate_user", user_id=mock_rdu_user.id), follow_redirects=True)
+    resp = test_app_client.get(
+        url_for("admin.deactivate_user", user_id=mock_logged_in_rdu_user.id), follow_redirects=True
+    )
 
     assert resp.status == "403 FORBIDDEN"
     assert resp.status_code == 403
@@ -41,23 +41,15 @@ def test_standard_user_cannot_view_admin_urls(test_app_client, mock_rdu_user):
     assert resp.status_code == 403
 
 
-def test_admin_user_can_view_admin_page(test_app_client, mock_admin_user):
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
+def test_admin_user_can_view_admin_page(test_app_client, mock_logged_in_admin_user):
     resp = test_app_client.get(url_for("admin.index"), follow_redirects=True)
 
     assert resp.status_code == 200
 
 
 def test_admin_user_can_setup_account_for_rdu_user(
-    app, test_app_client, mock_admin_user, mock_create_and_send_activation_email
+    app, test_app_client, mock_logged_in_admin_user, mock_create_and_send_activation_email
 ):
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
     user_details = {"email": "invited_user@somedept.gov.uk", "user_type": TypeOfUser.RDU_USER.name}
 
     resp = test_app_client.post(url_for("admin.add_user"), data=user_details, follow_redirects=True)
@@ -67,19 +59,15 @@ def test_admin_user_can_setup_account_for_rdu_user(
     assert resp.status_code == 200
 
     user = User.query.filter_by(email="invited_user@somedept.gov.uk").one()
-    assert not user.active
-    assert not user.password
-    assert not user.confirmed_at
+    assert user.active is False
+    assert user.password is None
+    assert user.confirmed_at is None
 
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert page.find("title").string == "Users"
 
 
-def test_admin_user_cannot_setup_account_for_user_with_non_gov_uk_email(test_app_client, mock_admin_user):
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
+def test_admin_user_cannot_setup_account_for_user_with_non_gov_uk_email(test_app_client, mock_logged_in_admin_user):
     user_details = {"email": "invited_user@notgovemail.com", "user_type": "INTERNAL_USER"}
     resp = test_app_client.post(url_for("admin.add_user"), data=user_details, follow_redirects=True)
 
@@ -91,102 +79,82 @@ def test_admin_user_cannot_setup_account_for_user_with_non_gov_uk_email(test_app
     assert page.find("title").string == "Error: Add user"
 
 
-def test_admin_user_can_deactivate_user_account(test_app_client, mock_admin_user, db, db_session):
-
-    db.session.add(User(email="someuser@somedept.gov.uk", active=True, user_type=TypeOfUser.RDU_USER))
-    db.session.commit()
-
-    user = User.query.filter_by(email="someuser@somedept.gov.uk").one()
-    assert user.active
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
+def test_admin_user_can_deactivate_user_account(test_app_client, mock_logged_in_admin_user):
+    user = UserFactory(active=True, user_type=TypeOfUser.RDU_USER)
+    assert user.active is True
 
     resp = test_app_client.get(url_for("admin.deactivate_user", user_id=user.id), follow_redirects=True)
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "User account for: someuser@somedept.gov.uk deactivated"
-
-    user = User.query.filter_by(email="someuser@somedept.gov.uk").one()
-    assert not user.active
+    assert page.find("div", class_="alert-box").span.string == f"User account for: {user.email} deactivated"
+    assert user.active is False
 
 
-def test_admin_user_can_grant_or_remove_rdu_user_admin_rights(test_app_client, mock_rdu_user, mock_admin_user):
+def test_admin_user_can_grant_or_remove_rdu_user_admin_rights(test_app_client, mock_logged_in_admin_user):
+    rdu_user = UserFactory(user_type=TypeOfUser.RDU_USER)
+    assert not rdu_user.is_admin_user()
 
-    assert not mock_rdu_user.is_admin_user()
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
-    resp = test_app_client.get(url_for("admin.make_admin_user", user_id=mock_rdu_user.id), follow_redirects=True)
+    resp = test_app_client.get(url_for("admin.make_admin_user", user_id=rdu_user.id), follow_redirects=True)
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "User %s is now an admin user" % mock_rdu_user.email
+    assert page.find("div", class_="alert-box").span.string == "User %s is now an admin user" % rdu_user.email
 
-    assert mock_rdu_user.is_admin_user()
+    assert rdu_user.is_admin_user()
 
-    resp = test_app_client.get(url_for("admin.make_rdu_user", user_id=mock_rdu_user.id), follow_redirects=True)
+    resp = test_app_client.get(url_for("admin.make_rdu_user", user_id=rdu_user.id), follow_redirects=True)
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert (
-        page.find("div", class_="alert-box").span.string == "User %s is now a standard RDU user" % mock_rdu_user.email
-    )
+    assert page.find("div", class_="alert-box").span.string == "User %s is now a standard RDU user" % rdu_user.email
 
-    assert mock_rdu_user.is_rdu_user()
+    assert rdu_user.is_rdu_user()
 
 
-def test_admin_user_cannot_grant_departmental_user_admin_rights(test_app_client, mock_dept_user, mock_admin_user):
+def test_admin_user_cannot_grant_departmental_user_admin_rights(test_app_client, mock_logged_in_admin_user):
+    dept_user = UserFactory(user_type=TypeOfUser.DEPT_USER)
+    assert not dept_user.is_admin_user()
 
-    assert not mock_dept_user.is_admin_user()
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
-    resp = test_app_client.get(url_for("admin.make_admin_user", user_id=mock_dept_user.id), follow_redirects=True)
+    resp = test_app_client.get(url_for("admin.make_admin_user", user_id=dept_user.id), follow_redirects=True)
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert page.find("div", class_="alert-box").span.string == "Only RDU users can be made admin"
 
-    assert not mock_dept_user.is_admin_user()
+    assert not dept_user.is_admin_user()
 
 
-def test_admin_user_cannot_remove_their_own_admin_rights(test_app_client, mock_admin_user):
+def test_admin_user_cannot_remove_their_own_admin_rights(test_app_client, mock_logged_in_admin_user):
+    assert mock_logged_in_admin_user.is_admin_user()
 
-    assert mock_admin_user.is_admin_user()
-
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
-    resp = test_app_client.get(url_for("admin.make_rdu_user", user_id=mock_admin_user.id), follow_redirects=True)
+    resp = test_app_client.get(
+        url_for("admin.make_rdu_user", user_id=mock_logged_in_admin_user.id), follow_redirects=True
+    )
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert page.find("div", class_="alert-box").span.string == "You can't remove your own admin rights"
 
-    assert mock_admin_user.is_admin_user()
+    assert mock_logged_in_admin_user.is_admin_user()
 
 
-def test_admin_user_cannot_add_user_if_case_insensitive_email_in_use(test_app_client, mock_admin_user, mock_rdu_user):
+def test_admin_user_cannot_add_user_if_case_insensitive_email_in_use(test_app_client, mock_logged_in_admin_user):
+    existing_rdu_user = UserFactory(email="existing@rdu.gov.uk", user_type=TypeOfUser.RDU_USER)
+    user_details = {"email": existing_rdu_user.email.upper(), "user_type": TypeOfUser.RDU_USER.name}
 
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_admin_user.id
-
-    user_details = {"email": mock_rdu_user.email.upper(), "user_type": TypeOfUser.RDU_USER.name}
     resp = test_app_client.post(url_for("admin.add_user"), data=user_details, follow_redirects=True)
 
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert (
-        page.find("div", class_="alert-box").text.strip() == "User: %s is already in the system" % mock_rdu_user.email
+        page.find("div", class_="alert-box").text.strip() == f"User: {existing_rdu_user.email} is already in the system"
     )
 
 
-def test_reset_password_rejects_easy_password(app, test_app_client, mock_rdu_user):
+def test_reset_password_rejects_easy_password(app, test_app_client):
+    rdu_user = UserFactory(user_type=TypeOfUser.RDU_USER)
 
-    token = generate_token(mock_rdu_user.email, app)
+    token = generate_token(rdu_user.email, app)
     confirmation_url = url_for("auth.reset_password", token=token, _external=True)
 
     user_details = {"password": "long-enough-but-too-easy", "confirm_password": "long-enough-but-too-easy"}
@@ -196,12 +164,13 @@ def test_reset_password_rejects_easy_password(app, test_app_client, mock_rdu_use
     assert (
         page.find("div", class_="alert-box").text.strip()
         == "Your password is too weak. Use a mix of numbers as well as upper and lowercase letters"
-    )  # noqa
+    )
 
 
-def test_reset_password_accepts_good_password(app, test_app_client, mock_rdu_user):
+def test_reset_password_accepts_good_password(app, test_app_client):
+    rdu_user = UserFactory(user_type=TypeOfUser.RDU_USER)
 
-    token = generate_token(mock_rdu_user.email, app)
+    token = generate_token(rdu_user.email, app)
     confirmation_url = url_for("auth.reset_password", token=token, _external=True)
 
     user_details = {"password": "This sh0uld b3 Ok n0w", "confirm_password": "This sh0uld b3 Ok n0w"}

--- a/tests/application/cms/test_classification_service.py
+++ b/tests/application/cms/test_classification_service.py
@@ -4,40 +4,35 @@ from application.cms.classification_service import ClassificationService
 from application.cms.exceptions import ClassificationNotFoundException
 from application.cms.models import Classification, Ethnicity
 
+from tests.models import ClassificationFactory
+
 classification_service = ClassificationService()
 
 
-def build_a_number_of_ethnicity_clasifications(number):
-    for num in range(number):
-        # Add one to make 1-based classifications
-        classification_service.create_classification(f"C{num+1}", "Subfamily", f"Classification {num+1}")
-
-
-def test_get_classification_by_id_does_return_classification(db_session):
-    # given the london boroughs classifications
-    build_a_number_of_ethnicity_clasifications(2)
+def test_get_classification_by_id_does_return_classification():
+    c1, c2 = ClassificationFactory(id="C1"), ClassificationFactory(id="C2")
 
     # when we get classifications by code using the classification service
     expect_c1 = classification_service.get_classification_by_id("C1")
     expect_c2 = classification_service.get_classification_by_id("C2")
 
     # then we expect to get the correct classifications returned
-    assert expect_c1.title == "Classification 1"
-    assert expect_c2.title == "Classification 2"
+    assert expect_c1 is c1
+    assert expect_c2 is c2
 
 
-def test_create_classification(db_session):
-    assert not Classification.query.all()
-
+def test_create_classification():
     classification = classification_service.create_classification("2B", "", "White and Other")
 
-    assert classification == Classification.query.all()[0]
+    assert classification == Classification.query.get("2B")
 
 
-def test_delete_classification_removes_classification(db_session):
+def test_delete_classification_removes_classification():
     # Given some classifications
-    assert not Classification.query.all()
-    build_a_number_of_ethnicity_clasifications(4)
+    ClassificationFactory(id="C1")
+    ClassificationFactory(id="C2")
+    ClassificationFactory(id="C3")
+    ClassificationFactory(id="C4")
     assert Classification.query.count() == 4
 
     # When we delete a classification
@@ -51,7 +46,7 @@ def test_delete_classification_removes_classification(db_session):
     assert Classification.query.count() == 3
 
 
-def test_create_or_get_value_creates_a_value(db_session):
+def test_create_or_get_value_creates_a_value():
     assert not Ethnicity.query.all()
 
     value = classification_service.get_or_create_value("Purple")
@@ -60,7 +55,7 @@ def test_create_or_get_value_creates_a_value(db_session):
     assert value.value == "Purple"
 
 
-def test_create_or_get_value_recalls_existing_value(db_session):
+def test_create_or_get_value_recalls_existing_value():
     # given a setup with one Ethnicity value
     assert not Ethnicity.query.all()
     value = classification_service.get_or_create_value("Green")
@@ -73,92 +68,107 @@ def test_create_or_get_value_recalls_existing_value(db_session):
     assert Ethnicity.query.count() == 1
 
 
-def test_add_values_to_classification_appends_new_values(db_session):
+def test_add_values_to_classification_appends_new_values():
     # given a setup with two empty classifications
-    build_a_number_of_ethnicity_clasifications(2)
+    c1, c2 = (
+        ClassificationFactory(id="C1", ethnicities=[], parent_values=[]),
+        ClassificationFactory(id="C2", ethnicities=[], parent_values=[]),
+    )
 
-    classification_1 = classification_service.get_classification_by_id("C1")
-    classification_2 = classification_service.get_classification_by_id("C2")
-    assert len(classification_1.ethnicities) == 0
-    assert len(classification_2.ethnicities) == 0
+    assert len(c1.ethnicities) == 0
+    assert len(c2.ethnicities) == 0
 
     # when we add some values to the empty classifications
-    classification_service.add_values_to_classification(classification_1, ["Green", "Red", "Purple"])
-    classification_service.add_values_to_classification(classification_2, ["Red", "Pink"])
+    classification_service.add_values_to_classification(c1, ["Green", "Red", "Purple"])
+    classification_service.add_values_to_classification(c2, ["Red", "Pink"])
 
     # then the values have been added
-    assert len(classification_1.ethnicities) == 3
-    assert len(classification_2.ethnicities) == 2
+    assert len(c1.ethnicities) == 3
+    assert len(c2.ethnicities) == 2
 
     # And all classifications containing a particular value can be found
     red = classification_service.get_or_create_value("Red")
     pink = classification_service.get_or_create_value("Pink")
     assert len(red.classifications) == 2
     assert len(pink.classifications) == 1
-    assert set(red.classifications) == set([classification_1, classification_2])
-    assert pink.classifications == [classification_2]
+    assert set(red.classifications) == set([c1, c2])
+    assert pink.classifications == [c2]
 
 
-def test_remove_value_from_classification_removes_value(db_session):
+def test_remove_value_from_classification_removes_value():
     # given a setup with two classifications with values
-    build_a_number_of_ethnicity_clasifications(2)
-    classification_1 = classification_service.get_classification_by_id("C1")
-    classification_2 = classification_service.get_classification_by_id("C2")
-    classification_service.add_values_to_classification(classification_1, ["Green", "Red", "Purple"])
-    classification_service.add_values_to_classification(classification_2, ["Red", "Pink"])
+    ethnicities = {colour.lower(): Ethnicity(value=colour) for colour in ["Green", "Red", "Purple", "Pink"]}
+    c1, c2 = (
+        ClassificationFactory(
+            id="C1",
+            title="Classification 1",
+            ethnicities=[ethnicities["green"], ethnicities["red"], ethnicities["purple"]],
+            parent_values=[],
+        ),
+        ClassificationFactory(
+            id="C2", title="Classification 2", ethnicities=[ethnicities["red"], ethnicities["pink"]], parent_values=[]
+        ),
+    )
 
     # when we remove a value from one classification that also exisits in the second classification
-    classification_service.remove_value_from_classification(classification_2, "Red")
+    classification_service.remove_value_from_classification(c2, "Red")
 
     # then the value is gone from the specified classification but still exists in the other classification
     red = classification_service.get_value("Red")
     assert len(red.classifications) == 1
-    assert len(classification_1.ethnicities) == 3
-    assert len(classification_2.ethnicities) == 1
+    assert len(c1.ethnicities) == 3
+    assert len(c2.ethnicities) == 1
     assert "Classification 2" not in [c.title for c in red.classifications]
-    assert "Red" not in [c.value for c in classification_2.ethnicities]
-    assert "Red" in [c.value for c in classification_1.ethnicities]
+    assert "Red" not in [c.value for c in c2.ethnicities]
+    assert "Red" in [c.value for c in c1.ethnicities]
 
 
-def test_add_parent_value_to_classification_appends_new_parent(db_session):
+def test_add_parent_value_to_classification_appends_new_parent():
     # given a setup with one classification
-    people = ["Tom", "Frankie", "Caroline", "Adam", "Cath", "Marcus", "Sylvia", "Katerina"]
+    people = [
+        Ethnicity(value=person)
+        for person in ["Tom", "Frankie", "Caroline", "Adam", "Cath", "Marcus", "Sylvia", "Katerina"]
+    ]
 
     # Create classifications (also commits them to the database).
-    classification_service.create_classification_with_values("G1", "Teams", "Race Disparity Unit", values=people)
-
-    rdu_by_tribe = classification_service.create_classification_with_values(
-        "G2", "Teams", "Race Disparity Unit by Tribe", values=people
+    g1 = ClassificationFactory(
+        id="G1", title="Teams", long_title="Race Disparity Unit", ethnicities=people, parent_values=[]
     )
-    rdu_by_gender = classification_service.create_classification_with_values(
-        "G3", "Teams", "Race Disparity Unit by Gender", values=people
+    g2 = ClassificationFactory(
+        id="G2", title="Teams", long_title="Race Disparity Unit by Tribe", ethnicities=people, parent_values=[]
+    )
+    g3 = ClassificationFactory(
+        id="G3", title="Teams", long_title="Race Disparity Unit by Gender", ethnicities=people, parent_values=[]
     )
 
     # when we link to parents
-    classification_service.add_values_to_classification_as_parents(rdu_by_gender, ["Male", "Female"])
-    classification_service.add_values_to_classification_as_parents(rdu_by_tribe, ["Data", "Digital", "Policy"])
+    classification_service.add_values_to_classification_as_parents(g2, ["Data", "Digital", "Policy"])
+    classification_service.add_values_to_classification_as_parents(g3, ["Male", "Female"])
 
     # then
-    standard = classification_service.get_classification_by_id("G1")
-    by_tribe = classification_service.get_classification_by_id("G2")
-    by_gender = classification_service.get_classification_by_id("G3")
-    assert len(standard.parent_values) == 0
-    assert len(by_tribe.parent_values) == 3
-    assert len(by_gender.parent_values) == 2
+    assert len(g1.parent_values) == 0
+    assert len(g2.parent_values) == 3
+    assert len(g3.parent_values) == 2
 
 
-def test_remove_parent_value_from_classification_removes_value(db_session):
+def test_remove_parent_value_from_classification_removes_value():
     # given a setup with one classification
-    people = ["Tom", "Frankie", "Caroline", "Adam", "Cath", "Marcus", "Sylvia", "Katerina"]
-    classification_service.create_classification_with_values(
-        "G2", "Teams", "Race Disparity Unit by Tribe", values=people
+    people = [
+        Ethnicity(value=person)
+        for person in ["Tom", "Frankie", "Caroline", "Adam", "Cath", "Marcus", "Sylvia", "Katerina"]
+    ]
+    g2 = ClassificationFactory(
+        id="G2", title="Teams", long_title="Race Disparity Unit by Tribe", ethnicities=people, parent_values=[]
     )
-    by_tribe = classification_service.get_classification_by_id("G2")
-    classification_service.add_values_to_classification_as_parents(by_tribe, ["Data", "Digital", "Policy"])
 
-    # when
-    classification_service.remove_parent_value_from_classification(by_tribe, "Digital")
+    # when we add some parent values
+    classification_service.add_values_to_classification_as_parents(g2, ["Data", "Digital", "Policy"])
 
-    # then
-    by_tribe = classification_service.get_classification_by_id("G2")
-    assert len(by_tribe.parent_values) == 2
+    # then we have all of those parent values for the classification
+    assert len(g2.parent_values) == 3
+
+    # when we remove one of the parent values
+    classification_service.remove_parent_value_from_classification(g2, "Digital")
+
+    # then we have one fewer parent values for the classification
+    assert len(g2.parent_values) == 2

--- a/tests/application/cms/test_dimension_service.py
+++ b/tests/application/cms/test_dimension_service.py
@@ -1,64 +1,58 @@
-from application.cms.dimension_service import DimensionService
-from application.cms.models import Chart, Dimension, DimensionClassification
-from application import db
 from datetime import datetime
+
+from application import db
+from application.cms.dimension_service import DimensionService
+from application.cms.models import Chart, Dimension
+from tests.models import MeasureVersionFactory, MeasureVersionWithDimensionFactory
 
 dimension_service = DimensionService()
 
 
-def test_create_dimension_on_measure_page(stub_measure_page):
-
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
+def test_create_dimension_on_measure_page():
+    measure_version = MeasureVersionFactory()
+    assert measure_version.dimensions.count() == 0
 
     dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
+        measure_version, title="test-dimension", time_period="time_period", summary="summary"
     )
 
-    db_dimension = Dimension.query.all()[0]
-    assert stub_measure_page.dimensions[0].guid == db_dimension.guid
-    assert stub_measure_page.dimensions[0].title == db_dimension.title
-    assert stub_measure_page.dimensions[0].created_at is not None, "Should have set a creation timestamp"
+    assert measure_version.dimensions.count() == 1
+    assert measure_version.dimensions[0].title == "test-dimension"
+    assert measure_version.dimensions[0].time_period == "time_period"
+    assert measure_version.dimensions[0].summary == "summary"
+    assert measure_version.dimensions[0].created_at is not None, "Should have set a creation timestamp"
 
     assert (
-        datetime.utcnow() - stub_measure_page.dimensions[0].created_at
+        datetime.utcnow() - measure_version.dimensions[0].created_at
     ).seconds < 5, "Creation time should be within the last 5 seconds"
 
     assert (
-        stub_measure_page.dimensions[0].updated_at == stub_measure_page.dimensions[0].created_at
+        measure_version.dimensions[0].updated_at == measure_version.dimensions[0].created_at
     ), "Should have set the updated timestamp to be the same as the creation timestamp"
 
 
-def test_delete_dimension_from_measure_page(stub_measure_page):
+def test_delete_dimension_from_draft_measure_page():
+    measure_version = MeasureVersionWithDimensionFactory(status="DRAFT", dimensions__guid="abc123")
 
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
+    assert measure_version.dimensions.count() == 1
+    assert measure_version.dimensions[0].guid == "abc123"
 
-    dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
+    dimension_service.delete_dimension(measure_version, "abc123")
+
+    assert measure_version.dimensions.count() == 0
+
+
+def test_update_dimension():
+    measure_version = MeasureVersionWithDimensionFactory(
+        dimensions__title="test dimension", dimensions__time_period="time period", dimensions__summary="summary"
     )
-
-    db_dimension = Dimension.query.all()[0]
-    assert stub_measure_page.dimensions[0].guid == db_dimension.guid
-
-    dimension_service.delete_dimension(stub_measure_page, db_dimension.guid)
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-
-def test_update_dimension(stub_measure_page):
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-    dimension = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
-    )
+    dimension = measure_version.dimensions[0]
 
     update_data = {"title": "updated-title", "time_period": "updated_time_period"}
 
     dimension_service.update_dimension(dimension, update_data)
 
-    updated_dimension = stub_measure_page.dimensions[0]
+    updated_dimension = measure_version.dimensions[0]
     assert dimension.guid == updated_dimension.guid
     assert updated_dimension.title == "updated-title"
     assert updated_dimension.time_period == "updated_time_period"
@@ -72,63 +66,52 @@ def test_update_dimension(stub_measure_page):
     ).seconds < 5, "Update time should be within the last 5 seconds"
 
 
-def test_update_dimension_does_not_call_update_dimension_classification_by_default(
-    stub_measure_page, two_classifications_2A_5A
-):
-    # Given a dimension with some metadata
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-    dimension = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
+def test_update_dimension_does_not_call_update_dimension_classification_by_default():
+    measure_version = MeasureVersionWithDimensionFactory(
+        dimensions__title="test-dimension",
+        dimensions__time_period="time_period",
+        dimensions__summary="summary",
+        dimensions__classification_links__includes_parents=False,
+        dimensions__classification_links__includes_all=True,
+        dimensions__classification_links__includes_unknown=True,
+        dimensions__classification_links__classification__id="my-classification",
     )
 
-    # And a classification
-    assert dimension.dimension_classification is None
-    dimension_classification = DimensionClassification()
-    dimension_classification.dimension_guid = dimension.guid
-    dimension_classification.classification_id = "5A"
-    dimension_classification.includes_parents = False
-    dimension_classification.includes_all = True
-    dimension_classification.includes_unknown = True
-    db.session.add(dimension_classification)
-    db.session.commit()
-    assert dimension.dimension_classification is not None
+    dimension = measure_version.dimensions[0]
+    assert measure_version.dimensions.count() == 1
+    assert dimension.title == "test-dimension"
+    assert dimension.time_period == "time_period"
+    assert dimension.summary == "summary"
+    assert dimension.dimension_classification.classification_id == "my-classification"
+    assert dimension.dimension_classification.includes_parents is False
+    assert dimension.dimension_classification.includes_all is True
+    assert dimension.dimension_classification.includes_unknown is True
 
     # When update_dimension() is called without explicitly telling it to reclassify the dimension
     update_data = {"title": "updated-title", "time_period": "updated_time_period"}
     dimension_service.update_dimension(dimension, update_data)
 
     # Then the dimension classification should not have been overwritten/deleted
-    updated_dimension = stub_measure_page.dimensions[0]
-    assert updated_dimension.dimension_classification is not None
-    assert updated_dimension.dimension_classification.classification_id == "5A"
-    assert updated_dimension.dimension_classification.includes_parents is False
-    assert updated_dimension.dimension_classification.includes_all is True
-    assert updated_dimension.dimension_classification.includes_unknown is True
+    assert dimension.title == "updated-title"
+    assert dimension.time_period == "updated_time_period"
+    assert dimension.summary == "summary"
+    assert dimension.dimension_classification.classification_id == "my-classification"
+    assert dimension.dimension_classification.includes_parents is False
+    assert dimension.dimension_classification.includes_all is True
+    assert dimension.dimension_classification.includes_unknown is True
 
 
-def test_update_dimension_does_call_update_dimension_classification_if_told_to(
-    stub_measure_page, two_classifications_2A_5A
-):
-    # Given a dimension with some metadata
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-    dimension = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
+def test_update_dimension_does_call_update_dimension_classification_if_told_to():
+    measure_version = MeasureVersionWithDimensionFactory(
+        dimensions__title="test-dimension",
+        dimensions__time_period="time_period",
+        dimensions__summary="summary",
+        dimensions__dimension_chart=None,
+        dimensions__dimension_table=None,
     )
 
-    # And a classification
-    assert dimension.dimension_classification is None
-    dimension_classification = DimensionClassification()
-    dimension_classification.dimension_guid = dimension.guid
-    dimension_classification.classification_id = "5A"
-    dimension_classification.includes_parents = False
-    dimension_classification.includes_all = True
-    dimension_classification.includes_unknown = True
-    db.session.add(dimension_classification)
-    db.session.commit()
+    dimension = measure_version.dimensions[0]
+    assert measure_version.dimensions.count() == 1
     assert dimension.dimension_classification is not None
 
     # When update_dimension() is called without explicitly telling it to reclassify the dimension
@@ -137,48 +120,35 @@ def test_update_dimension_does_call_update_dimension_classification_if_told_to(
 
     # Then the dimension classification should have been overwritten/deleted
     # (in this case deleted as there is no associated chart or table object)
-    updated_dimension = stub_measure_page.dimensions[0]
-    assert updated_dimension.dimension_classification is None
+    assert dimension.dimension_classification is None
 
 
-def test_add_chart_to_dimension(stub_measure_page):
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-    dimension = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
-    )
-
+def test_add_chart_to_dimension():
+    measure_version = MeasureVersionWithDimensionFactory(dimensions__guid="abc123", dimensions__dimension_chart=None)
+    dimension = measure_version.dimensions[0]
     chart = {"chart_is_just_a": "dictionary"}
 
-    update_data = {"chart": chart}
+    assert dimension.guid == "abc123"
+    assert dimension.chart is None
 
-    dimension_service.update_dimension(dimension, update_data)
+    dimension_service.update_dimension(measure_version.dimensions[0], {"chart": chart})
 
-    updated_dimension = stub_measure_page.dimensions[0]
-    assert dimension.guid == updated_dimension.guid
-    assert updated_dimension.chart
-    assert updated_dimension.chart == chart
+    assert dimension.guid == "abc123"
+    assert dimension.chart == chart
 
 
-def test_add_table_to_dimension(stub_measure_page):
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
-
-    dimension = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension", time_period="time_period", summary="summary"
-    )
-
+def test_add_table_to_dimension():
+    measure_version = MeasureVersionWithDimensionFactory(dimensions__guid="abc123", dimensions__dimension_table=None)
+    dimension = measure_version.dimensions[0]
     table = {"table_is_just_a": "dictionary"}
 
-    update_data = {"table": table}
+    assert dimension.guid == "abc123"
+    assert dimension.table is None
 
-    dimension_service.update_dimension(dimension, update_data)
+    dimension_service.update_dimension(dimension, {"table": table})
 
-    updated_dimension = stub_measure_page.dimensions[0]
-    assert dimension.guid == updated_dimension.guid
-    assert updated_dimension.table
-    assert updated_dimension.table == table
+    assert dimension.guid == "abc123"
+    assert dimension.table == table
 
 
 def test_adding_table_with_data_matching_an_ethnicity_classification(stub_measure_page, two_classifications_2A_5A):
@@ -459,26 +429,26 @@ def test_adding_table_with_custom_data_and_existing_less_detailed_chart(stub_mea
     assert dimension.dimension_classification.includes_unknown is True
 
 
-def test_add_or_update_dimensions_to_measure_page_preserves_order(stub_measure_page):
+def test_add_or_update_dimensions_to_measure_page_preserves_order():
+    measure_version = MeasureVersionFactory()
 
-    assert not Dimension.query.all()
-    assert stub_measure_page.dimensions.count() == 0
+    assert measure_version.dimensions.count() == 0
 
     d1 = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension-1", time_period="time_period", summary="summary"
+        measure_version, title="test-dimension-1", time_period="time_period", summary="summary"
     )
 
     d2 = dimension_service.create_dimension(
-        stub_measure_page, title="test-dimension-2", time_period="time_period", summary="summary"
+        measure_version, title="test-dimension-2", time_period="time_period", summary="summary"
     )
 
-    assert stub_measure_page.dimensions[0].title == d1.title
+    assert measure_version.dimensions[0].title == d1.title
     assert d1.position == 0
-    assert stub_measure_page.dimensions[0].position == d1.position
+    assert measure_version.dimensions[0].position == d1.position
 
-    assert stub_measure_page.dimensions[1].title == "test-dimension-2"
+    assert measure_version.dimensions[1].title == "test-dimension-2"
     assert d2.position == 1
-    assert stub_measure_page.dimensions[1].position == d2.position
+    assert measure_version.dimensions[1].position == d2.position
 
     # after update. positions should not have changed
     dimension_service.update_dimension(d1, {"summary": "updated summary"})

--- a/tests/application/cms/test_page_hierarchy_models.py
+++ b/tests/application/cms/test_page_hierarchy_models.py
@@ -1,25 +1,42 @@
-def test_references_between_subtopic_and_topic(stub_topic, stub_subtopic):
-    assert stub_topic.subtopics == [stub_subtopic]
-    assert stub_subtopic.topic == stub_topic
+from tests.models import TopicFactory, SubtopicFactory, MeasureFactory
 
 
-def test_reference_from_subtopic_to_measures(stub_subtopic, stub_measure_1, stub_measure_2):
+def test_references_between_subtopic_and_topic():
+    topic = TopicFactory()
+    subtopic = SubtopicFactory(topic=topic)
+
+    assert topic.subtopics == [subtopic]
+    assert subtopic.topic == topic
+
+
+def test_reference_from_subtopic_to_measures():
     # Given a subtopic with no measures
-    assert stub_subtopic.measures == []
+    subtopic = SubtopicFactory()
+    assert subtopic.measures == []
+
     # When a subtopic is added to a measure
-    stub_measure_1.subtopics.append(stub_subtopic)
+    measure1 = MeasureFactory(subtopics=[])
+    measure1.subtopics.append(subtopic)
+
     # Then the subtopic has that measure in its measures list
-    assert stub_subtopic.measures == [stub_measure_1]
+    assert subtopic.measures == [measure1]
+
     # When another measure has the same subtopic
-    stub_measure_2.subtopics.append(stub_subtopic)
+    measure2 = MeasureFactory(subtopics=[])
+    measure2.subtopics.append(subtopic)
+
     # Then both measures are in the measures list
-    assert stub_subtopic.measures == [stub_measure_1, stub_measure_2]
+    assert subtopic.measures == [measure1, measure2]
 
 
-def test_reference_from_measure_to_subtopics(stub_subtopic, stub_measure_1, stub_measure_2):
+def test_reference_from_measure_to_subtopics():
     # Given a measure with no subtopic
-    assert stub_measure_1.subtopics == []
+    measure1 = MeasureFactory(subtopics=[])
+    assert measure1.subtopics == []
+
     # When a measure is added to a subtopic
-    stub_subtopic.measures.append(stub_measure_1)
+    subtopic = SubtopicFactory()
+    subtopic.measures.append(measure1)
+
     # Then the measure has that subtopic in its subtopics list
-    assert stub_measure_1.subtopics == [stub_subtopic]
+    assert measure1.subtopics == [subtopic]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ from application.config import TestConfig
 from application.data.standardisers.ethnicity_dictionary_lookup import EthnicityDictionaryLookup
 from application.factory import create_app
 
-from tests.models import MeasureVersionFactory
+from tests.models import MeasureVersionFactory, UserFactory
 from tests.test_data.chart_and_table import simple_table, grouped_table, single_series_bar_chart, multi_series_bar_chart
 from tests.utils import UnmockedRequestException
 
@@ -174,17 +174,35 @@ def mock_rdu_user(db_session):
 
 
 @pytest.fixture(scope="function")
-def mock_logged_in_dept_user(mock_dept_user, test_app_client):
+def mock_logged_in_admin_user(test_app_client):
+    user = UserFactory(user_type=TypeOfUser.ADMIN_USER)
     with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_dept_user.id
-    return mock_dept_user
+        session["user_id"] = user.id
+    return user
 
 
 @pytest.fixture(scope="function")
-def mock_logged_in_rdu_user(mock_rdu_user, test_app_client):
+def mock_logged_in_dept_user(test_app_client):
+    user = UserFactory(user_type=TypeOfUser.DEPT_USER)
     with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_rdu_user.id
-    return mock_rdu_user
+        session["user_id"] = user.id
+    return user
+
+
+@pytest.fixture(scope="function")
+def mock_logged_in_rdu_user(test_app_client):
+    user = UserFactory(user_type=TypeOfUser.RDU_USER)
+    with test_app_client.session_transaction() as session:
+        session["user_id"] = user.id
+    return user
+
+
+@pytest.fixture(scope="function")
+def mock_logged_in_dev_user(test_app_client):
+    user = UserFactory(user_type=TypeOfUser.DEV_USER)
+    with test_app_client.session_transaction() as session:
+        session["user_id"] = user.id
+    return user
 
 
 # To use this fixture pass in a TypeOfUser as request.param

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,520 @@
+"""
+This module exposes a set of factories for generating realistic(ish) instances of our main models to aid with testing.
+All of the models in our application code are likely to have a corresponding factory here, which declares all of the
+same attributes (columns), as well as the most (if not all) of the relationships.
+
+See `tests/README.md` for further information on our use of Factory Boy.
+"""
+
+import itertools
+import random
+
+import factory
+from faker import Faker
+
+from application.auth.models import CAPABILITIES, TypeOfUser, User
+from application.cms.models import (
+    publish_status,
+    Chart,
+    Classification,
+    DataSource,
+    Dimension,
+    DimensionClassification,
+    Ethnicity,
+    FrequencyOfRelease,
+    LowestLevelOfGeography,
+    Measure,
+    MeasureVersion,
+    Organisation,
+    Subtopic,
+    Table,
+    Topic,
+    TypeOfData,
+    TypeOfOrganisation,
+    TypeOfStatistic,
+    UKCountry,
+    Upload,
+)
+from application.utils import generate_review_token
+
+PARENT_AND_CHILD_ETHNICITIES = {
+    "Cat": ["Tabby", "Maine Coon", "Ragdoll", "Scottish Fold", "Siamese", "Persian", "Russian Blue", "Munchkin"],
+    "Dog": ["English Mastiff", "Irish Setter", "Pembroke Welsh Corgi", "Scottish Terrier", "Beagle", "Akita"],
+    "Bird": ["Parrot", "Canary", "Robin", "Cockatiel", "Cockatoo", "Budgie", "Macaw", "Dove", "Pigeon", "Owl"],
+}
+
+
+def _random_combination(from_iterable):
+    return random.choice(list(itertools.combinations(from_iterable, random.randint(1, len(list(from_iterable))))))
+
+
+class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = User
+        exclude = ("_password_to_hash",)
+
+    _password_to_hash = factory.Faker("word")
+
+    id = factory.Sequence(lambda x: x)
+    email = factory.Faker("email")
+    # password = factory.LazyAttribute(lambda o: hash_password(o._password_to_hash))  # Using `hash_password` is SLOW
+    password = factory.LazyAttribute(lambda o: o._password_to_hash)
+    active = factory.Faker("boolean")
+    confirmed_at = factory.Faker("past_date", start_date="-1y")
+    user_type = factory.LazyFunction(lambda: random.choice(list(TypeOfUser)))
+    capabilities = factory.LazyAttribute(lambda o: CAPABILITIES[o.user_type])
+
+
+class FrequencyOfReleaseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = FrequencyOfRelease
+
+    id = factory.Sequence(lambda x: x)
+    description = factory.Faker("text")
+    position = factory.SelfAttribute("id")
+
+
+class LowestLevelOfGeographyFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = LowestLevelOfGeography
+
+    name = factory.Faker("sentence", nb_words=3)
+    description = factory.Faker("sentence", nb_words=6)
+    position = factory.Sequence(lambda x: x)
+
+
+class TypeOfStatisticFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = TypeOfStatistic
+
+    id = factory.Sequence(lambda x: x)
+    internal = factory.Faker("sentence", nb_words=5)
+    external = factory.Faker("sentence", nb_words=5)
+    position = factory.SelfAttribute("id")
+
+
+class OrganisationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Organisation
+
+    id = factory.Sequence(lambda x: x)
+    name = factory.Faker("company")
+    other_names = factory.LazyFunction(lambda: [])
+    abbreviations = factory.LazyFunction(lambda: [])
+    organisation_type = factory.LazyFunction(lambda: random.choice(list(TypeOfOrganisation)))
+
+
+class DataSourceFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = DataSource
+
+    id = factory.Sequence(lambda x: x)
+    title = factory.Faker("sentence", nb_words=5)
+    type_of_data = factory.LazyFunction(lambda: _random_combination(TypeOfData))
+    type_of_statistic_id = factory.SelfAttribute("type_of_statistic.id")
+    publisher_id = factory.SelfAttribute("publisher.id")
+    source_url = factory.Faker("url")
+    publication_date = factory.Faker("past_date", start_date="-30d")
+    note_on_corrections_or_updates = factory.Faker("paragraph", nb_sentences=5)
+    frequency_of_release_id = factory.SelfAttribute("frequency_of_release.id")
+    frequency_of_release_other = factory.Faker("paragraph", nb_sentences=3)
+    purpose = factory.Faker("paragraph", nb_sentences=3)
+
+    # scalar relationships
+    type_of_statistic = factory.SubFactory(TypeOfStatisticFactory)
+    publisher = factory.SubFactory(OrganisationFactory)
+    frequency_of_release = factory.SubFactory(FrequencyOfReleaseFactory)
+
+    # array-based relationships
+    @factory.post_generation
+    def pages(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some pages were passed into the create invocation: eg factory.Create(pages=[page1, page2])
+        if extracted is not None:
+            # Attach those pages to this newly-created instance.
+            for page in extracted:
+                self.pages.append(page)
+
+
+class UploadFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Upload
+
+    guid = factory.Faker("uuid4")
+    title = factory.Faker("sentence", nb_words=5)
+    file_name = factory.Faker("file_path", depth=3)
+    description = factory.Faker("paragraph", nb_sentences=3)
+    size = factory.LazyFunction(lambda: random.randint(0, 100_000))
+
+    measure_version_id = None
+    page_id = None
+    page_version = None
+
+    # array-based relationships
+    @factory.post_generation
+    def page(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            self.page = extracted
+            self.measure_version_id = self.page.id
+            self.page_id = self.page.guid
+            self.page_version = self.page.version
+
+
+class TopicFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Topic
+
+    id = factory.Sequence(lambda x: x)
+    slug = factory.LazyFunction(lambda: "-".join(Faker().words(nb=3)))
+    title = factory.Faker("sentence", nb_words=6)
+    description = factory.Faker("paragraph", nb_sentences=3)
+    additional_description = factory.Faker("paragraph", nb_sentences=5)
+
+    # array-based relationships
+    @factory.post_generation
+    def subtopics(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some subtopics were passed into the create invocation: eg factory.Create(subtopics=[subtopic1, subtopic2])
+        if extracted is not None:
+            # Attach those subtopics to this newly-created instance.
+            for subtopic in extracted:
+                self.subtopics.append(subtopic)
+
+    # NOTE: Not including relationships 'towards' MeasureVersionFactory; see tests/README.md
+
+
+class SubtopicFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Subtopic
+
+    id = factory.Sequence(lambda x: x)
+    slug = factory.LazyFunction(lambda: "-".join(Faker().words(nb=3)))
+    title = factory.Faker("sentence", nb_words=6)
+    position = factory.Sequence(lambda x: x)
+    topic_id = factory.SelfAttribute("topic.id")
+
+    # scalar relationships
+    topic = factory.SubFactory(TopicFactory)
+
+    @factory.post_generation
+    def measures(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted is not None:
+            for measure in extracted:
+                self.measures.append(measure)
+
+    # NOTE: Not including relationships 'towards' MeasureVersionFactory; see tests/README.md
+
+
+class MeasureFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Measure
+
+    id = factory.Sequence(lambda x: x)
+    slug = factory.LazyFunction(lambda: "-".join(Faker().words(nb=3)))
+    position = factory.Sequence(lambda x: x)
+    reference = factory.LazyFunction(lambda: " ".join(Faker().words(nb=3)))
+
+    # array-based relationships
+    @factory.post_generation
+    def subtopics(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some subtopics were passed into the create invocation: eg factory.Create(subtopics=[subtopic1, subtopic2])
+        if extracted is not None:
+            # Attach those subtopics to this newly-created instance.
+            for subtopic in extracted:
+                self.subtopics.append(subtopic)
+
+        # Otherwise, just create an subtopic and attach it.
+        else:
+            self.subtopics = [SubtopicFactory(**kwargs)]
+
+
+class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = MeasureVersion
+        exclude = {"_creator", "_publisher", "_unpublished", "_unpublisher"}
+
+    # Underscored attributes are helpers that assist in the creation of a valid (business-logic-wise) measure version.
+    _creator = factory.SubFactory(UserFactory)
+    _publisher = factory.SubFactory(UserFactory)
+    _unpublished = factory.LazyAttribute(lambda o: o.status == "UNPUBLISHED")
+    _unpublisher = factory.Maybe("_unpublished", yes_declaration=factory.SubFactory(UserFactory))
+
+    # columns
+    id = factory.Sequence(lambda x: x)
+    measure_id = factory.SelfAttribute("measure.id")
+    guid = factory.Faker("uuid4")
+    version = factory.LazyFunction(lambda: "1.0")
+    internal_reference = factory.Faker("sentence", nb_words=3)
+    latest = True  # TODO: Add smarter logic
+    slug = factory.LazyFunction(lambda: "-".join(Faker().words(nb=3)))
+    review_token = factory.LazyAttribute(
+        lambda o: generate_review_token(o.guid, o.version)
+        if publish_status[o.status] >= publish_status["DEPARTMENT_REVIEW"]
+        else None
+    )
+    description = factory.Faker("paragraph", nb_sentences=3)
+    additional_description = factory.Faker("paragraph", nb_sentences=5)
+    page_type = factory.LazyFunction(lambda: "measure")
+    position = factory.Sequence(lambda x: x)
+    status = factory.LazyFunction(lambda: random.choice([status for status in publish_status.keys()]))
+    created_at = factory.Faker("date_between", start_date="-30d", end_date="-7d")
+    created_by = factory.SelfAttribute("_creator.email")
+    updated_at = factory.Faker("past_date", start_date="-7d")
+    last_updated_by = factory.SelfAttribute("_creator.email")
+    published = factory.LazyAttribute(lambda o: True if o.status == "APPROVED" else False)
+    published_at = factory.Maybe("published", yes_declaration=factory.Faker("past_date", start_date="-7d"))
+    published_by = factory.Maybe("published", yes_declaration=factory.SelfAttribute("_publisher.email"))
+    unpublished_at = factory.Maybe("_unpublished", yes_declaration=Faker().past_date(start_date="-7d"))
+    unpublished_by = factory.Maybe("_unpublished", yes_declaration=factory.SelfAttribute("_unpublisher.email"))
+    # unsupported: old way of doing things
+    # parent_id = db.Column(db.Integer)
+    # parent_guid = db.Column(db.String(255))
+    # parent_version = db.Column(db.String())
+    db_version_id = factory.Sequence(lambda x: x)
+    title = factory.Faker("sentence", nb_words=6)
+    summary = factory.Faker("sentence", nb_words=10)
+    need_to_know = factory.Faker("paragraph", nb_sentences=3)
+    measure_summary = factory.Faker("paragraph", nb_sentences=3)
+    ethnicity_definition_summary = factory.Faker("paragraph", nb_sentences=3)
+    area_covered = factory.LazyFunction(lambda: _random_combination(UKCountry))
+    time_covered = factory.Faker("paragraph", nb_sentences=3)
+    external_edit_summary = factory.Faker("sentence", nb_words=10)
+    internal_edit_summary = factory.Faker("sentence", nb_words=10)
+    lowest_level_of_geography_id = factory.SelfAttribute("lowest_level_of_geography.name")
+    methodology = factory.Faker("paragraph", nb_sentences=3)
+    suppression_and_disclosure = factory.Faker("paragraph", nb_sentences=3)
+    estimation = factory.Faker("paragraph", nb_sentences=3)
+    related_publications = factory.Faker("paragraph", nb_sentences=3)
+    qmi_url = factory.Faker("paragraph", nb_sentences=3)
+    further_technical_information = factory.Faker("paragraph", nb_sentences=3)
+
+    # scalar relationships
+    measure = factory.SubFactory(MeasureFactory)
+    lowest_level_of_geography = factory.SubFactory(LowestLevelOfGeographyFactory)
+
+    # one-to-many relatioships
+    @factory.post_generation
+    def uploads(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some uploads were passed into the create invocation: eg factory.Create(uploads=[upload1, upload2])
+        if extracted:
+            # Attach those uploads to this newly-created instance.
+            for upload in extracted:
+                self.uploads.append(upload)
+
+        else:
+            UploadFactory(page=self, **kwargs)
+
+    # By default, do not create any dimensions. See alternative factory, `MeasureVersionWithDimensionFactory`
+    dimensions = factory.LazyFunction(lambda: [])
+
+
+class MeasureVersionWithDimensionFactory(MeasureVersionFactory):
+    @factory.post_generation
+    def dimensions(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some dimensions were passed into the create invocation:
+        #   eg factory.Create(dimensions=[dimension1, dimension2])
+        if extracted is not None:
+            # Attach those dimensions to this newly-created instance.
+            for dimension in extracted:
+                self.dimensions.append(dimension)
+
+        else:
+            # self.dimensions.append(DimensionFactory(page=self, **kwargs))
+            DimensionFactory(page=self, **kwargs)
+
+
+class EthnicityFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Ethnicity
+
+    id = factory.Sequence(lambda x: x)
+    value = factory.Iterator([child for children in PARENT_AND_CHILD_ETHNICITIES.values() for child in children])
+    position = factory.SelfAttribute("id")
+
+
+class ClassificationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Classification
+        exclude = ("_parent_child_ethnicities",)
+
+    _parent_child_ethnicities = factory.LazyFunction(
+        lambda: {
+            k: _random_combination(PARENT_AND_CHILD_ETHNICITIES[k])
+            for k in _random_combination(PARENT_AND_CHILD_ETHNICITIES.keys())
+        }
+    )
+
+    id = factory.Sequence(lambda x: str(x))
+    title = factory.Faker("sentence", nb_words=5)
+    long_title = factory.Faker("sentence", nb_words=10)
+    subfamily = factory.Faker("word")
+    position = factory.Sequence(lambda x: x)
+
+    # array-based relationships
+    @factory.lazy_attribute
+    def parent_values(self):
+        parent_values = []
+
+        for i, parent in enumerate(self._parent_child_ethnicities.keys()):
+            parent_values.append(EthnicityFactory(value=parent, position=i * 1000))
+
+        return parent_values
+
+    @factory.lazy_attribute
+    def ethnicities(self):
+        ethnicities = []
+
+        for i, children in enumerate(self._parent_child_ethnicities.values()):
+            for j, child in enumerate(children, start=1):
+                ethnicities.append(EthnicityFactory(value=child, position=(i * 1000) + j))
+
+        return ethnicities
+
+
+class DimensionClassificationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = DimensionClassification
+
+    # columns
+    dimension_guid = factory.SelfAttribute("dimension.guid")
+    classification_id = factory.SelfAttribute("classification.id")
+
+    includes_parents = factory.Faker("boolean")
+    includes_all = factory.Faker("boolean")
+    includes_unknown = factory.Faker("boolean")
+
+    classification = factory.SubFactory(ClassificationFactory)
+    dimension = factory.SubFactory("tests.models.DimensionFactory")
+
+    # NOTE: Not including relationships 'towards' MeasureVersionFactory; see tests/README.md
+
+
+class _ChartAndTableFactoryMixin(factory.alchemy.SQLAlchemyModelFactory):
+    id = factory.Sequence(lambda x: x)
+    classification_id = factory.SelfAttribute("classification.id")
+    includes_parents = factory.Faker("boolean")
+    includes_all = factory.Faker("boolean")
+    includes_unknown = factory.Faker("boolean")
+
+    # scalar relationships
+    classification = factory.SubFactory(ClassificationFactory)
+
+
+class ChartFactory(_ChartAndTableFactoryMixin):
+    class Meta:
+        model = Chart
+
+
+class TableFactory(_ChartAndTableFactoryMixin):
+    class Meta:
+        model = Table
+
+
+class DimensionFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """
+    TODO: Needs further work around generating chart/table highcharts and source data (maybe).
+    """
+
+    class Meta:
+        model = Dimension
+
+    guid = factory.Faker("uuid4")
+    title = factory.Faker("sentence", nb_words=5)
+    time_period = "2018/19"  # questionable
+    summary = factory.Faker("sentence", nb_words=10)
+
+    created_at = factory.Faker("past_date", start_date="-30d")
+    updated_at = factory.Faker("past_date", start_date="-7d")
+
+    # Too hard to realistically generate valid highcharts chart/table data, so leave these blank by default.
+    # If tests need them ... DIY.
+    chart = None
+    table = None
+    chart_builder_version = 2
+    chart_source_data = None
+    chart_2_source_data = None
+
+    table_source_data = {}
+    table_builder_version = 2
+    table_2_source_data = {}
+
+    measure_version_id = None  # Configured via `page` post_generation attribute
+    page_id = None  # Configured via `page` post_generation attribute
+    page_version = None  # Configured via `page` post_generation attribute
+
+    position = factory.Sequence(lambda x: x)
+
+    chart_id = factory.Maybe("dimension_chart", factory.SelfAttribute("dimension_chart.id"))
+    table_id = factory.Maybe("dimension_table", factory.SelfAttribute("dimension_table.id"))
+
+    # scalar relationships
+    dimension_chart = factory.SubFactory(ChartFactory)
+    dimension_table = factory.SubFactory(TableFactory)
+
+    # array-based relationships
+    @factory.post_generation
+    def page(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            self.page = extracted
+            self.measure_version_id = self.page.id
+            self.page_id = self.page.guid
+            self.page_version = self.page.version
+
+        else:
+            self.page = MeasureVersionFactory(dimensions=[self])
+            self.measure_version_id = self.page.id
+            self.page_id = self.page.guid
+            self.page_version = self.page.version
+
+    @factory.post_generation
+    def classification_links(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        # If some classification_links were passed into the create invocation:
+        #   eg factory.Create(classification_links=[classification_link1, classification_link2])
+        if extracted is not None:
+            # Attach those classification_links to this newly-created instance.
+            for classification_link in extracted:
+                self.classification_links.append(classification_link)
+
+        else:
+            self.classification_links = [DimensionClassificationFactory(dimension=self, **kwargs)]
+
+    # NOTE: Not including relationships 'towards' MeasureVersionFactory; see tests/README.md
+
+
+def __get_all_subclasses(cls):
+    all_subclasses = []
+
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(__get_all_subclasses(subclass))
+
+    return all_subclasses
+
+
+ALL_FACTORIES = __get_all_subclasses(factory.alchemy.SQLAlchemyModelFactory)
+__all__ = [factory.__name__ for factory in ALL_FACTORIES]


### PR DESCRIPTION
## Summary
This PR adds [Factory Boy](https://factoryboy.readthedocs.io/en/latest/introduction.html) to our test suite, which is a tool for generating random but realistic instances of models to test against. This would in theory replace our extensive use of fixtures, which feel fairly difficult to reason about and result in making assertions against data specified in fixtures within tests, which is perhaps not best practice.

Factory Boy intends to simplify the process of creating test models. You can specify just the fields you're interested in, and everything else required to create a valid instance will be generated by the factory. The factory also handles creating required relationships, such as Measure/Subtopic/Topic/etc in the case of a MeasureVersion.

`tests/README.md` has been updated to explain our usage of Factory Boy, and in the effort of not repeating myself I would recommend reading that first to understand the principles I've taken in implementing Factory Boy for our tests.

I've updated a number of our tests to use Factory Boy rather than our fixtures as an example of how it might look/be used. Some tests can't be updated yet as the factories that I've written use the new data model, while some tests still require the old data model.