### PR TITLE
Hide custom classification panel correctly

### DIFF
--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -76,7 +76,6 @@ $(document).ready(function () {
     */
 
     function handleNewData(on_success) {
-
         // get the data
         var tabbedData = $("#data_text_area").val();
 
@@ -106,10 +105,12 @@ $(document).ready(function () {
                 // populate the ethnicity presets from the response
                 presets = response['presets'];
                 populateEthnicityPresets(presets);
+                showHideCustomEthnicityPanel()
 
                 // show the presets (step 2) and chart type (step 3) section
                 document.getElementById('ethnicity_settings_section').classList.remove('hidden')
                 document.getElementById('select_chart_type').classList.remove('hidden')
+
 
                 // any further processing
                 if (on_success) {
@@ -184,7 +185,7 @@ $(document).ready(function () {
         if($('#ethnicity_settings').val() === 'custom') {
             document.getElementById('custom_classification__panel').classList.remove('hidden')
         } else {
-            document.getElementById('custom_classification__panel').classList.remove('hidden')
+            document.getElementById('custom_classification__panel').classList.add('hidden')
         }
     }
 

--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -138,6 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 // populate the ethnicity presets from the response
                 presets = response['presets'];
                 populateEthnicityPresets(presets);
+                showHideCustomEthnicityPanel()
 
                 // show the presets (step 2) and table type (step 3) section
                 document.getElementById('ethnicity_settings_section').classList.remove('hidden')

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -150,6 +150,7 @@ class ChartBuilderPageLocators:
     PANEL_BAR_CHART_PRIMARY = (By.ID, "panel_primary_column")
     PANEL_BAR_CHART_SECONDARY = (By.ID, "panel_grouping_column")
     CHART_ETHNICITY_SETTINGS = (By.ID, "ethnicity_settings")
+    CUSTOM_CLASSIFICATION_PANEL = (By.ID, "custom_classification__panel")
 
     CHART_LINE_X_AXIS = (By.ID, "line__x-axis_column")
 
@@ -191,6 +192,7 @@ class TableBuilderPageLocators:
     TABLE_DATA_EDIT = (By.ID, "edit-data")
 
     TABLE_ETHNICITY_SETTINGS = (By.ID, "ethnicity_settings")
+    CUSTOM_CLASSIFICATION_PANEL = (By.ID, "custom_classification__panel")
     COMPLEX_TABLE_DATA_STYLE = (By.ID, "complex-table__data-style")
     COMPLEX_TABLE_COLUMNS = (By.ID, "ethnicity-as-row__columns")
     COMPLEX_TABLE_ROWS = (By.ID, "ethnicity-as-column__rows")

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -727,6 +727,10 @@ class ChartBuilderPage(BasePage):
         all_labels = self.driver.find_elements_by_class_name("highcharts-xaxis-labels")
         return all_labels[0].text.split("\n")
 
+    def get_custom_classification_panel(self):
+        element = self.wait_for_invisible_element(ChartBuilderPageLocators.CUSTOM_CLASSIFICATION_PANEL)
+        return element
+
     def get_ethnicity_settings_value(self):
         element = self.wait_for_element(ChartBuilderPageLocators.CHART_ETHNICITY_SETTINGS)
         dropdown = Select(element)
@@ -840,6 +844,10 @@ class TableBuilderPage(BasePage):
         element = self.wait_for_element(TableBuilderPageLocators.TABLE_DATA_CANCEL)
         self.scroll_to(element)
         element.click()
+
+    def get_custom_classification_panel(self):
+        element = self.wait_for_invisible_element(TableBuilderPageLocators.CUSTOM_CLASSIFICATION_PANEL)
+        return element
 
     def get_ethnicity_settings_value(self):
         element = self.wait_for_element(TableBuilderPageLocators.TABLE_ETHNICITY_SETTINGS)

--- a/tests/functional/test_chart_builder.py
+++ b/tests/functional/test_chart_builder.py
@@ -101,6 +101,7 @@ def run_save_and_load_scenario(chart_builder_page, driver):
     """
     assert chart_builder_page.get_ethnicity_settings_code() == "5B"
     assert chart_builder_page.get_ethnicity_settings_value() == "ONS 2011 - 5+1"
+    assert chart_builder_page.get_custom_classification_panel().is_displayed() is False
 
     """
     WHEN we select an alternate classification and save
@@ -138,6 +139,7 @@ def run_bar_chart_scenarios(chart_builder_page, driver):
     assert chart_builder_page.source_contains("5 rows by 2 columns")
     assert len(chart_builder_page.get_ethnicity_settings_list()) == 3
     assert chart_builder_page.get_ethnicity_settings_value() == "ONS 2011 - 5+1"
+    assert chart_builder_page.get_custom_classification_panel().is_displayed() is False
 
     """
     WHEN we select bar chart

--- a/tests/functional/test_table_builder.py
+++ b/tests/functional/test_table_builder.py
@@ -88,6 +88,7 @@ def run_save_and_load_scenario(table_builder_page, driver):
     """
     assert table_builder_page.get_ethnicity_settings_code() == "5B"
     assert table_builder_page.get_ethnicity_settings_value() == "ONS 2011 - 5+1"
+    assert table_builder_page.get_custom_classification_panel().is_displayed() is False
 
     """
     WHEN we choose a column to display
@@ -131,6 +132,7 @@ def run_simple_table_scenarios(table_builder_page, driver):
     assert table_builder_page.source_contains("5 rows by 2 columns")
     assert len(table_builder_page.get_ethnicity_settings_list()) == 3
     assert table_builder_page.get_ethnicity_settings_value() == "ONS 2011 - 5+1"
+    assert table_builder_page.get_custom_classification_panel().is_displayed() is False
     assert table_builder_page.input_index_column_name() == "Ethnicity"
 
     """


### PR DESCRIPTION
Chartbuilder had a `classList.remove` for both sides of the conditional.
We actually want to add the `hidden` class if the classification is not
custom. Also, both chart and table builders didn't correctly call code
to show/hide the custom classification panel after populating it with
data from the server.

 ## Ticket
https://trello.com/c/wrufHlxo/1328