### PR TITLE
Add checkbox for data corrections

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -241,7 +241,8 @@ class MeasureVersionForm(FlaskForm):
 
     # Edit summaries
     update_corrects_data_mistake = RDURadioField(
-        label="Does this update correct a mistake in the data, commentary, charts, or tables?",
+        label="Are you correcting something that’s factually incorrect?",
+        hint="For example, in the data or commentary",
         choices=((True, "Yes"), (False, "No")),
         coerce=lambda value: None if value is None else get_bool(value),
         validators=[
@@ -253,9 +254,8 @@ class MeasureVersionForm(FlaskForm):
         label="Changes to previous version",
         validators=[RequiredForReviewValidator()],
         hint=(
-            "If you’ve updated only a sentence or two, add the updated content here. Otherwise, briefly summarise "
-            "what’s changed in the latest version (for example, ‘Updated with new data’ or ‘Minor changes for style "
-            "and accuracy’)."
+            "If you’ve corrected the data, explain what’s changed and why. Otherwise, summarise what you’ve updated "
+            "(for example, ‘Updated with the latest available data’)."
         ),
         strip_whitespace=True,
     )

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -2,7 +2,7 @@ from flask_wtf import FlaskForm
 from markupsafe import Markup
 from wtforms import StringField, TextAreaField, FileField, HiddenField
 from wtforms.fields.html5 import DateField
-from wtforms.validators import DataRequired, Optional, ValidationError, Length
+from wtforms.validators import DataRequired, Optional, ValidationError, Length, InputRequired
 
 from application.cms.models import (
     TypeOfData,
@@ -37,15 +37,15 @@ class FrequencyOfReleaseOtherRequiredValidator:
                 raise ValidationError(message)
 
 
-class RequiredForReviewValidator(DataRequired):
+class RequiredForReviewValidator(InputRequired):
     """
     This validator is designed for measure pages which can have their progress saved half-way through filling in
     fields, but need to ensure certain fields have been filled in when the measure page is being submitted for review.
 
     This validator checks whether the form has been called with the `sending_to_review` argument. If it has, then
-    it applies the DataRequired validator to all fields with this validator. If it has not, then you can specify whether
-    or not the field should be considered optional - this is useful for e.g. radio fields, which by default need a
-    value selected.
+    it applies the InputRequired validator to all fields with this validator. If it has not, then you can specify
+    whether or not the field should be considered optional - this is useful for e.g. radio fields, which by default need
+    a value selected.
 
     Note: if you use the `else_optional` functionality of this validator, the validator should be the last entry in the
     validation chain, as `Optional` validators end the validation chain.

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -241,7 +241,7 @@ class MeasureVersionForm(FlaskForm):
 
     # Edit summaries
     update_corrects_data_mistake = RDURadioField(
-        label="Does this update correct a mistake in the data?",
+        label="Does this update correct a mistake in the data, commentary, charts, or tables?",
         choices=((True, "Yes"), (False, "No")),
         coerce=lambda value: None if value is None else get_bool(value),
         validators=[

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -305,6 +305,7 @@ class MeasureVersion(db.Model, CopyableModel):
     time_covered = db.Column(db.String(255))  # public metadata
     external_edit_summary = db.Column(db.TEXT)  # notes on new version, displayed on public measure page
     internal_edit_summary = db.Column(db.TEXT)  # internal notes on new version, not displayed on public measure page
+    update_corrects_data_mistake = db.Column(db.Boolean)  # Whether or not a minor updates fixes a mistake in the data
 
     # lowest_level_of_geography is not displayed on the public site but is used for geographic dashboard
     lowest_level_of_geography_id = db.Column(

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -263,7 +263,7 @@ class PageService(Service):
         ):
             raise UpdateAlreadyExists()
 
-        new_version = measure_version.copy()
+        new_version = measure_version.copy(exclude_fields=["update_corrects_data_mistake"])
         new_version.guid = measure_version.guid
 
         if update_type == NewVersionType.NEW_MEASURE:

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -197,7 +197,7 @@
 
                     {{ form.further_technical_information(disabled=form_disabled, diffs=diffs) }}
 
-                    <h3 class="heading-medium">Additional information</h3>
+                    <h3 class="heading-medium">Updates and corrections</h3>
                     <div class="{% if new or measure_version.version == '1.0' %} hidden{% endif %}">
                         {% if form.is_minor_update %}
                             {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, fieldset_class="inline") }}

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -199,6 +199,10 @@
 
                     <h3 class="heading-medium">Additional information</h3>
                     <div class="{% if new or measure_version.version == '1.0' %} hidden{% endif %}">
+                        {% if form.is_minor_update %}
+                            {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, fieldset_class="inline") }}
+                        {% endif %}
+
                         {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
 
                         {{ form.internal_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}

--- a/migrations/versions/2019_02_14_data_corrections_add_a_column_to_the_measure_version_.py
+++ b/migrations/versions/2019_02_14_data_corrections_add_a_column_to_the_measure_version_.py
@@ -1,0 +1,33 @@
+"""Add a column to the measure_version table recording whether a minor update addresses a mistake in the data we
+published
+
+Revision ID: 2019_02_14_data_corrections
+Revises: 2019_02_12_new_mat_views
+Create Date: 2019-02-14 13:27:41.083950
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_02_14_data_corrections"
+down_revision = "2019_02_12_new_mat_views"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    measure_version = sa.Table(
+        "measure_version", sa.MetaData(), sa.Column("update_corrects_data_mistake", sa.Boolean())
+    )
+
+    op.add_column("measure_version", sa.Column("update_corrects_data_mistake", sa.Boolean(), nullable=True))
+
+    # This will lock the entire `measure_version` table, but at our scale this shouldn't be a concern as it won't lock
+    # for very long at all, in reality.
+    op.get_bind().execute(measure_version.update().values({"update_corrects_data_mistake": False}))
+
+
+def downgrade():
+    op.drop_column("measure_version", "update_corrects_data_mistake")

--- a/tests/application/cms/test_forms.py
+++ b/tests/application/cms/test_forms.py
@@ -1,4 +1,6 @@
+import pytest
 from werkzeug.datastructures import ImmutableMultiDict
+
 
 from application.cms.models import DataSource
 from application.cms.forms import DataSourceForm, MeasureVersionForm
@@ -40,7 +42,7 @@ class TestDataSourceForm:
 
 class TestMeasurePageForm:
     def test_runs_full_validation_when_sending_to_review(self):
-        form = MeasureVersionForm(sending_to_review=True)
+        form = MeasureVersionForm(is_minor_update=False, sending_to_review=True)
 
         form.validate()
 
@@ -56,3 +58,11 @@ class TestMeasurePageForm:
             "methodology",
             "external_edit_summary",
         }
+
+    @pytest.mark.parametrize("is_minor_update, form_should_error", ((False, False), (True, True)))
+    def test_update_corrects_data_mistake_only_on_minor_versions(self, is_minor_update, form_should_error):
+        form = MeasureVersionForm(is_minor_update, sending_to_review=True)
+
+        form.validate()
+
+        assert ("update_corrects_data_mistake" in form.errors.keys()) == form_should_error

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -202,7 +202,7 @@ class TestPageService:
         created_measure_version = page_service.create_measure(
             subtopic=subtopic,
             measure_version_form=MeasureVersionForm(
-                title="I care", published_at=datetime.now().date(), internal_reference="abc123"
+                is_minor_update=False, title="I care", published_at=datetime.now().date(), internal_reference="abc123"
             ),
             data_source_forms=[],
             created_by_email=user.email,
@@ -225,7 +225,9 @@ class TestPageService:
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
         created_page = page_service.create_measure(
             subtopic=subtopic,
-            measure_version_form=MeasureVersionForm(title="I care", published_at=datetime.now().date()),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=False, title="I care", published_at=datetime.now().date()
+            ),
             data_source_forms=[],
             created_by_email=user.email,
         )
@@ -234,7 +236,7 @@ class TestPageService:
             page_service.create_measure(
                 subtopic=subtopic,
                 measure_version_form=MeasureVersionForm(
-                    title=created_page.title, published_at=created_page.published_at
+                    is_minor_update=False, title=created_page.title, published_at=created_page.published_at
                 ),
                 data_source_forms=[],
                 created_by_email=user.email,
@@ -247,7 +249,10 @@ class TestPageService:
         page = page_service.create_measure(
             subtopic=subtopic,
             measure_version_form=MeasureVersionForm(
-                title="\n\t   I care\n", published_at=datetime.now().date(), methodology="\n\n\n\n\n\n"
+                is_minor_update=False,
+                title="\n\t   I care\n",
+                published_at=datetime.now().date(),
+                methodology="\n\n\n\n\n\n",
             ),
             created_by_email=user.email,
             data_source_forms=[],
@@ -262,7 +267,9 @@ class TestPageService:
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
         created_page = page_service.create_measure(
             subtopic=subtopic,
-            measure_version_form=MeasureVersionForm(title="the title", published_at=datetime.now().date()),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=False, title="the title", published_at=datetime.now().date()
+            ),
             created_by_email=user.email,
             data_source_forms=[],
         )
@@ -272,7 +279,9 @@ class TestPageService:
 
         updated_page = page_service.update_measure_version(
             created_page,
-            measure_version_form=MeasureVersionForm(title="an updated title", db_version_id=created_page.db_version_id),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=True, title="an updated title", db_version_id=created_page.db_version_id
+            ),
             data_source_forms=[],
             last_updated_by_email=user.email,
         )
@@ -286,7 +295,9 @@ class TestPageService:
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
         created_page = page_service.create_measure(
             subtopic=subtopic,
-            measure_version_form=MeasureVersionForm(title="the title", published_at=datetime.now().date()),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=False, title="the title", published_at=datetime.now().date()
+            ),
             created_by_email=user.email,
             data_source_forms=[],
         )
@@ -297,7 +308,7 @@ class TestPageService:
         page_service.update_measure_version(
             created_page,
             measure_version_form=MeasureVersionForm(
-                title="the title", status="APPROVED", db_version_id=created_page.db_version_id
+                is_minor_update=True, title="the title", status="APPROVED", db_version_id=created_page.db_version_id
             ),
             data_source_forms=[],
             last_updated_by_email=user.email,
@@ -310,7 +321,9 @@ class TestPageService:
 
         page_service.update_measure_version(
             copied_page,
-            measure_version_form=MeasureVersionForm(title="the updated title", db_version_id=copied_page.db_version_id),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=True, title="the updated title", db_version_id=copied_page.db_version_id
+            ),
             data_source_forms=[],
             last_updated_by_email=user.email,
         )
@@ -435,12 +448,12 @@ class TestPageService:
 
     def test_update_measure_version(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionFactory(status="DRAFT")
+        measure_version = MeasureVersionFactory(version="1.0", status="DRAFT")
 
         page_service.update_measure_version(
             measure_version,
             measure_version_form=MeasureVersionForm(
-                title="I care too much!", db_version_id=measure_version.db_version_id
+                is_minor_update=True, title="I care too much!", db_version_id=measure_version.db_version_id
             ),
             data_source_forms=[],
             last_updated_by_email=user.email,
@@ -454,7 +467,7 @@ class TestPageService:
 
     def test_update_measure_version_raises_if_page_not_editable(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionFactory(status="DRAFT")
+        measure_version = MeasureVersionFactory(version="1.0", status="DRAFT")
 
         measure_version_from_db = page_service.get_measure_version_by_id(
             measure_version.measure.id, measure_version.version
@@ -463,7 +476,9 @@ class TestPageService:
 
         page_service.update_measure_version(
             measure_version,
-            measure_version_form=MeasureVersionForm(title="Who cares", db_version_id=measure_version.db_version_id),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=True, title="Who cares", db_version_id=measure_version.db_version_id
+            ),
             data_source_forms=[],
             last_updated_by_email=user.email,
             **{"status": "APPROVED"},
@@ -478,7 +493,7 @@ class TestPageService:
             page_service.update_measure_version(
                 measure_version,
                 measure_version_form=MeasureVersionForm(
-                    title="I care too much!", db_version_id=measure_version.db_version_id
+                    is_minor_update=True, title="I care too much!", db_version_id=measure_version.db_version_id
                 ),
                 data_source_forms=[],
                 last_updated_by_email=user.email,
@@ -486,11 +501,12 @@ class TestPageService:
 
     def test_update_measure_version_trims_whitespace(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionFactory(status="DRAFT")
+        measure_version = MeasureVersionFactory(version="1.0", status="DRAFT")
 
         page_service.update_measure_version(
             measure_version,
             measure_version_form=MeasureVersionForm(
+                is_minor_update=False,
                 title="Who cares",
                 db_version_id=measure_version.db_version_id,
                 published_at=datetime.now().date(),
@@ -505,6 +521,7 @@ class TestPageService:
         page_service.update_measure_version(
             measure_version,
             measure_version_form=MeasureVersionForm(
+                is_minor_update=False,
                 title="Who cares",
                 db_version_id=measure_version.db_version_id,
                 ethnicity_definition_summary="\n   How about some more whitespace? \n             \n",
@@ -520,13 +537,15 @@ class TestPageService:
 
     def test_reject_measure_version(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionFactory(status="DRAFT")
+        measure_version = MeasureVersionFactory(version="1.0", status="DRAFT")
 
         assert measure_version.status == "DRAFT"
 
         page_service.update_measure_version(
             measure_version,
-            measure_version_form=MeasureVersionForm(title="Who cares", db_version_id=measure_version.db_version_id),
+            measure_version_form=MeasureVersionForm(
+                is_minor_update=False, title="Who cares", db_version_id=measure_version.db_version_id
+            ),
             last_updated_by_email=user.email,
             data_source_forms=[],
             **{"status": "DEPARTMENT_REVIEW"},

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -36,7 +36,7 @@ class TestGetCreateMeasurePage:
         LowestLevelOfGeographyFactory(name=stub_measure_data["lowest_level_of_geography_id"])
         subtopic = SubtopicFactory()
         SubtopicPageFactory(slug=subtopic.slug)  # TODO: Remove
-        form = MeasureVersionForm(**stub_measure_data)
+        form = MeasureVersionForm(is_minor_update=False, **stub_measure_data)
 
         response = test_app_client.post(
             url_for("cms.create_measure", topic_slug=subtopic.topic.slug, subtopic_slug=subtopic.slug),
@@ -54,7 +54,7 @@ class TestGetCreateMeasurePage:
         LowestLevelOfGeographyFactory(name=stub_measure_data["lowest_level_of_geography_id"])
         subtopic = SubtopicFactory()
         SubtopicPageFactory(slug=subtopic.slug)  # TODO: Remove
-        form = MeasureVersionForm(**stub_measure_data)
+        form = MeasureVersionForm(is_minor_update=False, **stub_measure_data)
         request_mock = mock.Mock()
         request_mock.method = "POST"
         data_source_form, data_source_2_form = get_data_source_forms(request_mock, None)

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -596,7 +596,7 @@ def test_view_edit_measure_page_for_minor_update_shows_data_correction_radio(
         legend = update_corrects_data_mistake.find("legend")
         labels = update_corrects_data_mistake.findAll("label")
 
-        assert legend.text.strip() == "Does this update correct a mistake in the data, commentary, charts, or tables?"
+        assert legend.text.strip() == "Are you correcting something that’s factually incorrect?"
         assert labels[0].text.strip() == "Yes"
         assert labels[1].text.strip() == "No"
         assert (

--- a/tests/models.py
+++ b/tests/models.py
@@ -310,13 +310,14 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = MeasureVersion
         sqlalchemy_session_persistence = "flush"
-        exclude = {"_creator", "_publisher", "_unpublished", "_unpublisher"}
+        exclude = {"_creator", "_publisher", "_unpublished", "_unpublisher", "_is_major_version"}
 
     # Underscored attributes are helpers that assist in the creation of a valid (business-logic-wise) measure version.
     _creator = factory.SubFactory(UserFactory)
     _publisher = factory.SubFactory(UserFactory)
     _unpublished = factory.LazyAttribute(lambda o: o.status == "UNPUBLISHED")
     _unpublisher = factory.Maybe("_unpublished", yes_declaration=factory.SubFactory(UserFactory))
+    _is_major_version = factory.LazyAttribute(lambda o: o.version.endswith(".0"))
 
     # columns
     id = factory.Sequence(lambda x: x)
@@ -355,6 +356,9 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     time_covered = factory.Faker("paragraph", nb_sentences=3)
     external_edit_summary = factory.Faker("sentence", nb_words=10)
     internal_edit_summary = factory.Faker("sentence", nb_words=10)
+    update_corrects_data_mistake = factory.LazyAttribute(
+        lambda o: False if o._is_major_version else random.choice((True, False))
+    )
     lowest_level_of_geography_id = factory.SelfAttribute("lowest_level_of_geography.name")
     methodology = factory.Faker("paragraph", nb_sentences=3)
     suppression_and_disclosure = factory.Faker("paragraph", nb_sentences=3)


### PR DESCRIPTION
# Commit 1
`InputRequired` ensures that the user has submitted _some_ data, but
doesn't care what that data is. `DataRequired` enforces that the data is
also 'truthy'. Therefore, in order to accept falsey values (e.g. a
literal boolean False), we need to use `InputRequired` instead. We want
to ask whether an update to a measure version is due to correcting a
mistake in the data, and this is stored in the database as a boolean, so
we need to be able to accept falsey values in forms.

# Commit 2
When a minor update is published for a measure page, we want to know
whether or not the update is being published in order to correct a
mistake in the data so that we can be reputable and responsible
publishers of statistical data.

This patch adds a radio field to the measure page form which is only
required and visible for minor updates asking the user to confirm
whether or not they're correcting a mistake in the data. We can then
have a page elsewhere on the site that lists all of the times we've
corrected data mistakes.

 ## Ticket
https://trello.com/c/6DCYrLBY/1299

## What it looks like
![screen shot 2019-02-18 at 09 35 36](https://user-images.githubusercontent.com/2920760/52941380-915a4500-3360-11e9-94f6-1fc978b92169.png)


