### PR TITLE
Specify width of email input

### DIFF
--- a/application/templates/static_site/_newsletter-sign-up.html
+++ b/application/templates/static_site/_newsletter-sign-up.html
@@ -7,7 +7,7 @@
 
     <div class="govuk-form-group email">
       <label class="govuk-label" for="newsletter-email">Email address</label>
-      <input id="newsletter-email" type="email" class="govuk-input" name="EMAIL" />
+      <input id="newsletter-email" type="email" class="govuk-input govuk-input--width-20" name="EMAIL" />
       <button class="govuk-button">Subscribe</button>
     </div>
 


### PR DESCRIPTION
This stops the e-mail input being full-width on the static build.