### PR TITLE
Read uploads based on measure id, not guid

### DIFF
--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -36,8 +36,8 @@ class FileService:
             self.system = LocalFileSystem(root=app.config["LOCAL_ROOT"])
             self.logger.info("initialised local file system in %s" % (app.config["LOCAL_ROOT"]))
 
-    def page_system(self, page):
-        full_path = "%s/%s" % (page.guid, page.version)
+    def page_system(self, measure_version):
+        full_path = "%s/%s" % (measure_version.measure.id, measure_version.version)
         return PageFileSystem(self.system, full_path)
 
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -297,7 +297,7 @@ class MeasureVersion(db.Model, CopyableModel):
     # relationships
     measure = db.relationship("Measure", back_populates="versions")
     lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="pages")
-    uploads = db.relationship("Upload", back_populates="page", lazy="dynamic", cascade="all,delete")
+    uploads = db.relationship("Upload", back_populates="measure_version", lazy="dynamic", cascade="all,delete")
     dimensions = db.relationship(
         "Dimension", back_populates="page", lazy="dynamic", order_by="Dimension.position", cascade="all,delete"
     )
@@ -341,7 +341,7 @@ class MeasureVersion(db.Model, CopyableModel):
 
     def get_upload(self, guid):
         try:
-            upload = Upload.query.filter_by(guid=guid, page=self).one()
+            upload = Upload.query.filter_by(guid=guid, measure_version=self).one()
             return upload
         except NoResultFound:
             raise UploadNotFoundException
@@ -734,6 +734,7 @@ class Upload(db.Model, CopyableModel):
     # metadata
     __tablename__ = "upload"
     __table_args__ = (
+        # TODO: Update to only check measure_version_id
         ForeignKeyConstraint(
             ["measure_version_id", "page_id", "page_version"],
             ["measure_version.id", "measure_version.guid", "measure_version.version"],
@@ -749,11 +750,11 @@ class Upload(db.Model, CopyableModel):
     size = db.Column(db.String(255))
 
     measure_version_id = db.Column(db.Integer, nullable=False)
-    page_id = db.Column(db.String(255), nullable=False)
-    page_version = db.Column(db.String(), nullable=False)
+    page_id = db.Column(db.String(255), nullable=False)  # TODO: Remove as part of final cleanup migration
+    page_version = db.Column(db.String(), nullable=False)  # TODO: Remove as part of final cleanup migration
 
     # relationships
-    page = db.relationship("MeasureVersion", back_populates="uploads")
+    measure_version = db.relationship("MeasureVersion", back_populates="uploads")
 
     def extension(self):
         return self.file_name.split(".")[-1]

--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -25,14 +25,14 @@ class UploadService(Service):
     def __init__(self):
         super().__init__()
 
-    def get_url_for_file(self, page, file_name, directory="data"):
-        page_file_system = self.app.file_service.page_system(page)
+    def get_url_for_file(self, measure_version, file_name, directory="data"):
+        page_file_system = self.app.file_service.page_system(measure_version)
         return page_file_system.url_for_file("%s/%s" % (directory, file_name))
 
     def copy_uploads_between_measure_versions(self, from_measure_version, to_measure_version):
         page_file_system = self.app.file_service.page_system(to_measure_version)
-        from_key = "%s/%s/source" % (from_measure_version.guid, from_measure_version.version)
-        to_key = "%s/%s/source" % (to_measure_version.guid, to_measure_version.version)
+        from_key = "%s/%s/source" % (from_measure_version.measure.id, from_measure_version.version)
+        to_key = "%s/%s/source" % (to_measure_version.measure.id, to_measure_version.version)
 
         for upload in to_measure_version.uploads:
             from_path = "%s/%s" % (from_key, upload.file_name)
@@ -66,26 +66,26 @@ class UploadService(Service):
 
         return encoding.upper()
 
-    def delete_upload_files(self, page, file_name):
+    def delete_upload_files(self, measure_version, file_name):
         try:
-            page_file_system = self.app.file_service.page_system(page)
+            page_file_system = self.app.file_service.page_system(measure_version)
             page_file_system.delete("source/%s" % file_name)
         except FileNotFoundError:
             self.logger.exception("Could not find source/%s" % file_name)
 
-    def get_page_uploads(self, page):
-        page_file_system = self.app.file_service.page_system(page)
+    def get_page_uploads(self, measure_version):
+        page_file_system = self.app.file_service.page_system(measure_version)
         return page_file_system.list_files("data")
 
     def get_measure_download(self, upload, file_name, directory):
-        page_file_system = self.app.file_service.page_system(upload.page)
+        page_file_system = self.app.file_service.page_system(upload.measure_version)
         output_file = tempfile.NamedTemporaryFile(delete=False)
         key = "%s/%s" % (directory, file_name)
         page_file_system.read(key, output_file.name)
         return output_file.name
 
-    def upload_data(self, page, file, filename=None):
-        page_file_system = self.app.file_service.page_system(page)
+    def upload_data(self, measure_version, file, filename=None):
+        page_file_system = self.app.file_service.page_system(measure_version)
         if not filename:
             filename = file.name
 
@@ -107,65 +107,76 @@ class UploadService(Service):
 
         return page_file_system
 
-    def delete_upload_obj(self, page, upload):
-        if page.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.title)
+    def delete_upload_obj(self, measure_version, upload):
+        if measure_version.not_editable():
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(
+                measure_version.title
+            )
             self.logger.error(message)
             raise PageUnEditable(message)
         try:
-            self.delete_upload_files(page=page, file_name=upload.file_name)
+            self.delete_upload_files(measure_version=measure_version, file_name=upload.file_name)
         except FileNotFoundError:
             pass
 
         db.session.delete(upload)
         db.session.commit()
 
-    def get_upload(self, page, file_name):
+    def get_upload(self, measure_version, file_name):
         try:
-            upload = Upload.query.filter_by(page=page, file_name=file_name).one()
+            upload = Upload.query.filter_by(measure_version=measure_version, file_name=file_name).one()
             return upload
         except NoResultFound as e:
             self.logger.exception(e)
             raise UploadNotFoundException()
 
-    def create_upload(self, page, upload, title, description):
+    def create_upload(self, measure_version, upload, title, description):
         extension = upload.filename.split(".")[-1]
         if title and extension:
             file_name = "%s.%s" % (slugify(title), extension)
         else:
             file_name = upload.filename
 
-        if page.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(page.title)
+        if measure_version.not_editable():
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(
+                measure_version.title
+            )
             self.logger.error(message)
             raise PageUnEditable(message)
 
         guid = create_guid(file_name)
 
-        if not self.check_upload_title_unique(page, title):
+        if not self.check_upload_title_unique(measure_version, title):
             raise UploadAlreadyExists("An upload with that title already exists for this measure")
         else:
             self.logger.info("Upload with guid %s does not exist ok to proceed", guid)
             upload.seek(0, os.SEEK_END)
             size = upload.tell()
             upload.seek(0)
-            self.upload_data(page, upload, filename=file_name)
+            self.upload_data(measure_version, upload, filename=file_name)
             db_upload = Upload(
-                guid=guid, title=title, file_name=file_name, description=description, page=page, size=size
+                guid=guid,
+                title=title,
+                file_name=file_name,
+                description=description,
+                measure_version=measure_version,
+                size=size,
             )
 
-            page.uploads.append(db_upload)
+            measure_version.uploads.append(db_upload)
             db.session.commit()
 
         return db_upload
 
-    def edit_upload(self, measure, upload, data, file=None):
-        if measure.not_editable():
-            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(measure.title)
+    def edit_upload(self, measure_version, upload, data, file=None):
+        if measure_version.not_editable():
+            message = 'Error updating page "{}" - only pages in DRAFT or REJECT can be edited'.format(
+                measure_version.title
+            )
             self.logger.error(message)
             raise PageUnEditable(message)
 
-        page_file_system = self.app.file_service.page_system(measure)
+        page_file_system = self.app.file_service.page_system(measure_version)
 
         new_title = data.get("title", upload.title)
         existing_title = upload.title
@@ -178,32 +189,32 @@ class UploadService(Service):
                 size = file.tell()
                 file.seek(0)
                 file.size = size
-                upload_service.upload_data(measure, file, filename=file_name)
+                upload_service.upload_data(measure_version, file, filename=file_name)
                 if upload.file_name != file_name:
-                    upload_service.delete_upload_files(page=measure, file_name=upload.file_name)
+                    upload_service.delete_upload_files(measure_version=measure_version, file_name=upload.file_name)
                 upload.file_name = file_name
             else:
                 file.seek(0, os.SEEK_END)
                 size = file.tell()
                 file.seek(0)
                 file.size = size
-                upload_service.upload_data(measure, file, filename=file.filename)
+                upload_service.upload_data(measure_version, file, filename=file.filename)
                 if upload.file_name != file.filename:
-                    upload_service.delete_upload_files(page=measure, file_name=upload.file_name)
+                    upload_service.delete_upload_files(measure_version=measure_version, file_name=upload.file_name)
                 upload.file_name = file.filename
         else:
             if new_title != existing_title:  # current file needs renaming
                 extension = upload.file_name.split(".")[-1]
                 file_name = "%s.%s" % (slugify(data["title"]), extension)
                 if self.app.config.get("FILE_SERVICE", "local").lower() == "local":
-                    path = self.get_url_for_file(measure, upload.file_name)
+                    path = self.get_url_for_file(measure_version, upload.file_name)
                     dir_path = os.path.dirname(path)
                     page_file_system.rename_file(upload.file_name, file_name, dir_path)
                 else:
                     if data["title"] != upload.title:
-                        path = "%s/%s/source" % (measure.guid, measure.version)
+                        path = "%s/%s/source" % (measure_version.measure.id, measure_version.version)
                         page_file_system.rename_file(upload.file_name, file_name, path)
-                upload_service.delete_upload_files(page=measure, file_name=upload.file_name)
+                upload_service.delete_upload_files(measure_version=measure_version, file_name=upload.file_name)
                 upload.file_name = file_name
 
         upload.description = data["description"] if "description" in data else upload.title
@@ -212,9 +223,9 @@ class UploadService(Service):
         db.session.commit()
 
     @staticmethod
-    def check_upload_title_unique(page, title):
+    def check_upload_title_unique(measure_version, title):
         try:
-            Upload.query.filter_by(page=page, title=title).one()
+            Upload.query.filter_by(measure_version=measure_version, title=title).one()
             return False
         except NoResultFound:
             return True

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -144,9 +144,11 @@ def edit_upload(topic_slug, subtopic_slug, measure_slug, version, upload_guid):
     if request.method == "POST":
         form = UploadForm(CombinedMultiDict((request.files, request.form)))
         if form.validate():
-            f = form.upload.data if form.upload.data else None
+            file_data = form.upload.data if form.upload.data else None
             try:
-                upload_service.edit_upload(measure=measure_version, upload=upload_object, file=f, data=form.data)
+                upload_service.edit_upload(
+                    measure_version=measure_version, upload=upload_object, file=file_data, data=form.data
+                )
                 message = "Updated upload {}".format(upload_object.title)
                 flash(message, "info")
                 return redirect(
@@ -373,10 +375,13 @@ def create_upload(topic_slug, subtopic_slug, measure_slug, version):
     if request.method == "POST":
         form = UploadForm(CombinedMultiDict((request.files, request.form)))
         if form.validate():
-            f = form.upload.data
+            file_data = form.upload.data
             try:
                 upload = upload_service.create_upload(
-                    page=measure_version, upload=f, title=form.data["title"], description=form.data["description"]
+                    measure_version=measure_version,
+                    upload=file_data,
+                    title=form.data["title"],
+                    description=form.data["description"],
                 )
 
                 message = 'Uploaded file "{}" to measure "{}"'.format(upload.title, measure_slug)
@@ -387,7 +392,13 @@ def create_upload(topic_slug, subtopic_slug, measure_slug, version):
                 message = "Error uploading file. {}".format(str(e))
                 current_app.logger.exception(e)
                 flash(message, "error")
-                context = {"form": form, "topic": topic, "subtopic": subtopic, "measure": measure_version}
+                context = {
+                    "form": form,
+                    "topic": topic,
+                    "subtopic": subtopic,
+                    "measure": measure_version.measure,
+                    "measure_version": measure_version,
+                }
                 return render_template("cms/create_upload.html", **context)
 
             return redirect(
@@ -400,7 +411,13 @@ def create_upload(topic_slug, subtopic_slug, measure_slug, version):
                 )
             )
 
-    context = {"form": form, "topic": topic, "subtopic": subtopic, "measure": measure_version}
+    context = {
+        "form": form,
+        "topic": topic,
+        "subtopic": subtopic,
+        "measure": measure_version.measure,
+        "measure_version": measure_version,
+    }
     return render_template("cms/create_upload.html", **context)
 
 

--- a/application/sitebuilder/build_service.py
+++ b/application/sitebuilder/build_service.py
@@ -1,4 +1,5 @@
 import atexit
+
 import traceback
 import uuid
 from contextlib import contextmanager

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
-    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure.title},
   ]
 %}
 
@@ -22,7 +22,7 @@
         <div class="column-two-thirds">
             {% block measure_form %}
                 <form method="POST" enctype="multipart/form-data"
-                      action="{{ url_for('cms.create_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure.version ) }}">
+                      action="{{ url_for('cms.create_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ form.upload.label }}

--- a/tests/models.py
+++ b/tests/models.py
@@ -163,7 +163,7 @@ class UploadFactory(factory.alchemy.SQLAlchemyModelFactory):
     page_version = factory.Maybe("page", factory.SelfAttribute("page.version"))
 
     # scalar relationships
-    page = None  # Don't generate relationships 'towards' MeasureVersionFactory; see tests/README.md
+    measure_version = None  # Don't generate relationships 'towards' MeasureVersionFactory; see tests/README.md
 
 
 class TopicFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -309,7 +309,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
 
         else:
             factory_method = _get_factory_generator_for_strategy(UploadFactory, create)
-            factory_method(page=self, **kwargs)
+            factory_method(measure_version=self, **kwargs)
 
     @factory.post_generation
     def data_sources(self, create, extracted, **kwargs):


### PR DESCRIPTION
Change uploads in S3 to key on the measure id rather than
measure_version/measure guids, which we plan to retire.

Sits on top of another commit/pr, so only review latest commit.