### PR TITLE
Longer timeout for test

### DIFF
--- a/tests/application/sitebuilder/test_build_service.py
+++ b/tests/application/sitebuilder/test_build_service.py
@@ -23,7 +23,7 @@ def test_build_exceptions_not_suppressed(app):
 
         request_build()
 
-        with pytest.raises(GeneralTestException) as e, stopit.SignalTimeout(1):
+        with pytest.raises(GeneralTestException) as e, stopit.SignalTimeout(2):
             build_site(app)
 
         assert str(e.value) == "build error"


### PR DESCRIPTION
This test sometimes fails on Heroku and my suspicion is that we
sometimes end up with a contested/slow CPU. Giving it some more time to
reach the `do_it` part of the `build_site` should give us fewer flaky
failures.