### PR TITLE
Fix `get_latest_version_of_all_measures`

### DIFF
--- a/application/admin/views.py
+++ b/application/admin/views.py
@@ -34,7 +34,7 @@ def users():
 def user_by_id(user_id):
     user = User.query.filter_by(id=user_id).one()
     if user.user_type == TypeOfUser.DEPT_USER:
-        latest_measure_versions = page_service.get_latest_version_of_all_measures(include_drafts=True)
+        latest_measure_versions = page_service.get_latest_version_of_all_measures(include_not_published=True)
         shared = user.measures
     else:
         latest_measure_versions = []

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -168,10 +168,7 @@ class TestPageService:
     def test_get_latest_version_of_all_measures(self):
         measure_1_version_1_0 = MeasureVersionFactory(version="1.0", status="APPROVED", title="Measure 1 version 1.0")
         measure_1_version_2_0 = MeasureVersionFactory(
-            version="2.0", status="APPROVED", title="Measure 1 version 2.0", measure=measure_1_version_1_0.measure
-        )
-        measure_1_version_2_1 = MeasureVersionFactory(
-            version="2.1", status="DRAFT", title="Measure 1 version 2.1", measure=measure_1_version_1_0.measure
+            version="2.0", status="DRAFT", title="Measure 1 version 2.1", measure=measure_1_version_1_0.measure
         )
 
         measure_2_version_1_0 = MeasureVersionFactory(
@@ -180,18 +177,18 @@ class TestPageService:
             title="Measure 2 version 1.0",
             measure__subtopics=measure_1_version_1_0.measure.subtopics,
         )
-        measure_2_version_2_0 = MeasureVersionFactory(
-            version="2.0", status="DRAFT", title="Measure 2 version 2.0", measure=measure_2_version_1_0.measure
+        measure_2_version_1_1 = MeasureVersionFactory(
+            version="1.1", status="APPROVED", title="Measure 2 version 2.0", measure=measure_2_version_1_0.measure
         )
 
-        assert page_service.get_latest_version_of_all_measures(include_drafts=False) == [
-            measure_1_version_2_0,
-            measure_2_version_1_0,
+        assert page_service.get_latest_version_of_all_measures(include_not_published=False) == [
+            measure_1_version_1_0,
+            measure_2_version_1_1,
         ]
 
-        assert page_service.get_latest_version_of_all_measures(include_drafts=True) == [
-            measure_1_version_2_1,
-            measure_2_version_2_0,
+        assert page_service.get_latest_version_of_all_measures(include_not_published=True) == [
+            measure_1_version_2_0,
+            measure_2_version_1_1,
         ]
 
     def test_create_measure(self):


### PR DESCRIPTION
The logic for this method was faulty - it would always filter on the
`published` attribute on the model regardless of the value of
`include_drafts`. We only want to filter out drafts if `include_drafts`
is false, otherwise we want to apply no filtering. It's also slightly
wonky to filter on `published`; instead we want to include/exclude by
whether the measure is approved (as it should show up in results if it's
been approved but just hasn't yet made it out to the static site).
Because of this, it feels wrong to call the parameter `include_drafts` -
instead, we rename it to `include_not_published`, which feels like a more
accurate description now.

 ## Ticket
https://trello.com/c/lzMBSpbP/1322