### PR TITLE
Only check user.can(...) if user is logged in

### DIFF
--- a/application/review/views.py
+++ b/application/review/views.py
@@ -26,6 +26,9 @@ def review_page(review_token):
             subtopic_slug=measure_version.measure.subtopic.slug,
             measure_version=measure_version,
             dimensions=dimensions,
+            versions=measure_version.previous_major_versions,
+            first_published_date=measure_version.first_published_date,
+            edit_history=measure_version.previous_minor_versions,
             preview=True,
         )
 

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -12,7 +12,7 @@
             {% if not current_user.is_anonymous and not preview %}
               <span><a href="{{ url_for('static_site.topic', topic_slug='testing-space') }}">Testing space</a></span>
 
-              {% if current_user.can(MANAGE_USERS) %}
+              {% if current_user.is_authenticated and current_user.can(MANAGE_USERS) %}
                 <span><a href="{{ url_for('admin.index') }}">Admin</a></span>
               {% endif %}
             {% endif %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -74,7 +74,7 @@
           {% if measure_version.latest %}
 
             {% if measure_version.status == 'APPROVED' %}
-              {% if current_user.can(CREATE_VERSION) %}
+              {% if current_user.is_authenticated and current_user.can(CREATE_VERSION) %}
                 <a class="button" href="{{ url_for('cms.new_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.slug, version=measure_version.version) }}">
                   Update
                 </a>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -36,7 +36,7 @@
                           version=version) }}"/>
 
 
-  {% if not static_mode %}
+  {% if not static_mode and not preview %}
     {% call status_banner(sticky=False) %}
       <div class="version-info left">
           <span class="info">Version&nbsp;<b>{% if new %}1.0{% else %}{{ measure_version.version }}{% endif %}</b></span>

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -31,7 +31,7 @@
                 <div class="accordion">
                     <div class="container">
                         {% for subtopic in (subtopics|selectattr('has_published_measures') if static_mode else subtopics) %}
-                            {% if measures_by_subtopic[subtopic.id]|length > 0 or current_user.can(CREATE_MEASURE) %}
+                            {% if measures_by_subtopic[subtopic.id]|length > 0 or (current_user.is_authenticated and current_user.can(CREATE_MEASURE)) %}
                                 <div class="accordion-section">
                                     <div class="accordion-section-header" data-on="click" data-event-category="Accordion" data-event-action="Section opened" data-event-label="{{ subtopic.title }}" >
                                         <h2 class="heading-medium">
@@ -40,7 +40,7 @@
                                     </div>
                                     <div class="accordion-section-body {% if not static_mode %}eff-!-padding-bottom-40{% endif %}">
                                         {% if not static_mode %}
-                                            {% if current_user.can(CREATE_MEASURE) %}
+                                            {% if current_user.is_authenticated and current_user.can(CREATE_MEASURE) %}
                                                 <p class="button-container"><a href="{{ url_for('cms.create_measure', topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}" class="button">Create a new page</a></p>
                                             {% endif %}
                                         {% endif %}
@@ -80,7 +80,7 @@
     {% block bodyEnd %}
         {{ super( )}}
 
-        {% if not static_mode and current_user.can(ORDER_MEASURES) %}
+        {% if not static_mode and current_user.is_authenticated and current_user.can(ORDER_MEASURES) %}
 
         <script type="text/javascript">
 

--- a/tests/application/review/test_views.py
+++ b/tests/application/review/test_views.py
@@ -1,44 +1,36 @@
 import pytest
-import uuid
 
 from bs4 import BeautifulSoup
 from flask import url_for
 from itsdangerous import SignatureExpired, BadSignature
 
-from application.cms.models import Upload
-from application.cms.new_page_service import new_page_service
 from application.utils import decode_review_token
+from tests.models import MeasureVersionFactory, MeasureVersionWithDimensionFactory
 
 
-def test_review_link_returns_page(test_app_client, mock_rdu_user, stub_measure_page):
+def test_review_link_returns_page(test_app_client):
 
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_rdu_user.id
-
-    assert stub_measure_page.status == "DRAFT"
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    assert stub_measure_page.status == "DEPARTMENT_REVIEW"
-
-    resp = test_app_client.get(url_for("review.review_page", review_token=stub_measure_page.review_token))
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
+    resp = test_app_client.get(url_for("review.review_page", review_token=measure_version.review_token))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("h1").text.strip() == stub_measure_page.title
+    assert page.find("h1").text.strip() == measure_version.title
 
 
-def test_review_link_returns_404_if_token_incomplete(test_app_client, mock_rdu_user, stub_measure_page):
+def test_review_page_does_not_include_status_bar(test_app_client):
 
-    with test_app_client.session_transaction() as session:
-        session["user_id"] = mock_rdu_user.id
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
+    resp = test_app_client.get(url_for("review.review_page", review_token=measure_version.review_token))
 
-    assert stub_measure_page.status == "DRAFT"
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    assert stub_measure_page.status == "DEPARTMENT_REVIEW"
+    page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+    assert not page.find("div", class_="status")
 
-    broken_token = stub_measure_page.review_token.replace(".", " ")
 
+def test_review_link_returns_404_if_token_incomplete(test_app_client):
+
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
+    broken_token = measure_version.review_token.replace(".", " ")
     resp = test_app_client.get(url_for("review.review_page", review_token=broken_token))
 
     assert resp.status_code == 404
@@ -50,47 +42,37 @@ def test_review_link_returns_404_if_token_incomplete(test_app_client, mock_rdu_u
     assert resp.status_code == 404
 
 
-def test_review_token_decoded_if_not_expired(app, mock_rdu_user, stub_measure_page):
+def test_review_token_decoded_if_not_expired(app):
 
-    assert stub_measure_page.status == "DRAFT"
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    assert stub_measure_page.status == "DEPARTMENT_REVIEW"
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW", guid="test-measure-page")
 
     expires_tomorrow = 1
-    slug, version = decode_review_token(
-        stub_measure_page.review_token,
+    decoded_guid, decoded_version = decode_review_token(
+        measure_version.review_token,
         {"SECRET_KEY": app.config["SECRET_KEY"], "PREVIEW_TOKEN_MAX_AGE_DAYS": expires_tomorrow},
     )
 
-    assert slug == stub_measure_page.slug
-    assert version == stub_measure_page.version
+    assert decoded_guid == measure_version.guid
+    assert decoded_version == measure_version.version
 
 
-def test_review_token_expired_throws_signature_expired(app, mock_rdu_user, stub_measure_page):
+def test_review_token_expired_throws_signature_expired(app):
 
-    assert stub_measure_page.status == "DRAFT"
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    assert stub_measure_page.status == "DEPARTMENT_REVIEW"
-
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
     expired_yesterday = -1
 
     with pytest.raises(SignatureExpired):
         decode_review_token(
-            stub_measure_page.review_token,
+            measure_version.review_token,
             {"SECRET_KEY": app.config["SECRET_KEY"], "PREVIEW_TOKEN_MAX_AGE_DAYS": expired_yesterday},
         )
 
 
-def test_review_token_messed_up_throws_bad_signature(app, mock_rdu_user, stub_measure_page):
+def test_review_token_messed_up_throws_bad_signature(app):
 
-    assert stub_measure_page.status == "DRAFT"
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    new_page_service.move_measure_version_to_next_state(stub_measure_page, mock_rdu_user.email)
-    assert stub_measure_page.status == "DEPARTMENT_REVIEW"
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
 
-    broken_token = stub_measure_page.review_token.replace(".", " ")
+    broken_token = measure_version.review_token.replace(".", " ")
 
     expires_tomorrow = 1
 
@@ -108,42 +90,43 @@ def test_review_token_messed_up_throws_bad_signature(app, mock_rdu_user, stub_me
 
 
 def test_page_main_download_available_without_login(
-    db_session, test_app_client, stub_measure_page, mock_get_measure_download, mock_get_csv_data_for_download
+    test_app_client, mock_get_measure_download, mock_get_csv_data_for_download
 ):
-    upload = Upload(guid=str(uuid.uuid4()), title="test file", file_name="test-file.csv")
-    stub_measure_page.uploads = [upload]
-
-    db_session.session.commit()
+    measure_version = MeasureVersionFactory(
+        status="DEPARTMENT_REVIEW", uploads__title="test file", uploads__file_name="test-file.csv"
+    )
 
     resp = test_app_client.get(
         url_for(
             "static_site.measure_version_file_download",
-            topic_slug=stub_measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=stub_measure_page.measure.subtopic.slug,
-            measure_slug=stub_measure_page.slug,
-            version=stub_measure_page.version,
-            filename=stub_measure_page.uploads[0].file_name,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
+            filename=measure_version.uploads[0].file_name,
         )
     )
 
-    mock_get_measure_download.assert_called_with(upload, upload.file_name, "source")
-    mock_get_csv_data_for_download.assert_called_with(upload.file_name)
+    mock_get_measure_download.assert_called_with(measure_version.uploads[0], "test-file.csv", "source")
+    mock_get_csv_data_for_download.assert_called_with("test-file.csv")
 
     assert resp.status_code == 200
     assert resp.content_type == "text/csv; charset=utf-8"
-    assert resp.headers["Content-Disposition"] == "attachment; filename=%s" % upload.file_name
+    assert resp.headers["Content-Disposition"] == "attachment; filename=test-file.csv"
 
 
-def test_page_dimension_download_available_without_login(test_app_client, mock_rdu_user, stub_page_with_dimension):
+def test_page_dimension_download_available_without_login(test_app_client):
+
+    measure_version = MeasureVersionWithDimensionFactory(dimensions__title="stub dimension")
 
     resp = test_app_client.get(
         url_for(
             "static_site.dimension_file_download",
-            topic_slug=stub_page_with_dimension.measure.subtopic.topic.slug,
-            subtopic_slug=stub_page_with_dimension.measure.subtopic.slug,
-            measure_slug=stub_page_with_dimension.slug,
-            version=stub_page_with_dimension.version,
-            dimension_guid=stub_page_with_dimension.dimensions[0].guid,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
+            dimension_guid=measure_version.dimensions[0].guid,
         )
     )
 

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -388,6 +388,9 @@ def test_view_measure_page(test_app_client, mock_rdu_user, stub_topic_page, stub
 
     assert page.h1.text.strip() == stub_measure_page.title
 
+    # check that the status bar is shown
+    assert page.find("div", class_="status")
+
     # check metadata
     metadata_titles = page.find("div", class_="metadata").find_all("dt")
     assert len(metadata_titles) == 5


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/qHTB0l6X/1296-bug-review-links-broken-for-anonymous-not-logged-in-users

These templates can in rare circumstances be rendered when there is no
logged in user (e.g. user using a review link for a page that has sice been published).

Changes here defensively check that there is a logged-in user before
testing the user's permissions.

The second commit here hides the "Status" bar from measure pages when acessed via a `/review` link, so that the page being reviewed looks like the published page will.