### PR TITLE
Fix UserFactory for tests

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -58,7 +58,9 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session_persistence = "commit"
         exclude = ("_password_to_hash",)
 
-    _password_to_hash = factory.Faker("word")
+    _password_to_hash = factory.Faker(
+        "password", length=random.randint(8, 12), special_chars=True, digits=True, upper_case=True, lower_case=True
+    )
 
     id = factory.Sequence(lambda x: x)
     email = factory.Faker("email")


### PR DESCRIPTION
The `UserFactory` was just using a single word as the password for
randomly-generated users, which sometimes selects words with just two
characters (and possibly one, presumably). Our login plugin doesn't seem
happy hashing such short strings, and this has been causing
intermittent/flaky test failures in our functional test suite (and
potentially in unit tests as well, though this hasn't been evidenced).

By enforcing a password generator of 8-12 random characters in the
factory we should avoid these intermittent failures.