### PR TITLE
Disable upload form

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -313,8 +313,15 @@ class UploadForm(FlaskForm):
     upload = FileField(
         label="File in CSV format", validators=[DataRequired(message="Please choose a file for users to download")]
     )
-    title = StringField(label="Title", validators=[DataRequired()])
-    description = TextAreaField()
+    title = RDUStringField(label="Title", hint="For example, ‘Household income data’", validators=[DataRequired()])
+    description = RDUTextAreaField(
+        hint=(
+            Markup(
+                "Please specify what the download file contains, for example:<br><br>This file contains the following: "
+                "measure, ethnicity, year, gender, age group, value, confidence intervals (upper bound, lower bound)."
+            )
+        )
+    )
 
 
 class DimensionRequiredForm(DimensionForm):

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -8,6 +8,7 @@
     {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure.latest_version.title},
   ]
 %}
+{% set form_disabled = not (measure_version.status == "DRAFT" or new) %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
 {% block pageTitle %}{{ page_title("Edit source data", error=(form.errors|length > 0) ) }}{% endblock %}
@@ -51,27 +52,27 @@
                         {{ form.upload.label }}
                         {% if form.upload.errors %}
                             - {{ form.upload.errors[0] }}
-                            {{ form.upload(class="error") }}
+                            {{ form.upload(class="error", disabled=form_disabled) }}
                         {% else %}
-                            {{ form.upload }}
+                            {{ form.upload(disabled=form_disabled) }}
                         {% endif %}
 
                         {{ form.title.label }}
                         <span class="form-hint">For example, ‘Household income data’</span>
                         {% if form.title.errors %}
                             - {{ form.title.errors[0] }}
-                            {{ form.title(class="error") }}
+                            {{ form.title(class="error", disabled=form_disabled) }}
                         {% else %}
-                            {{ form.title }}
+                            {{ form.title(disabled=form_disabled) }}
                         {% endif %}
 
                         {{ form.description.label }}
                         <span class="form-hint">Please specify what the download file contains, for example:<br><br>This file contains the following: measure, ethnicity, year, gender, age group, value, confidence intervals (upper bound, lower bound).</span>
                         {% if form.description.errors %}
                             - {{ form.description.errors[0] }}
-                            {{ form.description(class="error", rows='7',cols='100') }}
+                            {{ form.description(class="error", disabled=form_disabled, rows='7',cols='100') }}
                         {% else %}
-                            {{ form.description(rows='7',cols='100') }}
+                            {{ form.description(disabled=form_disabled, rows='7',cols='100') }}
                         {% endif %}
 
                     {% endblock fields %}

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -57,23 +57,9 @@
                             {{ form.upload(disabled=form_disabled) }}
                         {% endif %}
 
-                        {{ form.title.label }}
-                        <span class="form-hint">For example, ‘Household income data’</span>
-                        {% if form.title.errors %}
-                            - {{ form.title.errors[0] }}
-                            {{ form.title(class="error", disabled=form_disabled) }}
-                        {% else %}
-                            {{ form.title(disabled=form_disabled) }}
-                        {% endif %}
+                        {{ form.title(disabled=form_disabled) }}
 
-                        {{ form.description.label }}
-                        <span class="form-hint">Please specify what the download file contains, for example:<br><br>This file contains the following: measure, ethnicity, year, gender, age group, value, confidence intervals (upper bound, lower bound).</span>
-                        {% if form.description.errors %}
-                            - {{ form.description.errors[0] }}
-                            {{ form.description(class="error", disabled=form_disabled, rows='7',cols='100') }}
-                        {% else %}
-                            {{ form.description(disabled=form_disabled, rows='7',cols='100') }}
-                        {% endif %}
+                        {{ form.description(disabled=form_disabled, rows='7', cols='100') }}
 
                     {% endblock fields %}
 


### PR DESCRIPTION
When viewing historical versions of a measure as a CMS user, we don't
want form fields to be interactive. Users should be able to see what's
there, but not be given the impression they can edit it at all.

Also, this converts the UploadForm to use RDU form fields.

 ## Ticket
https://trello.com/c/uHW1om9S/1339