### PR TITLE
Always refresh_materialized_views() before building static site

### DIFF
--- a/application/sitebuilder/build_service.py
+++ b/application/sitebuilder/build_service.py
@@ -155,7 +155,11 @@ def _delete_files_not_needed_for_deploy(build_dir):
 def _start_build(app, build, session):
     build_exception = None
     try:
-        print("DEBUG _start_build(): Marking build as started...")
+        print("DEBUG _start_build(): Refreshing materialized views...")
+        from manage import refresh_materialized_views
+
+        refresh_materialized_views()
+        print("DEBUG _start_build(): Doing it...")
         do_it(app, build)
         print("DEBUG _start_build(): Done it!")
 


### PR DESCRIPTION
We have recently noticed that the dashboards published on the static
site are slightly behind the same dashboard in the publisher.

We suspect this may be because the materialized views used to build the
dashboards are out of date when the site is built immediately after a
new age has been published.  The views are refreshed nightly at 1am, so
the day following publication the Publisher dashboard includes the new
pages, but the static site still has the old version.

Forcing the views to be refreshed before starting any build of the site
should fix this issue.