### PR TITLE
guid+version no longer PK; fix review tokens to use ID only

### DIFF
--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -95,7 +95,7 @@ class DimensionService(Service):
 
     def delete_dimension(self, page, guid):
         if page.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.guid)
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.title)
             self.logger.error(message)
             raise PageUnEditable(message)
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -235,10 +235,8 @@ class MeasureVersion(db.Model, CopyableModel):
     # columns
     id = db.Column(db.Integer, nullable=False, primary_key=True, autoincrement=True)
     measure_id = db.Column(db.Integer, nullable=True)  # FK to `measure` table
-    guid = db.Column(db.String(255), nullable=False, primary_key=True)  # TODO: Remove, but needs dentangling first.
-    version = db.Column(
-        db.String(), nullable=False, primary_key=True
-    )  # The version number of this measure version in the format `X.y`.
+    guid = db.Column(db.String(255), nullable=False)  # TODO: Remove, but needs dentangling first.
+    version = db.Column(db.String(), nullable=False)  # The version number of this measure version in the format `X.y`.
     internal_reference = db.Column(db.String())  # optional internal reference number for measures
     latest = db.Column(db.Boolean, default=True)  # True if the current row is the latest version of a measure
     #                                               (latest created, not latest published, so could be a new draft)

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -452,7 +452,7 @@ class PageService(Service):
         message = measure_version.next_state()
         measure_version.last_updated_by = updated_by
         if measure_version.status == "DEPARTMENT_REVIEW":
-            measure_version.review_token = generate_review_token(measure_version.guid, measure_version.version)
+            measure_version.review_token = generate_review_token(measure_version.id)
         if measure_version.status == "APPROVED":
             measure_version.published_by = updated_by
         db.session.commit()

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -103,10 +103,10 @@ class PageService(Service):
 
     @staticmethod
     def get_measure_from_measure_version_id(measure_version_id):
-        try:
-            # TODO: Use `query.get` instead of `query.filter_by` after removing guid+version from MeasureVersion PK
-            return MeasureVersion.query.filter_by(id=measure_version_id).one().measure
-        except NoResultFound:
+        measure_version = MeasureVersion.query.get(measure_version_id)
+        if measure_version:
+            return measure_version.measure
+        else:
             raise PageNotFoundException()
 
     def get_measure_version_hierarchy(

--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -109,7 +109,7 @@ class UploadService(Service):
 
     def delete_upload_obj(self, page, upload):
         if page.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.guid)
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.title)
             self.logger.error(message)
             raise PageUnEditable(message)
         try:
@@ -136,7 +136,7 @@ class UploadService(Service):
             file_name = upload.filename
 
         if page.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.guid)
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.title)
             self.logger.error(message)
             raise PageUnEditable(message)
 
@@ -161,7 +161,7 @@ class UploadService(Service):
 
     def edit_upload(self, measure, upload, data, file=None):
         if measure.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure.guid)
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure.title)
             self.logger.error(message)
             raise PageUnEditable(message)
 

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -902,7 +902,7 @@ def save_chart_to_page(topic_slug, subtopic_slug, measure_slug, version, dimensi
     )
 
     if measure_version.not_editable():
-        message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_version.guid)
+        message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_version.title)
         current_app.logger.exception(message)
         raise PageUnEditable(message)
 
@@ -958,7 +958,7 @@ def save_table_to_page(topic_slug, subtopic_slug, measure_slug, version, dimensi
     )
 
     if measure_version.not_editable():
-        message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_version.guid)
+        message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure_version.title)
         current_app.logger.exception(message)
         raise PageUnEditable(message)
 

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -300,7 +300,7 @@
     {% if current_user.can(COPY_MEASURE) %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <form id="measure-action-section__copy_measure_form-{{ measure_version.guid }}" method="POST" action="{{ url_for('cms.copy_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
+            <form id="measure-action-section__copy_measure_form-{{ measure_version.id }}" method="POST" action="{{ url_for('cms.copy_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
                 {{ form.csrf_token }}
                 <button class="button copy-button" type="submit">Create a copy of this measure</button>
             </form>

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -402,7 +402,7 @@
             event.preventDefault();
             $.ajax({
                 type: 'GET',
-                url: "{{ url_for('review.get_new_review_url', id=measure_version.guid, version=measure_version.version)}}",
+                url: "{{ url_for('review.get_new_review_url', id=measure_version.id)}}",
                 success: function (data) {
                     $('#review-url').html(data);
                     initialiseCopy();

--- a/application/templates/cms/measure_actions.html
+++ b/application/templates/cms/measure_actions.html
@@ -1,6 +1,6 @@
 {% macro render_actions(topic, subtopic, measure, include_delete) -%}
     <div class="measure-action-section">
-        <div class="measure-action-section__main" id='measure-action-section-{{ measure.guid }}'>
-            <a href="{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.guid }}">View&nbsp;form</a>
+        <div class="measure-action-section__main" id='measure-action-section-{{ measure.id }}'>
+            <a href="{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.id }}">View&nbsp;form</a>
     </div>
 {%- endmacro %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -578,7 +578,6 @@
         </div>
       </div>
     </div>
-      <!-- TODO end versions -->
 
       <div class="govuk-document-footer">
 

--- a/application/utils.py
+++ b/application/utils.py
@@ -182,11 +182,10 @@ def write_dimension_tabular_csv(dimension):
         return output.getvalue()
 
 
-def generate_review_token(page_id, page_version):
+def generate_review_token(page_id):
     key = os.environ.get("SECRET_KEY")
     serializer = URLSafeTimedSerializer(key)
-    token = "%s|%s" % (page_id, page_version)
-    return serializer.dumps(token)
+    return serializer.dumps(str(page_id))
 
 
 def decode_review_token(token, config):
@@ -195,7 +194,9 @@ def decode_review_token(token, config):
     seconds_in_day = 24 * 60 * 60
     max_age_seconds = seconds_in_day * config.get("PREVIEW_TOKEN_MAX_AGE_DAYS")
     decoded_token = serializer.loads(token, max_age=max_age_seconds)
-    page_id, page_version = decoded_token.split("|")
+
+    # TODO: Once all guid-based tokens have expired adjust this to not split and return ID only
+    page_id, page_version = decoded_token.split("|") if "|" in decoded_token else (decoded_token, None)
     return page_id, page_version
 
 

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -254,7 +254,7 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(test_app_client):
     dept_user = UserFactory(user_type=TypeOfUser.DEPT_USER)
     admin_user = UserFactory(user_type=TypeOfUser.ADMIN_USER)
 
-    measure_page = MeasureVersionFactory(measure__shared_with=[dept_user])
+    measure_page = MeasureVersionFactory(status="DRAFT", measure__shared_with=[dept_user])
 
     with test_app_client.session_transaction() as session:
         session["user_id"] = dept_user.id

--- a/tests/application/review/test_views.py
+++ b/tests/application/review/test_views.py
@@ -2,7 +2,7 @@ import pytest
 
 from bs4 import BeautifulSoup
 from flask import url_for
-from itsdangerous import SignatureExpired, BadSignature
+from itsdangerous import SignatureExpired, BadSignature, URLSafeTimedSerializer
 
 from application.utils import decode_review_token
 from tests.models import MeasureVersionFactory, MeasureVersionWithDimensionFactory
@@ -44,7 +44,24 @@ def test_review_link_returns_404_if_token_incomplete(test_app_client):
 
 def test_review_token_decoded_if_not_expired(app):
 
+    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
+
+    expires_tomorrow = 1
+    decoded_guid, decoded_version = decode_review_token(
+        measure_version.review_token,
+        {"SECRET_KEY": app.config["SECRET_KEY"], "PREVIEW_TOKEN_MAX_AGE_DAYS": expires_tomorrow},
+    )
+
+    assert decoded_guid == str(measure_version.id)
+    assert decoded_version is None
+
+
+def test_old_style_review_token_decoded_if_not_expired(app):
+
+    serializer = URLSafeTimedSerializer(app.config["SECRET_KEY"])
     measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW", guid="test-measure-page")
+    old_style_token = serializer.dumps(f"{measure_version.guid}|{measure_version.version}")
+    measure_version.review_token = old_style_token
 
     expires_tomorrow = 1
     decoded_guid, decoded_version = decode_review_token(

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -211,28 +211,28 @@ class TopicPageLocators:
 
     @staticmethod
     def get_measure_edit_link(measure):
-        return By.ID, "measure-action-section__edit_button-%s" % measure.guid
+        return By.ID, "measure-action-section__edit_button-%s" % measure.id
 
     @staticmethod
     def get_measure_view_form_link(measure):
-        return By.ID, "measure-action-section__view_form_link-%s" % measure.guid
+        return By.ID, "measure-action-section__view_form_link-%s" % measure.id
 
     @staticmethod
     def get_measure_create_new_link(measure):
-        return By.ID, "measure-action-section__create_new_link-%s" % measure.guid
+        return By.ID, "measure-action-section__create_new_link-%s" % measure.id
 
     @staticmethod
     def get_measure_delete_link(measure):
-        return By.ID, "measure-action-section__delete_button-%s" % measure.guid
+        return By.ID, "measure-action-section__delete_button-%s" % measure.id
 
     @staticmethod
     def get_measure_confirm_yes_radio(measure):
-        return By.ID, "delete-radio-yes-%s" % measure.guid
+        return By.ID, "delete-radio-yes-%s" % measure.id
 
     @staticmethod
     def get_measure_confirm_no_radio(measure):
-        return By.ID, "delete-radio-yes-%s" % measure.guid
+        return By.ID, "delete-radio-yes-%s" % measure.id
 
     @staticmethod
     def get_measure_confirm_delete_button(measure):
-        return By.ID, "delete-confirm-button-%s" % measure.guid
+        return By.ID, "delete-confirm-button-%s" % measure.id

--- a/tests/models.py
+++ b/tests/models.py
@@ -258,7 +258,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     internal_reference = factory.Faker("sentence", nb_words=2)
     latest = True  # TODO: Add smarter logic
     review_token = factory.LazyAttribute(
-        lambda o: generate_review_token(o.guid, o.version)
+        lambda o: generate_review_token(o.id)
         if publish_status[o.status] >= publish_status["DEPARTMENT_REVIEW"]
         else None
     )


### PR DESCRIPTION
This PR removes all the "easy" places to swap in ID for GUID.

The main change here is in review tokens.  New tokens will be generated usng the ID only, but old tokens which have (guid, version) will also continue to work.

A later PR (in 2 weeks time) should drop the support for (guid, version) style tokens, as all existing tokens will have expired.