### PR TITLE
Remove old `page` model records

### DIFF
--- a/scripts/data_migrations/2019-02-18-remove-homepage-topic-subtopic-records.sql
+++ b/scripts/data_migrations/2019-02-18-remove-homepage-topic-subtopic-records.sql
@@ -1,0 +1,5 @@
+UPDATE measure_version SET parent_guid = null, parent_version = null;
+
+DELETE
+FROM measure_version
+WHERE page_type = 'subtopic' OR page_type = 'topic' OR page_type = 'homepage';


### PR DESCRIPTION
We now have proper tables for topics and subtopics, and the idea of a
homepage is integrated into the core of the site, so we can drop the
records in the (now) `measure_version` table that are hanging around
from the old `page` table.