### PR TITLE
 Add page listing corrected measure versions

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -405,7 +405,6 @@ def build_dashboards(build_dir):
 
 
 def build_other_static_pages(build_dir):
-
     template_path = os.path.join(os.getcwd(), "application/templates/static_site/static_pages")
 
     for root, dirs, files in os.walk(template_path):
@@ -425,6 +424,19 @@ def build_other_static_pages(build_dir):
             file_path = os.path.join(output_dir, "index.html")
             content = render_template(template_path)
             write_html(file_path, content)
+
+    # Data corrections page - relies on being run *after* publishing (and marking published) any new measure versions.
+    from application.cms.page_service import page_service
+
+    output_dir = os.path.join(build_dir, "corrections")
+    os.makedirs(output_dir, exist_ok=True)
+    write_html(
+        os.path.join(output_dir, "index.html"),
+        render_template(
+            "static_site/corrections.html",
+            measure_versions_corrected_and_published=page_service.get_measure_version_pairs_with_data_corrections(),
+        ),
+    )
 
 
 def build_error_pages(build_dir):

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -245,3 +245,14 @@ def search():
     )
     response._allow_google_custom_search_in_csp = True
     return response
+
+
+@static_site_blueprint.route("/corrections")
+@login_required
+def corrections():
+    measure_versions_corrected_and_published = page_service.get_measure_version_pairs_with_data_corrections()
+
+    return render_template(
+        "static_site/corrections.html",
+        measure_versions_corrected_and_published=measure_versions_corrected_and_published,
+    )

--- a/application/templates/_shared/_footer.html
+++ b/application/templates/_shared/_footer.html
@@ -23,6 +23,9 @@
               <li>
                   <a href="{{ url_for('static_site.privacy_policy').rstrip('/') }}">Privacy policy</a>
               </li>
+              <li>
+                  <a href="{{ url_for('static_site.corrections').rstrip('/') }}">Corrections</a>
+              </li>
           </ul>
       </div>
       <div class="column-one-third">

--- a/application/templates/static_site/corrections.html
+++ b/application/templates/static_site/corrections.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% set breadcrumbs =
+  [
+    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+  ]
+%}
+
+{% block pageTitle %}Corrections to published data - GOV.UK{% endblock %}
+
+{% block content %}
+    <h1 class="heading-xlarge">Corrections to published data</h1>
+
+    {% if measure_versions_corrected_and_published|length > 0 %}
+      {% for corrected_measure_version, published_version_with_correction in measure_versions_corrected_and_published %}
+        <div class="corrected-measure-version">
+        <h2 class="heading-small">
+          <a href="{{ url_for('static_site.measure_version',
+                               topic_slug=corrected_measure_version.measure.subtopic.topic.slug,
+                               subtopic_slug=corrected_measure_version.measure.subtopic.slug,
+                               measure_slug=corrected_measure_version.measure.slug,
+                               version=published_version_with_correction.version) }}">
+            {{ corrected_measure_version.title }}
+          </a>
+        </h2>
+        Version: {{ corrected_measure_version.version }}
+        <br>
+        {{ corrected_measure_version.published_at | format_friendly_date }}
+        <br>
+        {{ corrected_measure_version.external_edit_summary }}
+        </div>
+        <br>
+      {% endfor %}
+    {% else %}
+      <p>No data corrections have been published.</p>
+    {% endif %}
+{% endblock %}

--- a/scripts/data_migrations/2019-02-15_historical-data-corrections.sql
+++ b/scripts/data_migrations/2019-02-15_historical-data-corrections.sql
@@ -1,0 +1,44 @@
+UPDATE measure_version
+SET update_corrects_data_mistake = true
+FROM measure,
+     subtopic_measure,
+     subtopic,
+     topic
+WHERE measure_version.measure_id = measure.id
+  AND measure.id = subtopic_measure.measure_id
+  AND subtopic.id = subtopic_measure.subtopic_id
+  AND topic.id = subtopic.topic_id
+  AND topic.slug = 'work-pay-and-benefits'
+  AND subtopic.slug = 'employment'
+  AND measure.slug = 'employment'
+  AND measure_version.version = '1.2';
+
+UPDATE measure_version
+SET update_corrects_data_mistake = true
+FROM measure,
+     subtopic_measure,
+     subtopic,
+     topic
+WHERE measure_version.measure_id = measure.id
+  AND measure.id = subtopic_measure.measure_id
+  AND subtopic.id = subtopic_measure.subtopic_id
+  AND topic.id = subtopic.topic_id
+  AND topic.slug = 'education-skills-and-training'
+  AND subtopic.slug = 'after-education'
+  AND measure.slug = 'destinations-of-school-pupils-after-key-stage-4-usually-aged-16-years'
+  AND measure_version.version = '1.2';
+
+UPDATE measure_version
+SET update_corrects_data_mistake = true
+FROM measure,
+     subtopic_measure,
+     subtopic,
+     topic
+WHERE measure_version.measure_id = measure.id
+  AND measure.id = subtopic_measure.measure_id
+  AND subtopic.id = subtopic_measure.subtopic_id
+  AND topic.id = subtopic.topic_id
+  AND topic.slug = 'education-skills-and-training'
+  AND subtopic.slug = 'after-education'
+  AND measure.slug = 'destinations-of-students-after-key-stage-5-usually-aged-18-years'
+  AND measure_version.version = '1.2';

--- a/tests/application/dashboard/test_views.py
+++ b/tests/application/dashboard/test_views.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from flask import url_for
+from lxml import html
 
 import pytest
 
 from manage import refresh_materialized_views
-from tests.models import MeasureVersionWithDimensionFactory
+from tests.models import MeasureFactory, MeasureVersionFactory, MeasureVersionWithDimensionFactory
 
 
 @pytest.mark.parametrize(
@@ -33,3 +35,39 @@ def test_dashboard_pages_return_200(test_app_client, logged_in_rdu_user, dashboa
 
     resp = test_app_client.get(dashboard_url)
     assert resp.status_code == 200, f"Failed to load dashboards '{dashboard_url}'"
+
+
+def test_data_corrections_page_with_no_corrections(test_app_client, logged_in_rdu_user):
+    resp = test_app_client.get(url_for("static_site.corrections"))
+    doc = html.fromstring(resp.get_data(as_text=True))
+    assert len(doc.xpath("//div[@class='corrected-measure-version']")) == 0
+
+
+def test_data_corrections_page_shows_corrected_versions_with_link_to_latest_minor_version_in_same_major_version(
+    test_app_client, logged_in_rdu_user, db_session
+):
+    measure = MeasureFactory(slug="measure", subtopics__slug="subtopic", subtopics__topic__slug="topic")
+
+    measure_versions = []
+    for version, published_at, update_corrects_data_mistake in (
+        ("1.0", datetime.fromisoformat("2000-01-01T12:00:00"), False),
+        ("1.1", datetime.fromisoformat("2001-01-01T12:00:00"), True),
+        ("1.2", datetime.fromisoformat("2002-01-01T12:00:00"), False),
+        ("2.0", datetime.fromisoformat("2003-01-01T12:00:00"), False),
+    ):
+        measure_versions.append(
+            MeasureVersionFactory(
+                version=version,
+                status="APPROVED",
+                update_corrects_data_mistake=update_corrects_data_mistake,
+                published_at=published_at,
+                measure=measure,
+            )
+        )
+
+    resp = test_app_client.get(url_for("static_site.corrections"))
+    doc = html.fromstring(resp.get_data(as_text=True))
+
+    assert len(doc.xpath("//div[@class='corrected-measure-version']")) == 1
+    assert "1 January 2001" in doc.xpath("//div[@class='corrected-measure-version']")[0].text_content()
+    assert doc.xpath("//div[@class='corrected-measure-version']//h2/a/@href")[0] == "/topic/subtopic/measure/1.2"


### PR DESCRIPTION
 ## Summary
We now track when a minor update to a measure version is due to
correcting an issue with the data/commentary/chart/table. We also want
to have a page on the site that lists all of the times this has
happened. This page provides that list.

It lists each measure version, the date published, and the reasons. It
links out to the latest published minor version of the major version
which had the correction. This behaviour may be slightly odd but at the
moment we only publish the latest minor version for each major version
of a measure, so trying to link to the exact corrected version would end
up 404ing.

 ## Ticket
https://trello.com/c/mVvJZBQ9/1300

 ## Example
![screen shot 2019-02-19 at 10 45 22](https://user-images.githubusercontent.com/2920760/53009469-7e647500-3433-11e9-82f4-2e95e9323af0.png)