### PR TITLE
Fix broken bits of the site

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1151,7 +1151,12 @@ def new_version(topic_slug, subtopic_slug, measure_slug, version):
             )
 
     return render_template(
-        "cms/create_new_version.html", topic=topic, subtopic=subtopic, measure=measure_version, form=form
+        "cms/create_new_version.html",
+        topic=topic,
+        subtopic=subtopic,
+        measure=measure,
+        measure_version=measure_version,
+        form=form,
     )
 
 

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -10,7 +10,7 @@
     <div class="header-proposition">
       <div class="content">
         <nav id="proposition-menu">
-          <span itemprop="name"><a itemprop="url" href="{{ config.RDU_SITE | strip_trailing_slash }}{{ url_for('static_site.index') }}" id="proposition-name">
+          <span itemprop="name"><a itemprop="url" href="{{ (config.RDU_SITE | strip_trailing_slash) if static_mode else "" }}{{ url_for('static_site.index') }}" id="proposition-name">
             Ethnicity facts and figures
           </a></span>
           <ul class="header-nav">

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
-    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title},
   ]
 %}
 
@@ -20,13 +20,13 @@
 
     <div class="grid-row">
         <div class="column-two-thirds new-version">
-            <p>Current version: <b>{{ measure.version }}</b>
-                <a href="{{ url_for('static_site.measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version) }}">
+            <p>Current version: <b>{{ measure_version.version }}</b>
+                <a href="{{ url_for('static_site.measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
                     View page
                 </a>
             </p>
             <form method="POST"
-                  action="{{ url_for('cms.new_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version) }}">
+                  action="{{ url_for('cms.new_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
                 {{ form.csrf_token }}
                 {{ form.version_type }}
                 <button class="button">Create new version in draft</button>


### PR DESCRIPTION
On the publisher (live site), the `Ethnicity facts and figures` link in the header is redirecting to the static site. We only want to include the full static site URL during static builds (in order to generate URLs for valid schema.org datasets). In the publisher, we'll retain a relative URL so that it takes you back to the homepage.

There's also a bug with creating new measure versions where we passed a `MeasureVersion` instance into a template under the name `measure`, and then tried to use `measure.slug`, which is null on measure versions.