### PR TITLE
Update materialized views

### DIFF
--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -137,16 +137,13 @@ def get_ethnic_group_by_slug_dashboard_data(ethnic_group_slug):
 
     ethnic_group_title = ""
     page_count = 0
-    nested_measures_and_dimensions = {}
+    nested_measures_and_dimensions = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list))))
+
     if ethnicity:
         ethnic_group_title = ethnicity.value
         from application.dashboard.models import EthnicGroupByDimension
 
         dimension_links = EthnicGroupByDimension.query.filter_by(ethnicity_value=ethnicity.value).all()
-
-        nested_measures_and_dimensions = defaultdict(
-            lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-        )
 
         for link in sorted(
             dimension_links,

--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -115,19 +115,19 @@ def get_ethnic_groups_dashboard_data():
                 "value": link.ethnicity_value,
                 "position": link.ethnicity_position,
                 "url": url_for("dashboards.ethnic_group", value_slug=slugify(link.ethnicity_value)),
-                "measure_ids": {link.measure_id},  # temporary list to allow calculating `count_measures` later
-                "count_measures": 0,  # calculated afterwards using `measure_ids`
-                "count_dimensions": 1,
+                "measure_ids": {link.measure_id},  # temporary list to allow calculating `measure_count` later
+                "measure_count": 0,  # calculated afterwards using `measure_ids`
+                "dimension_count": 1,
                 "classifications": {link.classification_title},
             }
         else:
             ethnicities[link.ethnicity_value]["measure_ids"].add(link.measure_id)
-            ethnicities[link.ethnicity_value]["count_dimensions"] += 1
+            ethnicities[link.ethnicity_value]["dimension_count"] += 1
             ethnicities[link.ethnicity_value]["classifications"].add(link.classification_title)
 
     # Count the number of distinct measures for each ethnic group
     for ethnic_group in ethnicities.values():
-        ethnic_group["count_measures"] = len(ethnic_group.pop("measure_ids"))
+        ethnic_group["measure_count"] = len(ethnic_group.pop("measure_ids"))
 
     return ethnicities.values()
 

--- a/application/dashboard/models.py
+++ b/application/dashboard/models.py
@@ -30,24 +30,29 @@ class LatestPublishedMeasureVersionByGeography(db.Model):
 
 
 class EthnicGroupByDimension(db.Model):
-    __tablename__ = "ethnic_groups_by_dimension"
+    __tablename__ = "new_ethnic_groups_by_dimension"
 
-    subtopic_guid = db.Column("subtopic_guid", db.String())
-    page_guid = db.Column("page_guid", db.String())
-    page_title = db.Column("page_title", db.String())
-    page_version = db.Column("page_version", db.String())
-    page_status = db.Column("page_status", db.String())
-    page_publication_date = db.Column("page_publication_date", db.Date())
-    page_slug = db.Column("page_slug", db.String())
-    page_position = db.Column("page_position", db.Integer())
+    topic_title = db.Column("topic_title", db.String())
+    topic_slug = db.Column("topic_slug", db.String())
+    subtopic_title = db.Column("subtopic_title", db.String())
+    subtopic_slug = db.Column("subtopic_slug", db.String())
+    subtopic_position = db.Column("subtopic_position", db.Integer())
+    measure_id = db.Column("measure_id", db.Integer())
+    measure_slug = db.Column("measure_slug", db.String())
+    measure_position = db.Column("measure_position", db.Integer())
+    measure_version_id = db.Column("measure_version_id", db.Integer())
+    measure_version_title = db.Column("measure_version_title", db.String())
     dimension_guid = db.Column("dimension_guid", db.String())
     dimension_title = db.Column("dimension_title", db.String())
     dimension_position = db.Column("dimension_position", db.Integer())
-    categorisation = db.Column("categorisation", db.String())
-    value = db.Column("value", db.String())
-    value_position = db.Column("value_position", db.Integer())
+    classification_title = db.Column("classification_title", db.String())
+    ethnicity_value = db.Column("ethnicity_value", db.String())
+    ethnicity_position = db.Column("ethnicity_position", db.Integer())
 
-    __table_args__ = (PrimaryKeyConstraint("dimension_guid", "value", name="ethnic_groups_by_dimension_value_pk"), {})
+    __table_args__ = (
+        PrimaryKeyConstraint("dimension_guid", "ethnicity_value", name="ethnic_groups_by_dimension_value_pk"),
+        {},
+    )
 
 
 class CategorisationByDimension(db.Model):

--- a/application/dashboard/models.py
+++ b/application/dashboard/models.py
@@ -11,21 +11,22 @@ from sqlalchemy import PrimaryKeyConstraint
 from application import db
 
 
-class PageByLowestLevelOfGeography(db.Model):
-    __tablename__ = "pages_by_geography"
+class LatestPublishedMeasureVersionByGeography(db.Model):
+    __tablename__ = "new_latest_published_measure_versions_by_geography"
 
-    subtopic_guid = db.Column("subtopic_guid", db.String())
-    page_guid = db.Column("page_guid", db.String())
-    page_title = db.Column("page_title", db.String())
-    page_version = db.Column("page_version", db.String())
-    page_slug = db.Column("page_slug", db.String())
-    page_position = db.Column("page_position", db.Integer())
-
+    topic_title = db.Column("topic_title", db.String())
+    topic_slug = db.Column("topic_slug", db.String())
+    subtopic_title = db.Column("subtopic_title", db.String())
+    subtopic_slug = db.Column("subtopic_slug", db.String())
+    subtopic_position = db.Column("subtopic_position", db.Integer())
+    measure_slug = db.Column("measure_slug", db.String())
+    measure_position = db.Column("measure_position", db.Integer())
+    measure_version_id = db.Column("measure_version_id", db.Integer())
+    measure_version_title = db.Column("measure_version_title", db.String())
     geography_name = db.Column("geography_name", db.String())
-    geography_description = db.Column("geography_description", db.String())
     geography_position = db.Column("geography_position", db.Integer())
 
-    __table_args__ = (PrimaryKeyConstraint("page_guid"), {})
+    __table_args__ = (PrimaryKeyConstraint("measure_version_id"),)
 
 
 class EthnicGroupByDimension(db.Model):

--- a/application/dashboard/models.py
+++ b/application/dashboard/models.py
@@ -51,30 +51,32 @@ class EthnicGroupByDimension(db.Model):
 
     __table_args__ = (
         PrimaryKeyConstraint("dimension_guid", "ethnicity_value", name="ethnic_groups_by_dimension_value_pk"),
-        {},
     )
 
 
-class CategorisationByDimension(db.Model):
-    __tablename__ = "categorisations_by_dimension"
+class ClassificationByDimension(db.Model):
+    __tablename__ = "new_classifications_by_dimension"
 
-    subtopic_guid = db.Column("subtopic_guid", db.String())
-    page_guid = db.Column("page_guid", db.String())
-    page_title = db.Column("page_title", db.String())
-    page_version = db.Column("page_version", db.String())
-    page_slug = db.Column("page_slug", db.String())
-    page_position = db.Column("page_position", db.Integer())
+    topic_title = db.Column("topic_title", db.String())
+    topic_slug = db.Column("topic_slug", db.String())
+    subtopic_title = db.Column("subtopic_title", db.String())
+    subtopic_slug = db.Column("subtopic_slug", db.String())
+    subtopic_position = db.Column("subtopic_position", db.Integer())
+    measure_id = db.Column("measure_id", db.Integer())
+    measure_slug = db.Column("measure_slug", db.String())
+    measure_position = db.Column("measure_position", db.Integer())
+    measure_version_id = db.Column("measure_version_id", db.Integer())
+    measure_version_title = db.Column("measure_version_title", db.String())
     dimension_guid = db.Column("dimension_guid", db.String())
     dimension_title = db.Column("dimension_title", db.String())
     dimension_position = db.Column("dimension_position", db.Integer())
-    categorisation_id = db.Column("categorisation_id", db.Integer())
-    categorisation = db.Column("categorisation", db.String())
-    categorisation_position = db.Column("categorisation_position", db.Integer())
+    classification_id = db.Column("classification_id", db.Integer())
+    classification_title = db.Column("classification_title", db.String())
+    classification_position = db.Column("classification_position", db.Integer())
     includes_parents = db.Column("includes_parents", db.Boolean())
     includes_all = db.Column("includes_all", db.Boolean())
     includes_unknown = db.Column("includes_unknown", db.Boolean())
 
     __table_args__ = (
-        PrimaryKeyConstraint("dimension_guid", "categorisation_id", name="categorisation_by_dimension_value_pk"),
-        {},
+        PrimaryKeyConstraint("dimension_guid", "classification_id", name="classification_by_dimension_value_pk"),
     )

--- a/application/dashboard/view_sql.py
+++ b/application/dashboard/view_sql.py
@@ -6,14 +6,14 @@ drop_all_dashboard_helper_views = """
     DROP MATERIALIZED VIEW IF EXISTS new_latest_published_measure_versions_by_geography CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS latest_published_measure_versions CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS new_ethnic_groups_by_dimension CASCADE;
-    DROP MATERIALIZED VIEW IF EXISTS categorisations_by_dimension CASCADE;
+    DROP MATERIALIZED VIEW IF EXISTS new_classifications_by_dimension CASCADE;
 """
 
 refresh_all_dashboard_helper_views = """
     REFRESH MATERIALIZED VIEW CONCURRENTLY latest_published_measure_versions;
     REFRESH MATERIALIZED VIEW CONCURRENTLY new_latest_published_measure_versions_by_geography;
     REFRESH MATERIALIZED VIEW CONCURRENTLY new_ethnic_groups_by_dimension;
-    REFRESH MATERIALIZED VIEW CONCURRENTLY categorisations_by_dimension;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY classifications_by_dimension;
 """
 
 latest_published_measure_versions_view = """
@@ -97,72 +97,63 @@ CREATE MATERIALIZED VIEW new_ethnic_groups_by_dimension AS
       (
          (
          SELECT
-            topic.title AS topic_title, topic.slug AS topic_slug, subtopic.title AS subtopic_title, subtopic.slug AS subtopic_slug, subtopic.position AS subtopic_position, measure.id AS measure_id, measure.slug AS measure_slug, measure.position AS measure_position, latest_published_measure_versions.id AS measure_version_id, latest_published_measure_versions.title AS measure_version_title, dimension.guid AS dimension_guid, dimension.title AS dimension_title, dimension.position AS dimension_position, classification.title AS classification_title, ethnicity.value AS ethnicity_value, ethnicity.position AS ethnicity_position
-         FROM
-            latest_published_measure_versions
-            JOIN
-               measure
-               ON latest_published_measure_versions.measure_id = measure.id
-            JOIN
-               subtopic_measure
-               ON measure.id = subtopic_measure.measure_id
-            JOIN
-               subtopic
-               ON subtopic_measure.subtopic_id = subtopic.id
-            JOIN
-               topic
-               ON subtopic.topic_id = topic.id
-            JOIN
-               dimension
-               ON dimension.measure_version_id = latest_published_measure_versions.id
-            JOIN
-               dimension_categorisation
-               ON dimension.guid = dimension_categorisation.dimension_guid
-            JOIN
-               classification
-               ON dimension_categorisation.classification_id = classification.id
-            JOIN
-               ethnicity_in_classification
-               ON classification.id = ethnicity_in_classification.classification_id
-            JOIN
-               ethnicity
-               ON ethnicity_in_classification.ethnicity_id = ethnicity.id
+            topic.title AS topic_title,
+            topic.slug AS topic_slug,
+            subtopic.title AS subtopic_title,
+            subtopic.slug AS subtopic_slug,
+            subtopic.position AS subtopic_position,
+            measure.id AS measure_id,
+            measure.slug AS measure_slug,
+            measure.position AS measure_position,
+            latest_published_measure_versions.id AS measure_version_id,
+            latest_published_measure_versions.title AS measure_version_title,
+            dimension.guid AS dimension_guid,
+            dimension.title AS dimension_title,
+            dimension.position AS dimension_position,
+            classification.title AS classification_title,
+            ethnicity.value AS ethnicity_value,
+            ethnicity.position AS ethnicity_position
+         FROM latest_published_measure_versions
+             JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+             JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+             JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+             JOIN topic ON subtopic.topic_id = topic.id
+             JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+             JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+             JOIN classification ON dimension_categorisation.classification_id = classification.id
+             JOIN ethnicity_in_classification ON classification.id = ethnicity_in_classification.classification_id
+             JOIN ethnicity ON ethnicity_in_classification.ethnicity_id = ethnicity.id
          )
          UNION
          (
             SELECT
-               topic.title AS topic_title, topic.slug AS topic_slug, subtopic.title AS subtopic_title, subtopic.slug AS subtopic_slug, subtopic.position AS subtopic_position, measure.id AS measure_id, measure.slug AS measure_slug, measure.position AS measure_position, latest_published_measure_versions.id AS measure_version_id, latest_published_measure_versions.title AS measure_version_title, dimension.guid AS dimension_guid, dimension.title AS dimension_title, dimension.position AS dimension_position, classification.title AS classification_title, ethnicity.value AS ethnicity_value, ethnicity.position AS ethnicity_position
-            FROM
-               latest_published_measure_versions
-               JOIN
-                  measure
-                  ON latest_published_measure_versions.measure_id = measure.id
-               JOIN
-                  subtopic_measure
-                  ON measure.id = subtopic_measure.measure_id
-               JOIN
-                  subtopic
-                  ON subtopic_measure.subtopic_id = subtopic.id
-               JOIN
-                  topic
-                  ON subtopic.topic_id = topic.id
-               JOIN
-                  dimension
-                  ON dimension.measure_version_id = latest_published_measure_versions.id
-               JOIN
-                  dimension_categorisation
-                  ON dimension.guid = dimension_categorisation.dimension_guid
-               JOIN
-                  classification
-                  ON dimension_categorisation.classification_id = classification.id
-               JOIN
-                  parent_ethnicity_in_classification
-                  ON classification.id = parent_ethnicity_in_classification.classification_id
-               JOIN
-                  ethnicity
-                  ON parent_ethnicity_in_classification.ethnicity_id = ethnicity.id
-            WHERE
-               dimension_categorisation.includes_parents
+               topic.title AS topic_title,
+               topic.slug AS topic_slug,
+               subtopic.title AS subtopic_title,
+               subtopic.slug AS subtopic_slug,
+               subtopic.position AS subtopic_position,
+               measure.id AS measure_id,
+               measure.slug AS measure_slug,
+               measure.position AS measure_position,
+               latest_published_measure_versions.id AS measure_version_id,
+               latest_published_measure_versions.title AS measure_version_title,
+               dimension.guid AS dimension_guid,
+               dimension.title AS dimension_title,
+               dimension.position AS dimension_position,
+               classification.title AS classification_title,
+               ethnicity.value AS ethnicity_value,
+               ethnicity.position AS ethnicity_position
+            FROM latest_published_measure_versions
+                JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+                JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+                JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+                JOIN topic ON subtopic.topic_id = topic.id
+                JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+                JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+                JOIN classification ON dimension_categorisation.classification_id = classification.id
+                JOIN parent_ethnicity_in_classification ON classification.id = parent_ethnicity_in_classification.classification_id
+                JOIN ethnicity ON parent_ethnicity_in_classification.ethnicity_id = ethnicity.id
+            WHERE dimension_categorisation.includes_parents
          )
       )
       AS all_measure_version_ethnicities
@@ -172,45 +163,39 @@ CREATE UNIQUE INDEX uix_ethnic_groups_by_dimension ON new_ethnic_groups_by_dimen
 """  # noqa
 
 
-categorisations_by_dimension = """
-        CREATE
-        MATERIALIZED
-        VIEW
-        categorisations_by_dimension as ( SELECT all_dimension_categorisations.* FROM
-      (
-            (
-              SELECT subtopic.guid AS "subtopic_guid",
-              mv.guid AS "page_guid",
-              mv.title AS "page_title",
-              mv.version AS "page_version",
-              mv.slug AS "page_slug",
-              mv.position AS "page_position",
-              d.guid AS "dimension_guid",
-              d.title AS "dimension_title",
-              d.position AS "dimension_position",
-              c.id AS "categorisation_id",
-              c.title AS "categorisation",
-              c.position AS "categorisation_position",
-              dc.includes_parents AS "includes_parents",
-              dc.includes_all AS "includes_all",
-              dc.includes_unknown AS "includes_unknown"
-              FROM measure_version mv
-              JOIN measure_version subtopic ON mv.parent_guid = subtopic.guid
-              JOIN dimension d ON d.page_id = mv.guid AND d.page_version = mv.version
-              JOIN dimension_categorisation dc ON d.guid = dc.dimension_guid
-              JOIN classification c ON dc.classification_id = c.id
-              )
-      ) AS all_dimension_categorisations
-      JOIN
-      (SELECT guid, version_arr[1] || '.' || version_arr[2] AS "version" FROM
-        (SELECT guid, MAX(string_to_array(version, '.')::int[]) AS "version_arr"
-          FROM measure_version
-          WHERE status = 'APPROVED'
-          GROUP BY guid
-        ) AS latest_arr
-      ) AS latest
-      ON all_dimension_categorisations.page_guid = latest.guid AND all_dimension_categorisations.page_version = latest.version
-    );
+classifications_by_dimension = """
+CREATE MATERIALIZED VIEW new_classifications_by_dimension AS
+(
+   SELECT
+      topic.title AS topic_title,
+      topic.slug AS topic_slug,
+      subtopic.title AS subtopic_title,
+      subtopic.slug AS subtopic_slug,
+      subtopic.position AS subtopic_position,
+      measure.id AS measure_id,
+      measure.slug AS measure_slug,
+      measure.position AS measure_position,
+      latest_published_measure_versions.id AS measure_version_id,
+      latest_published_measure_versions.title AS measure_version_title,
+      dimension.guid AS dimension_guid,
+      dimension.title AS dimension_title,
+      dimension.position AS dimension_position,
+      classification.id AS classification_id,
+      classification.title AS classification_title,
+      classification.position AS classification_position,
+      dimension_categorisation.includes_parents AS includes_parents,
+      dimension_categorisation.includes_all AS includes_all,
+      dimension_categorisation.includes_unknown AS includes_unknown
+   FROM
+      latest_published_measure_versions
+      JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+      JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+      JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+      JOIN topic ON subtopic.topic_id = topic.id
+      JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+      JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+      JOIN classification ON dimension_categorisation.classification_id = classification.id
+);
 
-     CREATE UNIQUE INDEX uix_categorisations_by_dimension ON categorisations_by_dimension (dimension_guid, categorisation_id);
+CREATE UNIQUE INDEX uix_categorisations_by_dimension ON new_classifications_by_dimension (dimension_guid, classification_id);
 """  # noqa

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -76,9 +76,12 @@ def ethnic_groups():
 @login_required
 @user_can(VIEW_DASHBOARDS)
 def ethnic_group(value_slug):
-    value_title, page_count, results = get_ethnic_group_by_slug_dashboard_data(value_slug)
+    value_title, page_count, nested_measures_and_dimensions = get_ethnic_group_by_slug_dashboard_data(value_slug)
     return render_template(
-        "dashboards/ethnic_group.html", ethnic_group=value_title, measure_count=page_count, measure_tree=results
+        "dashboards/ethnic_group.html",
+        ethnic_group=value_title,
+        measure_count=page_count,
+        nested_measures_and_dimensions=nested_measures_and_dimensions,
     )
 
 

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -115,10 +115,12 @@ def locations():
 @login_required
 @user_can(VIEW_DASHBOARDS)
 def location(slug):
-    loc, page_count, subtopics = get_geographic_breakdown_by_slug_dashboard_data(slug)
+    geography, page_count, measure_titles_and_urls_by_topic_and_subtopic = get_geographic_breakdown_by_slug_dashboard_data(  # noqa
+        slug
+    )
     return render_template(
         "dashboards/lowest-level-of-geography.html",
-        level_of_geography=loc.name,
+        level_of_geography=geography.name,
         page_count=page_count,
-        measure_tree=subtopics,
+        measure_titles_and_urls_by_topic_and_subtopic=measure_titles_and_urls_by_topic_and_subtopic,
     )

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -97,12 +97,14 @@ def ethnicity_classifications():
 @login_required
 @user_can(VIEW_DASHBOARDS)
 def ethnicity_classification(classification_id):
-    classification_title, page_count, results = get_ethnicity_classification_by_id_dashboard_data(classification_id)
+    classification_title, page_count, nested_measures_and_dimensions = get_ethnicity_classification_by_id_dashboard_data(  # noqa
+        classification_id
+    )
     return render_template(
         "dashboards/ethnicity_classification.html",
         classification_title=classification_title,
         page_count=page_count,
-        measure_tree=results,
+        nested_measures_and_dimensions=nested_measures_and_dimensions,
     )
 
 

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -368,14 +368,14 @@ def build_dashboards(build_dir):
 
     # Individual ethnicity classifications dashboards
     for classification in classifications:
-        classification_title, page_count, results = get_ethnicity_classification_by_id_dashboard_data(
+        classification_title, page_count, nested_measures_and_dimensions = get_ethnicity_classification_by_id_dashboard_data(  # noqa
             classification["id"]
         )
         content = render_template(
             "dashboards/ethnicity_classification.html",
             classification_title=classification_title,
             page_count=page_count,
-            measure_tree=results,
+            nested_measures_and_dimensions=nested_measures_and_dimensions,
         )
         dir_path = os.path.join(dashboards_dir, f'ethnicity-classifications/{classification["id"]}')
         os.makedirs(dir_path, exist_ok=True)

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -387,12 +387,14 @@ def build_dashboards(build_dir):
     # Individual geographic area dashboards
     for loc_level in location_levels:
         slug = loc_level["url"][loc_level["url"].rindex("/") + 1 :]  # The part of the url after the final /
-        loc, page_count, subtopics = get_geographic_breakdown_by_slug_dashboard_data(slug)
+        geography, page_count, measure_titles_and_urls_by_topic_and_subtopic = get_geographic_breakdown_by_slug_dashboard_data(  # noqa
+            slug
+        )
         content = render_template(
             "dashboards/lowest-level-of-geography.html",
-            level_of_geography=loc.name,
+            level_of_geography=geography.name,
             page_count=page_count,
-            measure_tree=subtopics,
+            measure_titles_and_urls_by_topic_and_subtopic=measure_titles_and_urls_by_topic_and_subtopic,
         )
         dir_path = os.path.join(dashboards_dir, f"geographic-breakdown/{slug}")
         os.makedirs(dir_path, exist_ok=True)

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -349,9 +349,12 @@ def build_dashboards(build_dir):
     # Individual ethnic group dashboards
     for ethnicity in sorted_ethnicity_list:
         slug = ethnicity["url"][ethnicity["url"].rindex("/") + 1 :]  # The part of the url after the final /
-        value_title, page_count, results = get_ethnic_group_by_slug_dashboard_data(slug)
+        value_title, page_count, nested_measures_and_dimensions = get_ethnic_group_by_slug_dashboard_data(slug)
         content = render_template(
-            "dashboards/ethnic_group.html", ethnic_group=value_title, measure_count=page_count, measure_tree=results
+            "dashboards/ethnic_group.html",
+            ethnic_group=value_title,
+            measure_count=page_count,
+            nested_measures_and_dimensions=nested_measures_and_dimensions,
         )
         dir_path = os.path.join(dashboards_dir, f"ethnic-groups/{slug}")
         os.makedirs(dir_path, exist_ok=True)

--- a/application/templates/dashboards/ethnic_group.html
+++ b/application/templates/dashboards/ethnic_group.html
@@ -32,22 +32,24 @@
       </thead>
 
     <tbody>
-    {% for subtopic in measure_tree %}
-        {% for page in subtopic.measures %}
-          <tr>
-            <td>{{ subtopic.topic }}</td>
-            <td>{{ subtopic.title }}</td>
-            <td>
-              <a href="{{ page.url }}">{{ page.title }}</a>
-                {% for dimension in page.dimensions %}
-                    <ul class="dimensions">
-                       <li><a href="{{ page.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
-                    </ul>
-                {%  endfor %}
-            </td>
-          </tr>
+    {% for topic_title, measures_with_dimensions_by_subtopic in nested_measures_and_dimensions.items() %}
+        {% for subtopic_title, measures_with_dimensions in measures_with_dimensions_by_subtopic.items() %}
+            {% for measure_title, measure_with_dimensions in measures_with_dimensions.items() %}
+              <tr>
+                <td>{{ topic_title }}</td>
+                <td>{{ subtopic_title }}</td>
+                <td>
+                  <a href="{{ measure_with_dimensions.url }}">{{ measure_with_dimensions.title }}</a>
+                    {% for dimension in measure_with_dimensions.dimensions %}
+                        <ul class="dimensions">
+                           <li><a href="{{ measure_with_dimensions.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
+                        </ul>
+                    {%  endfor %}
+                </td>
+              </tr>
+            {%  endfor %}
         {%  endfor %}
-    {%  endfor %}
+    {% endfor %}
     </tbody>
   </table>
 

--- a/application/templates/dashboards/ethnicity_classification.html
+++ b/application/templates/dashboards/ethnicity_classification.html
@@ -34,22 +34,23 @@
 
     <tbody>
     {% for topic_title, measures_with_dimensions_by_subtopic in nested_measures_and_dimensions.items() %}
-        {% for subtopic_title, measures_with_dimensions in measures_with_dimensions_by_subtopic.items() %}
-            {% for measure_title, measure_with_dimensions in measures_with_dimensions.items() %}
+      {% for subtopic_title, measures_with_dimensions in measures_with_dimensions_by_subtopic.items() %}
+        {% for measure_title, measure_with_dimensions in measures_with_dimensions.items() %}
           <tr>
             <td>{{ topic_title }}</td>
             <td>{{ subtopic_title }}</td>
             <td>
               <a href="{{ measure_with_dimensions.url }}">{{ measure_with_dimensions.title }}</a>
-                    {% for dimension in measure_with_dimensions.dimensions %}
-                    <ul class="dimensions">
-                       <li><a href="{{ measure_with_dimensions.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
-                    </ul>
-                {%  endfor %}
+
+              {% for dimension in measure_with_dimensions.dimensions %}
+                <ul class="dimensions">
+                   <li><a href="{{ measure_with_dimensions.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
+                </ul>
+              {%  endfor %}
             </td>
           </tr>
-            {%  endfor %}
         {%  endfor %}
+      {%  endfor %}
     {%  endfor %}
 
     {% for page in pages %}

--- a/application/templates/dashboards/ethnicity_classification.html
+++ b/application/templates/dashboards/ethnicity_classification.html
@@ -33,20 +33,22 @@
       </thead>
 
     <tbody>
-    {% for subtopic in measure_tree %}
-        {% for page in subtopic.measures %}
+    {% for topic_title, measures_with_dimensions_by_subtopic in nested_measures_and_dimensions.items() %}
+        {% for subtopic_title, measures_with_dimensions in measures_with_dimensions_by_subtopic.items() %}
+            {% for measure_title, measure_with_dimensions in measures_with_dimensions.items() %}
           <tr>
-            <td>{{ subtopic.topic }}</td>
-            <td>{{ subtopic.title }}</td>
+            <td>{{ topic_title }}</td>
+            <td>{{ subtopic_title }}</td>
             <td>
-              <a href="{{ page.url }}">{{ page.title }}</a>
-                {% for dimension in page.dimensions %}
+              <a href="{{ measure_with_dimensions.url }}">{{ measure_with_dimensions.title }}</a>
+                    {% for dimension in measure_with_dimensions.dimensions %}
                     <ul class="dimensions">
-                       <li><a href="{{ page.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
+                       <li><a href="{{ measure_with_dimensions.url }}#{{ dimension.title|slugify_value }}">… {{ dimension.short_title }}</a></li>
                     </ul>
                 {%  endfor %}
             </td>
           </tr>
+            {%  endfor %}
         {%  endfor %}
     {%  endfor %}
 

--- a/application/templates/dashboards/ethnicity_values.html
+++ b/application/templates/dashboards/ethnicity_values.html
@@ -34,8 +34,8 @@
       {% for ethnic_group in ethnic_groups %}
             <tr>
               <th><a href="{{ ethnic_group.url }}">{{ ethnic_group.value }}</a></th>
-              <td class="numeric">{{ ethnic_group.pages }}</td>
-              <td class="numeric">{{ ethnic_group.dimensions }}</td>
+              <td class="numeric">{{ ethnic_group.count_measures }}</td>
+              <td class="numeric">{{ ethnic_group.count_dimensions }}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/application/templates/dashboards/ethnicity_values.html
+++ b/application/templates/dashboards/ethnicity_values.html
@@ -34,8 +34,8 @@
       {% for ethnic_group in ethnic_groups %}
             <tr>
               <th><a href="{{ ethnic_group.url }}">{{ ethnic_group.value }}</a></th>
-              <td class="numeric">{{ ethnic_group.count_measures }}</td>
-              <td class="numeric">{{ ethnic_group.count_dimensions }}</td>
+              <td class="numeric">{{ ethnic_group.measure_count }}</td>
+              <td class="numeric">{{ ethnic_group.dimension_count }}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/application/templates/dashboards/lowest-level-of-geography.html
+++ b/application/templates/dashboards/lowest-level-of-geography.html
@@ -33,35 +33,22 @@
       </thead>
 
     <tbody>
-    {% for subtopic in measure_tree %}
+    {% for topic_title, measure_titles_and_urls_by_subtopic in measure_titles_and_urls_by_topic_and_subtopic.items() %}
+        {% for subtopic_title, measure_titles_and_urls in measure_titles_and_urls_by_subtopic.items() %}
         <tr>
-            <td>{{ subtopic.topic }}</td>
-            <td>{{ subtopic.title }}</td>
-                    <td>
+            <td>{{ topic_title }}</td>
+            <td>{{ subtopic_title }}</td>
 
-            {% for page in subtopic.measures %}
+            <td>
+            {% for measure_title_and_url in measure_titles_and_urls %}
                 <ul class="dimensions">
-                    <a href="{{ page.url }}">{{ page.title }}</a>
+                    <a href="{{ measure_title_and_url.url }}">{{ measure_title_and_url.title }}</a>
                 </ul>
             {%  endfor %}
             </td>
 
           </tr>
-    {%  endfor %}
-
-    {% for page in pages %}
-        <tr>
-        <td>{{ page.topic }}</td>
-        <td>{{ page.subtopic }}</td>
-        <td>
-          <a href="{{ page.measure_url }}">{{ page.measure }}</a>
-            {% for dimension in page.dimensions %}
-                <ul class="dimensions">
-                   <li><a href="{{ page.measure_url }}#{{ dimension.dimension|slugify_value }}">… {{ dimension.short_title }}</a></li>
-                </ul>
-            {%  endfor %}
-        </td>
-      </tr>
+        {% endfor %}
     {%  endfor %}
     </tbody>
   </table>

--- a/manage.py
+++ b/manage.py
@@ -329,14 +329,14 @@ def drop_and_create_materialized_views():
         latest_published_measure_versions_view,
         latest_published_measure_versions_by_geography_view,
         ethnic_groups_by_dimension_view,
-        categorisations_by_dimension,
+        classifications_by_dimension,
     )
 
     db.session.execute(drop_all_dashboard_helper_views)
     db.session.execute(latest_published_measure_versions_view)
     db.session.execute(latest_published_measure_versions_by_geography_view)
     db.session.execute(ethnic_groups_by_dimension_view)
-    db.session.execute(categorisations_by_dimension)
+    db.session.execute(classifications_by_dimension)
     db.session.commit()
     print("Drop and create MATERIALIZED VIEWS done")
 

--- a/manage.py
+++ b/manage.py
@@ -327,14 +327,14 @@ def drop_and_create_materialized_views():
     from application.dashboard.view_sql import (
         drop_all_dashboard_helper_views,
         latest_published_measure_versions_view,
-        pages_by_geography_view,
+        latest_published_measure_versions_by_geography_view,
         ethnic_groups_by_dimension_view,
         categorisations_by_dimension,
     )
 
     db.session.execute(drop_all_dashboard_helper_views)
     db.session.execute(latest_published_measure_versions_view)
-    db.session.execute(pages_by_geography_view)
+    db.session.execute(latest_published_measure_versions_by_geography_view)
     db.session.execute(ethnic_groups_by_dimension_view)
     db.session.execute(categorisations_by_dimension)
     db.session.commit()

--- a/manage.py
+++ b/manage.py
@@ -326,14 +326,14 @@ def refresh_materialized_views():
 def drop_and_create_materialized_views():
     from application.dashboard.view_sql import (
         drop_all_dashboard_helper_views,
-        latest_published_pages_view,
+        latest_published_measure_versions_view,
         pages_by_geography_view,
         ethnic_groups_by_dimension_view,
         categorisations_by_dimension,
     )
 
     db.session.execute(drop_all_dashboard_helper_views)
-    db.session.execute(latest_published_pages_view)
+    db.session.execute(latest_published_measure_versions_view)
     db.session.execute(pages_by_geography_view)
     db.session.execute(ethnic_groups_by_dimension_view)
     db.session.execute(categorisations_by_dimension)

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 # List of views to exclude when generating migration files
 [alembic:exclude]
-views = latest_published_measure_versions,ethnic_groups_by_dimension,categorisations_by_dimension,pages_by_geography
+views = latest_published_measure_versions,ethnic_groups_by_dimension,categorisations_by_dimension,new_latest_published_measure_versions_by_geography
 
 # Logging configuration
 [loggers]

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 # List of views to exclude when generating migration files
 [alembic:exclude]
-views = latest_published_measure_versions,new_ethnic_groups_by_dimension,categorisations_by_dimension,new_latest_published_measure_versions_by_geography
+views = latest_published_measure_versions,new_ethnic_groups_by_dimension,classifications_by_dimension,new_latest_published_measure_versions_by_geography
 
 # Logging configuration
 [loggers]

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 # List of views to exclude when generating migration files
 [alembic:exclude]
-views = latest_published_pages,ethnic_groups_by_dimension,categorisations_by_dimension,pages_by_geography
+views = latest_published_measure_versions,ethnic_groups_by_dimension,categorisations_by_dimension,pages_by_geography
 
 # Logging configuration
 [loggers]

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 # List of views to exclude when generating migration files
 [alembic:exclude]
-views = latest_published_measure_versions,ethnic_groups_by_dimension,categorisations_by_dimension,new_latest_published_measure_versions_by_geography
+views = latest_published_measure_versions,new_ethnic_groups_by_dimension,categorisations_by_dimension,new_latest_published_measure_versions_by_geography
 
 # Logging configuration
 [loggers]

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 # List of views to exclude when generating migration files
 [alembic:exclude]
-views = latest_published_measure_versions,new_ethnic_groups_by_dimension,classifications_by_dimension,new_latest_published_measure_versions_by_geography
+views = new_latest_published_measure_versions,new_ethnic_groups_by_dimension,new_classifications_by_dimension,new_latest_published_measure_versions_by_geography
 
 # Logging configuration
 [loggers]

--- a/migrations/versions/2019_02_12_new_mat_views.py
+++ b/migrations/versions/2019_02_12_new_mat_views.py
@@ -1,6 +1,6 @@
 """Create new materialized views for updated database model.
 
-This migration only adds new materialized views - it leaves the existing ones in tact to be removed by a later
+This migration only adds new materialized views - it leaves the existing ones intact to be removed by a later
 migration/PR.
 
 Revision ID: 2019_02_12_new_mat_views

--- a/migrations/versions/2019_02_12_new_mat_views.py
+++ b/migrations/versions/2019_02_12_new_mat_views.py
@@ -1,0 +1,202 @@
+"""Create new materialized views for updated database model.
+
+This migration only adds new materialized views - it leaves the existing ones in tact to be removed by a later
+migration/PR.
+
+Revision ID: 2019_02_12_new_mat_views
+Revises: 2019_01_15_uq_measure_version
+Create Date: 2019-01-15 12:25:28.892266
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_02_12_new_mat_views"
+down_revision = "2019_01_15_uq_measure_version"
+branch_labels = None
+depends_on = None
+
+latest_published_measure_versions_view = """
+CREATE MATERIALIZED VIEW new_latest_published_measure_versions AS
+(
+   SELECT
+      mv.*
+   FROM
+      measure_version AS mv
+      JOIN
+         (
+            SELECT
+               measure_version.measure_id,
+               array_to_string(MAX(string_to_array(measure_version.version, '.')), '.') AS max_approved_version
+            FROM
+               measure_version
+            WHERE
+               measure_version.status = 'APPROVED'
+            GROUP BY
+               measure_version.measure_id
+         )
+         AS max_approved_measure_versions
+         ON mv.measure_id = max_approved_measure_versions.measure_id
+         AND mv.version = max_approved_measure_versions.max_approved_version
+);
+
+CREATE UNIQUE INDEX uix_new_latest_published_measure_versions
+ON new_latest_published_measure_versions (id);
+"""
+
+latest_published_measure_versions_by_geography_view = """
+CREATE MATERIALIZED VIEW new_latest_published_measure_versions_by_geography AS
+(
+   SELECT
+      topic.title AS topic_title,
+      topic.slug AS topic_slug,
+      subtopic.title AS subtopic_title,
+      subtopic.slug AS subtopic_slug,
+      subtopic.position AS subtopic_position,
+      measure.slug AS measure_slug,
+      measure.position AS measure_position,
+      measure_version.id AS measure_version_id,
+      measure_version.title AS measure_version_title,
+      geography.name AS geography_name,
+      geography.position AS geography_position
+   FROM
+      new_latest_published_measure_versions AS mv
+      JOIN lowest_level_of_geography AS geography ON mv.lowest_level_of_geography_id = geography.name
+      JOIN measure_version ON measure_version.id = mv.id
+      JOIN measure ON measure.id = measure_version.measure_id
+      JOIN subtopic_measure ON subtopic_measure.measure_id = measure.id
+      JOIN subtopic ON subtopic.id = subtopic_measure.subtopic_id
+      JOIN topic ON topic.id = subtopic.topic_id
+   ORDER BY
+      geography.position ASC
+);
+
+CREATE UNIQUE INDEX uix_new_latest_published_measure_versions_by_geography
+ON new_latest_published_measure_versions_by_geography (measure_version_id);
+"""
+
+
+ethnic_groups_by_dimension_view = """
+CREATE MATERIALIZED VIEW new_ethnic_groups_by_dimension AS
+(
+     SELECT
+        topic.title AS topic_title,
+        topic.slug AS topic_slug,
+        subtopic.title AS subtopic_title,
+        subtopic.slug AS subtopic_slug,
+        subtopic.position AS subtopic_position,
+        measure.id AS measure_id,
+        measure.slug AS measure_slug,
+        measure.position AS measure_position,
+        new_latest_published_measure_versions.id AS measure_version_id,
+        new_latest_published_measure_versions.title AS measure_version_title,
+        dimension.guid AS dimension_guid,
+        dimension.title AS dimension_title,
+        dimension.position AS dimension_position,
+        classification.title AS classification_title,
+        ethnicity.value AS ethnicity_value,
+        ethnicity.position AS ethnicity_position
+     FROM new_latest_published_measure_versions
+          JOIN measure ON new_latest_published_measure_versions.measure_id = measure.id
+          JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+          JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+          JOIN topic ON subtopic.topic_id = topic.id
+          JOIN dimension ON dimension.measure_version_id = new_latest_published_measure_versions.id
+          JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+          JOIN classification ON dimension_categorisation.classification_id = classification.id
+          JOIN ethnicity_in_classification ON classification.id = ethnicity_in_classification.classification_id
+          JOIN ethnicity ON ethnicity_in_classification.ethnicity_id = ethnicity.id
+     UNION
+     SELECT
+        topic.title AS topic_title,
+        topic.slug AS topic_slug,
+        subtopic.title AS subtopic_title,
+        subtopic.slug AS subtopic_slug,
+        subtopic.position AS subtopic_position,
+        measure.id AS measure_id,
+        measure.slug AS measure_slug,
+        measure.position AS measure_position,
+        new_latest_published_measure_versions.id AS measure_version_id,
+        new_latest_published_measure_versions.title AS measure_version_title,
+        dimension.guid AS dimension_guid,
+        dimension.title AS dimension_title,
+        dimension.position AS dimension_position,
+        classification.title AS classification_title,
+        ethnicity.value AS ethnicity_value,
+        ethnicity.position AS ethnicity_position
+     FROM new_latest_published_measure_versions
+          JOIN measure ON new_latest_published_measure_versions.measure_id = measure.id
+          JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+          JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+          JOIN topic ON subtopic.topic_id = topic.id
+          JOIN dimension ON dimension.measure_version_id = new_latest_published_measure_versions.id
+          JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+          JOIN classification ON dimension_categorisation.classification_id = classification.id
+          JOIN parent_ethnicity_in_classification ON classification.id = parent_ethnicity_in_classification.classification_id
+          JOIN ethnicity ON parent_ethnicity_in_classification.ethnicity_id = ethnicity.id
+     WHERE dimension_categorisation.includes_parents
+);
+
+CREATE UNIQUE INDEX uix_new_ethnic_groups_by_dimension ON new_ethnic_groups_by_dimension (dimension_guid, ethnicity_value);
+"""  # noqa
+
+
+classifications_by_dimension = """
+CREATE MATERIALIZED VIEW new_classifications_by_dimension AS
+(
+   SELECT
+      topic.title AS topic_title,
+      topic.slug AS topic_slug,
+      subtopic.title AS subtopic_title,
+      subtopic.slug AS subtopic_slug,
+      subtopic.position AS subtopic_position,
+      measure.id AS measure_id,
+      measure.slug AS measure_slug,
+      measure.position AS measure_position,
+      new_latest_published_measure_versions.id AS measure_version_id,
+      new_latest_published_measure_versions.title AS measure_version_title,
+      dimension.guid AS dimension_guid,
+      dimension.title AS dimension_title,
+      dimension.position AS dimension_position,
+      classification.id AS classification_id,
+      classification.title AS classification_title,
+      classification.position AS classification_position,
+      dimension_categorisation.includes_parents AS includes_parents,
+      dimension_categorisation.includes_all AS includes_all,
+      dimension_categorisation.includes_unknown AS includes_unknown
+   FROM
+      new_latest_published_measure_versions
+      JOIN measure ON new_latest_published_measure_versions.measure_id = measure.id
+      JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+      JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+      JOIN topic ON subtopic.topic_id = topic.id
+      JOIN dimension ON dimension.measure_version_id = new_latest_published_measure_versions.id
+      JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+      JOIN classification ON dimension_categorisation.classification_id = classification.id
+);
+
+CREATE UNIQUE INDEX uix_new_categorisations_by_dimension ON new_classifications_by_dimension (dimension_guid, classification_id);
+"""  # noqa
+
+drop_all_dashboard_helper_views = """
+DROP INDEX IF EXISTS uix_new_latest_published_measure_versions;
+DROP INDEX IF EXISTS uix_new_latest_published_measure_versions_by_geography;
+DROP INDEX IF EXISTS uix_new_ethnic_groups_by_dimension;
+DROP INDEX IF EXISTS uix_new_categorisations_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS new_latest_published_measure_versions_by_geography;
+DROP MATERIALIZED VIEW IF EXISTS new_ethnic_groups_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS new_classifications_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS new_latest_published_measure_versions;
+"""
+
+
+def upgrade():
+    op.execute(latest_published_measure_versions_view)
+    op.execute(latest_published_measure_versions_by_geography_view)
+    op.execute(ethnic_groups_by_dimension_view)
+    op.execute(classifications_by_dimension)
+
+
+def downgrade():
+    op.execute(drop_all_dashboard_helper_views)


### PR DESCRIPTION
## Summary
This PR updates our materialized views to read from the new database model. It does this by creating a _new_ set of materialized view tables, leaving the old ones in place but updating all references so that all reads go via the new tables. This will allow us to rollback easily if needed. The existing materialized views will be dropped by a later migration in the cleanup ticket.

The nature of the materialized views is to drive all of our dashboards and prevent having to run any expensive/analytical join queries during requests. Therefore, all of the information needed for the dashboards is duplicated into the matviews (e.g. slugs and titles).

The data structures returned by the dashboard `data_helpers` are particularly complex and it would be nice to rationalise these somehow in the future. In particular, a few of the dashboards have an identical page structure and receive the same data structure, so we definitely have some repeated code that could probably be reduced/removed with a little more thought. However, in the spirit of keeping this as small and simple as possible, I've left it in place. I've also removed a block of template code from `lowest-level-of-geography.html` that appears to be unused (because `pages` is not defined).

~~I'm aware of a small bug at the moment that causes the new views to report different numbers of dimensions/pages for some classifications and I'm investigating it at the moment. The code should still be good to review on the whole.~~ False alarm

## Ticket
https://trello.com/c/TA4a5RJr/1242-8-dashboards-that-use-materialized-views-should-work-from-new-table-structure-5