### PR TITLE
Remove all deprecated data model refs

### DIFF
--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -18,11 +18,11 @@ class DimensionService(Service):
     def __init__(self):
         super().__init__()
 
-    def create_dimension(self, page, title, time_period, summary):
+    def create_dimension(self, measure_version, title, time_period, summary):
 
         guid = create_guid(title)
 
-        if not self.check_dimension_title_unique(page, title):
+        if not self.check_dimension_title_unique(measure_version, title):
             raise DimensionAlreadyExists()
         else:
             self.logger.info("Dimension with guid %s does not exist ok to proceed", guid)
@@ -32,14 +32,14 @@ class DimensionService(Service):
                 title=title,
                 time_period=time_period,
                 summary=summary,
-                page=page,
-                position=page.dimensions.count(),
+                measure_version=measure_version,
+                position=measure_version.dimensions.count(),
             )
 
-            page.dimensions.append(db_dimension)
+            measure_version.dimensions.append(db_dimension)
             db.session.commit()
 
-            return page.get_dimension(db_dimension.guid)
+            return measure_version.get_dimension(db_dimension.guid)
 
     # This does some pre-processing of form data submitted by chart and table builders
     # It also sets the flag update_clasification=True when update_dimension is called, to
@@ -112,9 +112,9 @@ class DimensionService(Service):
             raise DimensionNotFoundException()
 
     @staticmethod
-    def check_dimension_title_unique(page, title):
+    def check_dimension_title_unique(measure_version, title):
         try:
-            Dimension.query.filter_by(page=page, title=title).one()
+            Dimension.query.filter_by(measure_version=measure_version, title=title).one()
             return False
         except NoResultFound:
             return True

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -299,7 +299,11 @@ class MeasureVersion(db.Model, CopyableModel):
     lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="pages")
     uploads = db.relationship("Upload", back_populates="measure_version", lazy="dynamic", cascade="all,delete")
     dimensions = db.relationship(
-        "Dimension", back_populates="page", lazy="dynamic", order_by="Dimension.position", cascade="all,delete"
+        "Dimension",
+        back_populates="measure_version",
+        lazy="dynamic",
+        order_by="Dimension.position",
+        cascade="all,delete",
     )
     data_sources = db.relationship(
         "DataSource", secondary="data_source_in_measure_version", back_populates="pages", order_by=asc(DataSource.id)
@@ -334,7 +338,7 @@ class MeasureVersion(db.Model, CopyableModel):
 
     def get_dimension(self, guid):
         try:
-            dimension = Dimension.query.filter_by(guid=guid, page=self).one()
+            dimension = Dimension.query.filter_by(guid=guid, measure_version=self).one()
             return dimension
         except NoResultFound:
             raise DimensionNotFoundException
@@ -577,7 +581,7 @@ class Dimension(db.Model):
     # relationships
     dimension_chart = db.relationship("Chart")
     dimension_table = db.relationship("Table")
-    page = db.relationship("MeasureVersion", back_populates="dimensions")
+    measure_version = db.relationship("MeasureVersion", back_populates="dimensions")
     classification_links = db.relationship(
         "DimensionClassification", back_populates="dimension", lazy="dynamic", cascade="all,delete"
     )
@@ -682,7 +686,7 @@ class Dimension(db.Model):
         return {
             "guid": self.guid,
             "title": self.title,
-            "measure": self.page.guid,
+            "measure": self.measure_version.measure.id,
             "time_period": self.time_period,
             "summary": self.summary,
             "chart": self.chart,

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -177,7 +177,9 @@ class DataSource(db.Model, CopyableModel):
     frequency_of_release = db.relationship(
         "FrequencyOfRelease", foreign_keys=[frequency_of_release_id], back_populates="data_sources"
     )
-    pages = db.relationship("MeasureVersion", secondary="data_source_in_measure_version", back_populates="data_sources")
+    measure_versions = db.relationship(
+        "MeasureVersion", secondary="data_source_in_measure_version", back_populates="data_sources"
+    )
 
 
 class DataSourceInMeasureVersion(db.Model):
@@ -244,7 +246,7 @@ class MeasureVersion(db.Model, CopyableModel):
     review_token = db.Column(db.String())  # used for review page URLs
     description = db.Column(db.Text)  # Short description aimed at search result listings and social media sharing
 
-    # status for measure pages is one of APPROVED, DRAFT, DEPARTMENT_REVIEW, INTERNAL_REVIEW, REJECTED, UNPUBLISHED
+    # status for measure versions is one of APPROVED, DRAFT, DEPARTMENT_REVIEW, INTERNAL_REVIEW, REJECTED, UNPUBLISHED
     # but it's free text in the DB and for other page types we have NULL or "draft" ¯\_(ツ)_/¯
     status = db.Column(db.String(255))
 
@@ -253,10 +255,9 @@ class MeasureVersion(db.Model, CopyableModel):
     updated_at = db.Column(db.DateTime)  # timestamp when page updated
     last_updated_by = db.Column(db.String(255))  # email address of user who made the most recent update
 
-    # Only MEASURE PAGES are published. All other pages have published=False (or sometimes NULL)
-    published = db.Column(db.BOOLEAN, default=False)  # set to True when a page version is published
-    published_at = db.Column(db.Date, nullable=True)  # date set automatically by CMS when a page version is published
-    published_by = db.Column(db.String(255))  # email address of user who published the page
+    published = db.Column(db.BOOLEAN, default=False)  # set to True when a measure version is published
+    published_at = db.Column(db.Date, nullable=True)  # date - set automatically when a measure version is published
+    published_by = db.Column(db.String(255))  # email address of user who published the measure version
 
     unpublished_at = db.Column(db.Date, nullable=True)
     unpublished_by = db.Column(db.String(255))  # email address of user who unpublished the page
@@ -296,7 +297,7 @@ class MeasureVersion(db.Model, CopyableModel):
 
     # relationships
     measure = db.relationship("Measure", back_populates="versions")
-    lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="pages")
+    lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="measure_versions")
     uploads = db.relationship("Upload", back_populates="measure_version", lazy="dynamic", cascade="all,delete")
     dimensions = db.relationship(
         "Dimension",
@@ -306,7 +307,10 @@ class MeasureVersion(db.Model, CopyableModel):
         cascade="all,delete",
     )
     data_sources = db.relationship(
-        "DataSource", secondary="data_source_in_measure_version", back_populates="pages", order_by=asc(DataSource.id)
+        "DataSource",
+        secondary="data_source_in_measure_version",
+        back_populates="measure_versions",
+        order_by=asc(DataSource.id),
     )
 
     @property
@@ -949,7 +953,7 @@ class LowestLevelOfGeography(db.Model):
     position = db.Column(db.Integer, nullable=False)
 
     # relationships
-    pages = db.relationship("MeasureVersion", back_populates="lowest_level_of_geography")
+    measure_versions = db.relationship("MeasureVersion", back_populates="lowest_level_of_geography")
 
 
 class Topic(db.Model):

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -178,9 +178,9 @@ class PageService(Service):
                         return True
         return False
 
-    def _set_data_sources(self, page, data_source_forms):
-        current_data_sources = page.data_sources
-        page.data_sources = []
+    def _set_data_sources(self, measure_version, data_source_forms):
+        current_data_sources = measure_version.data_sources
+        measure_version.data_sources = []
 
         for i, data_source_form in enumerate(data_source_forms):
             existing_source = len(current_data_sources) > i
@@ -202,7 +202,7 @@ class PageService(Service):
                 )
 
                 if existing_source or source_has_truthy_values:
-                    page.data_sources.append(data_source)
+                    measure_version.data_sources.append(data_source)
 
     def create_measure(self, subtopic, measure_version_form, data_source_forms, created_by_email):
         title = measure_version_form.data.pop("title", "").strip()
@@ -234,7 +234,7 @@ class PageService(Service):
 
         measure_version_form.populate_obj(measure_version)
 
-        self._set_data_sources(page=measure_version, data_source_forms=data_source_forms)
+        self._set_data_sources(measure_version=measure_version, data_source_forms=data_source_forms)
 
         db.session.add(measure_version)
         db.session.commit()
@@ -365,7 +365,7 @@ class PageService(Service):
 
         # Update main fields of MeasureVersion
         measure_version_form.populate_obj(measure_version)
-        self._set_data_sources(page=measure_version, data_source_forms=data_source_forms)
+        self._set_data_sources(measure_version=measure_version, data_source_forms=data_source_forms)
 
         # Update fields in the parent Measure
         if "internal_reference" in measure_version_form.data:

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -612,7 +612,7 @@ def _post_create_dimension(topic_slug, subtopic_slug, measure_slug, version):
     if form.validate():
         try:
             dimension = dimension_service.create_dimension(
-                page=measure_version,
+                measure_version=measure_version,
                 title=form.data["title"],
                 time_period=form.data["time_period"],
                 summary=form.data["summary"],

--- a/application/data/dimensions.py
+++ b/application/data/dimensions.py
@@ -46,7 +46,6 @@ class DimensionObjectBuilder:
             if dimension.measure_version.measure.slug
             else "",
             "guid": dimension.guid,
-            "measure_guid": dimension.measure_version.guid if dimension.measure_version.guid else "",
             "measure_slug": dimension.measure_version.measure.slug if dimension.measure_version.measure.slug else "",
             "time_period": dimension.time_period if dimension.time_period else "",
             "location": dimension.measure_version.format_area_covered(),

--- a/application/data/dimensions.py
+++ b/application/data/dimensions.py
@@ -30,26 +30,26 @@ class DimensionObjectBuilder:
     def get_context(dimension):
         title, source_url, publisher, publication_date = "", "", "", ""
 
-        if dimension.page.primary_data_source:
-            title = dimension.page.primary_data_source.title
-            source_url = dimension.page.primary_data_source.source_url
+        if dimension.measure_version.primary_data_source:
+            title = dimension.measure_version.primary_data_source.title
+            source_url = dimension.measure_version.primary_data_source.source_url
 
-            if dimension.page.primary_data_source.publisher:
-                publisher = dimension.page.primary_data_source.publisher.name
+            if dimension.measure_version.primary_data_source.publisher:
+                publisher = dimension.measure_version.primary_data_source.publisher.name
 
-            publication_date = dimension.page.primary_data_source.publication_date
+            publication_date = dimension.measure_version.primary_data_source.publication_date
 
         return {
-            "measure": dimension.page.title,
+            "measure": dimension.measure_version.title,
             "dimension": dimension.title,
-            "dimension_slug": "%s/%s" % (dimension.page.measure.slug, dimension.guid)
-            if dimension.page.measure.slug
+            "dimension_slug": "%s/%s" % (dimension.measure_version.measure.slug, dimension.guid)
+            if dimension.measure_version.measure.slug
             else "",
             "guid": dimension.guid,
-            "measure_guid": dimension.page.guid if dimension.page.guid else "",
-            "measure_slug": dimension.page.measure.slug if dimension.page.measure.slug else "",
+            "measure_guid": dimension.measure_version.guid if dimension.measure_version.guid else "",
+            "measure_slug": dimension.measure_version.measure.slug if dimension.measure_version.measure.slug else "",
             "time_period": dimension.time_period if dimension.time_period else "",
-            "location": dimension.page.format_area_covered(),
+            "location": dimension.measure_version.format_area_covered(),
             "title": title,
             "source_url": source_url,
             "publisher": publisher,

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -223,7 +223,7 @@
                             <tr class="movable" data-dimension-guid="{{ dimension.guid }}">
                                 <td>{{ dimension.title }}</td>
                                 <td>
-                                    {% if dimension.page.version != '1.0' and dimension.updated_at != dimension.page.updated_at %}
+                                    {% if dimension.measure_version.version != '1.0' and dimension.updated_at != dimension.measure_version.updated_at %}
                                         <span class="updated-badge">Updated</span>
                                     {% endif %}
                                 </td>

--- a/migrations/versions/2019_02_22_clean_data_model.py
+++ b/migrations/versions/2019_02_22_clean_data_model.py
@@ -223,6 +223,7 @@ def upgrade():
     op.drop_column("measure_version", "slug")
     op.drop_column("measure_version", "additional_description")
     op.drop_column("measure_version", "page_type")
+    op.drop_column("measure_version", "internal_reference")
 
     # create primary key constraint
     op.create_primary_key("measure_version_id_pkey", "measure_version", ["id"])
@@ -264,6 +265,7 @@ def downgrade():
     op.drop_constraint(op.f("measure_version_id_pkey"), "measure_version", type_="primary")
 
     # create columns
+    op.add_column("measure_version", sa.Column("internal_reference", sa.String(), nullable=True))
     op.add_column("measure_version", sa.Column("page_type", sa.VARCHAR(length=255), autoincrement=False, nullable=True))
     op.add_column("measure_version", sa.Column("additional_description", sa.TEXT(), autoincrement=False, nullable=True))
     op.add_column("measure_version", sa.Column("slug", sa.VARCHAR(length=255), autoincrement=False, nullable=True))

--- a/migrations/versions/2019_02_22_clean_data_model.py
+++ b/migrations/versions/2019_02_22_clean_data_model.py
@@ -1,0 +1,325 @@
+"""Clean up our data model by removing fields/indexes/etc leftover from the old one
+
+Revision ID: 2019_02_22_clean_data_model
+Revises: 2019_02_15_remove_mid_matviews
+Create Date: 2019-02-22 16:40:55.560103
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_02_22_clean_data_model"
+down_revision = "2019_02_15_remove_mid_matviews"
+branch_labels = None
+depends_on = None
+
+drop_all_dashboard_helper_views = """
+DROP INDEX IF EXISTS uix_latest_published_measure_versions_by_geography;
+DROP INDEX IF EXISTS uix_latest_published_measure_versions;
+DROP INDEX IF EXISTS uix_ethnic_groups_by_dimension;
+DROP INDEX IF EXISTS uix_categorisations_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS latest_published_measure_versions_by_geography;
+DROP MATERIALIZED VIEW IF EXISTS ethnic_groups_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS classifications_by_dimension;
+DROP MATERIALIZED VIEW IF EXISTS latest_published_measure_versions;
+"""
+
+latest_published_measure_versions_view = """
+CREATE MATERIALIZED VIEW latest_published_measure_versions AS
+(
+   SELECT
+      mv.*
+   FROM
+      measure_version AS mv
+      JOIN
+         (
+            SELECT
+               measure_version.measure_id,
+               array_to_string(MAX(string_to_array(measure_version.version, '.')), '.') AS max_approved_version
+            FROM
+               measure_version
+            WHERE
+               measure_version.status = 'APPROVED'
+            GROUP BY
+               measure_version.measure_id
+         )
+         AS max_approved_measure_versions
+         ON mv.measure_id = max_approved_measure_versions.measure_id
+         AND mv.version = max_approved_measure_versions.max_approved_version
+);
+
+CREATE UNIQUE INDEX uix_latest_published_measure_versions
+ON latest_published_measure_versions (id);
+"""
+
+latest_published_measure_versions_by_geography_view = """
+CREATE MATERIALIZED VIEW latest_published_measure_versions_by_geography AS
+(
+   SELECT
+      topic.title AS topic_title,
+      topic.slug AS topic_slug,
+      subtopic.title AS subtopic_title,
+      subtopic.slug AS subtopic_slug,
+      subtopic.position AS subtopic_position,
+      measure.slug AS measure_slug,
+      measure.position AS measure_position,
+      measure_version.id AS measure_version_id,
+      measure_version.title AS measure_version_title,
+      geography.name AS geography_name,
+      geography.position AS geography_position
+   FROM
+      latest_published_measure_versions AS mv
+      JOIN lowest_level_of_geography AS geography ON mv.lowest_level_of_geography_id = geography.name
+      JOIN measure_version ON measure_version.id = mv.id
+      JOIN measure ON measure.id = measure_version.measure_id
+      JOIN subtopic_measure ON subtopic_measure.measure_id = measure.id
+      JOIN subtopic ON subtopic.id = subtopic_measure.subtopic_id
+      JOIN topic ON topic.id = subtopic.topic_id
+   ORDER BY
+      geography.position ASC
+);
+
+CREATE UNIQUE INDEX uix_latest_published_measure_versions_by_geography
+ON latest_published_measure_versions_by_geography (measure_version_id);
+"""
+
+
+ethnic_groups_by_dimension_view = """
+CREATE MATERIALIZED VIEW ethnic_groups_by_dimension AS
+(
+     SELECT
+        topic.title AS topic_title,
+        topic.slug AS topic_slug,
+        subtopic.title AS subtopic_title,
+        subtopic.slug AS subtopic_slug,
+        subtopic.position AS subtopic_position,
+        measure.id AS measure_id,
+        measure.slug AS measure_slug,
+        measure.position AS measure_position,
+        latest_published_measure_versions.id AS measure_version_id,
+        latest_published_measure_versions.title AS measure_version_title,
+        dimension.guid AS dimension_guid,
+        dimension.title AS dimension_title,
+        dimension.position AS dimension_position,
+        classification.title AS classification_title,
+        ethnicity.value AS ethnicity_value,
+        ethnicity.position AS ethnicity_position
+     FROM latest_published_measure_versions
+          JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+          JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+          JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+          JOIN topic ON subtopic.topic_id = topic.id
+          JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+          JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+          JOIN classification ON dimension_categorisation.classification_id = classification.id
+          JOIN ethnicity_in_classification ON classification.id = ethnicity_in_classification.classification_id
+          JOIN ethnicity ON ethnicity_in_classification.ethnicity_id = ethnicity.id
+     UNION
+     SELECT
+        topic.title AS topic_title,
+        topic.slug AS topic_slug,
+        subtopic.title AS subtopic_title,
+        subtopic.slug AS subtopic_slug,
+        subtopic.position AS subtopic_position,
+        measure.id AS measure_id,
+        measure.slug AS measure_slug,
+        measure.position AS measure_position,
+        latest_published_measure_versions.id AS measure_version_id,
+        latest_published_measure_versions.title AS measure_version_title,
+        dimension.guid AS dimension_guid,
+        dimension.title AS dimension_title,
+        dimension.position AS dimension_position,
+        classification.title AS classification_title,
+        ethnicity.value AS ethnicity_value,
+        ethnicity.position AS ethnicity_position
+     FROM latest_published_measure_versions
+          JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+          JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+          JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+          JOIN topic ON subtopic.topic_id = topic.id
+          JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+          JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+          JOIN classification ON dimension_categorisation.classification_id = classification.id
+          JOIN parent_ethnicity_in_classification ON classification.id = parent_ethnicity_in_classification.classification_id
+          JOIN ethnicity ON parent_ethnicity_in_classification.ethnicity_id = ethnicity.id
+     WHERE dimension_categorisation.includes_parents
+);
+
+CREATE UNIQUE INDEX uix_ethnic_groups_by_dimension ON ethnic_groups_by_dimension (dimension_guid, ethnicity_value);
+"""  # noqa
+
+
+classifications_by_dimension = """
+CREATE MATERIALIZED VIEW classifications_by_dimension AS
+(
+   SELECT
+      topic.title AS topic_title,
+      topic.slug AS topic_slug,
+      subtopic.title AS subtopic_title,
+      subtopic.slug AS subtopic_slug,
+      subtopic.position AS subtopic_position,
+      measure.id AS measure_id,
+      measure.slug AS measure_slug,
+      measure.position AS measure_position,
+      latest_published_measure_versions.id AS measure_version_id,
+      latest_published_measure_versions.title AS measure_version_title,
+      dimension.guid AS dimension_guid,
+      dimension.title AS dimension_title,
+      dimension.position AS dimension_position,
+      classification.id AS classification_id,
+      classification.title AS classification_title,
+      classification.position AS classification_position,
+      dimension_categorisation.includes_parents AS includes_parents,
+      dimension_categorisation.includes_all AS includes_all,
+      dimension_categorisation.includes_unknown AS includes_unknown
+   FROM
+      latest_published_measure_versions
+      JOIN measure ON latest_published_measure_versions.measure_id = measure.id
+      JOIN subtopic_measure ON measure.id = subtopic_measure.measure_id
+      JOIN subtopic ON subtopic_measure.subtopic_id = subtopic.id
+      JOIN topic ON subtopic.topic_id = topic.id
+      JOIN dimension ON dimension.measure_version_id = latest_published_measure_versions.id
+      JOIN dimension_categorisation ON dimension.guid = dimension_categorisation.dimension_guid
+      JOIN classification ON dimension_categorisation.classification_id = classification.id
+);
+
+CREATE UNIQUE INDEX uix_categorisations_by_dimension ON classifications_by_dimension (dimension_guid, classification_id);
+"""  # noqa
+
+
+def upgrade():
+    op.execute(drop_all_dashboard_helper_views)
+
+    # drop foreign key constraints
+    op.drop_constraint(op.f("measure_version_parent_id_fkey"), "measure_version", type_="foreignkey")
+    op.drop_constraint(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        type_="foreignkey",
+    )
+    op.drop_constraint(op.f("dimension_measure_version_id_fkey"), "dimension", type_="foreignkey")
+    op.drop_constraint(op.f("upload_measure_version_id_fkey"), "upload", type_="foreignkey")
+
+    # drop primary key constraint
+    op.drop_constraint(op.f("measure_version_id_pkey"), "measure_version", type_="primary")
+
+    # drop indexes
+    op.drop_index("ix_page_type_uri", table_name="measure_version")
+
+    # drop columns
+    op.drop_column("data_source_in_measure_version", "page_version")
+    op.drop_column("data_source_in_measure_version", "page_guid")
+    op.drop_column("dimension", "page_id")
+    op.drop_column("dimension", "page_version")
+    op.drop_column("upload", "page_id")
+    op.drop_column("upload", "page_version")
+    op.drop_column("measure_version", "guid")
+    op.drop_column("measure_version", "position")
+    op.drop_column("measure_version", "parent_guid")
+    op.drop_column("measure_version", "parent_version")
+    op.drop_column("measure_version", "parent_id")
+    op.drop_column("measure_version", "slug")
+    op.drop_column("measure_version", "additional_description")
+    op.drop_column("measure_version", "page_type")
+
+    # create primary key constraint
+    op.create_primary_key("measure_version_id_pkey", "measure_version", ["id"])
+
+    # create foreign key constraints
+    op.create_foreign_key(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        "measure_version",
+        ["measure_version_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        op.f("dimension_measure_version_id_fkey"), "dimension", "measure_version", ["measure_version_id"], ["id"]
+    )
+    op.create_foreign_key(
+        op.f("upload_measure_version_id_fkey"), "upload", "measure_version", ["measure_version_id"], ["id"]
+    )
+
+    op.execute(latest_published_measure_versions_view)
+    op.execute(latest_published_measure_versions_by_geography_view)
+    op.execute(ethnic_groups_by_dimension_view)
+    op.execute(classifications_by_dimension)
+
+
+def downgrade():
+    op.execute(drop_all_dashboard_helper_views)
+
+    # drop foreign key constraints
+    op.drop_constraint(op.f("upload_measure_version_id_fkey"), "upload", type_="foreignkey")
+    op.drop_constraint(op.f("dimension_measure_version_id_fkey"), "dimension", type_="foreignkey")
+    op.drop_constraint(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        type_="foreignkey",
+    )
+
+    # drop primary key constraint
+    op.drop_constraint(op.f("measure_version_id_pkey"), "measure_version", type_="primary")
+
+    # create columns
+    op.add_column("measure_version", sa.Column("page_type", sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column("measure_version", sa.Column("additional_description", sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("measure_version", sa.Column("slug", sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column("measure_version", sa.Column("parent_id", sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column("measure_version", sa.Column("parent_version", sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column(
+        "measure_version", sa.Column("parent_guid", sa.VARCHAR(length=255), autoincrement=False, nullable=True)
+    )
+    op.add_column("measure_version", sa.Column("position", sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column("measure_version", sa.Column("guid", sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column("upload", sa.Column("page_version", sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column("upload", sa.Column("page_id", sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column("dimension", sa.Column("page_version", sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column("dimension", sa.Column("page_id", sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column(
+        "data_source_in_measure_version",
+        sa.Column("page_guid", sa.VARCHAR(length=255), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "data_source_in_measure_version",
+        sa.Column("page_version", sa.VARCHAR(length=255), autoincrement=False, nullable=True),
+    )
+
+    # NOTE: Would need to re-populate guid/version fields on `measure_version` now for the rest of the migration
+    # to succeed; specifically setting up primary and foreign keys.
+
+    # create index
+    op.create_index("ix_page_type_uri", "measure_version", ["page_type", "slug"], unique=False)
+
+    # create primary key constraint
+    op.create_primary_key("measure_version_id_pkey", "measure_version", ["id", "guid", "version"])
+
+    # create foreign key constraints
+    op.create_foreign_key(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        "measure_version",
+        ["measure_version_id", "page_guid", "page_version"],
+        ["id", "guid", "version"],
+    )
+    op.create_foreign_key(
+        op.f("dimension_measure_version_id_fkey"),
+        "dimension",
+        "measure_version",
+        ["measure_version_id", "page_guid", "page_version"],
+        ["id", "guid", "version"],
+    )
+    op.create_foreign_key(
+        op.f("upload_measure_version_id_fkey"),
+        "upload",
+        "measure_version",
+        ["measure_version_id", "page_guid", "page_version"],
+        ["id", "guid", "version"],
+    )
+
+    op.execute(latest_published_measure_versions_view)
+    op.execute(latest_published_measure_versions_by_geography_view)
+    op.execute(ethnic_groups_by_dimension_view)
+    op.execute(classifications_by_dimension)

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ Example usage:
     This will create a Dimension with the given summary, no associated Chart, and all other data randomly-generated. It **will not** generate a MeasureVersion by default. A dimension is not valid without an associated MeasureVersion, so one will need to be created and the dimension attached to it before a database commit will succeed.
 * Creating a dimension and attaching it to an existing MeasureVersion:
     ```
-    dimension = DimensionFactory(page=measure_version)
+    dimension = DimensionFactory(measue_version=measure_version)
     ```
     Creates a Dimension and sets up the `page` relationship to point to an existing MeasureVersion.
 * Creating a Classification:

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -703,7 +703,7 @@ class TestMeasureVersion:
         assert minor_version_4.has_no_later_published_versions() is True
 
     def test_is_minor_or_minor_version(self):
-        page = MeasureVersionFactory(guid="test_page", version="1.0")
+        page = MeasureVersionFactory(version="1.0")
 
         assert page.version == "1.0"
         assert page.is_major_version() is True
@@ -738,21 +738,19 @@ class TestMeasureVersion:
 
     def test_measure_latest_version_returns_latest_measure_version(self):
         measure = MeasureFactory()
-        MeasureVersionFactory(version="1.0", guid=str(measure.id), latest=False, measure=measure)
-        MeasureVersionFactory(version="3.1", guid=str(measure.id), latest=True, measure=measure)
-        MeasureVersionFactory(version="2.0", guid=str(measure.id), latest=False, measure=measure)
-        MeasureVersionFactory(version="3.0", guid=str(measure.id), latest=False, measure=measure)
+        MeasureVersionFactory(version="1.0", latest=False, measure=measure)
+        MeasureVersionFactory(version="3.1", latest=True, measure=measure)
+        MeasureVersionFactory(version="2.0", latest=False, measure=measure)
+        MeasureVersionFactory(version="3.0", latest=False, measure=measure)
 
         assert measure.latest_version.version == "3.1"
 
     def test_measure_latest_published_version_returns_latest_published_version(self):
         measure = MeasureFactory()
-        MeasureVersionFactory(version="1.0", guid=str(measure.id), latest=False, status="APPROVED", measure=measure)
-        MeasureVersionFactory(version="2.0", guid=str(measure.id), latest=False, status="APPROVED", measure=measure)
-        MeasureVersionFactory(version="3.0", guid=str(measure.id), latest=False, status="APPROVED", measure=measure)
-        MeasureVersionFactory(
-            version="3.1", guid=str(measure.id), latest=True, status="DEPARTMENT_REVIEW", measure=measure
-        )
+        MeasureVersionFactory(version="1.0", latest=False, status="APPROVED", measure=measure)
+        MeasureVersionFactory(version="2.0", latest=False, status="APPROVED", measure=measure)
+        MeasureVersionFactory(version="3.0", latest=False, status="APPROVED", measure=measure)
+        MeasureVersionFactory(version="3.1", latest=True, status="DEPARTMENT_REVIEW", measure=measure)
 
         assert measure.latest_published_version.version == "3.0"
 
@@ -793,12 +791,12 @@ class TestMeasureVersion:
 
     def test_get_previous_version(self):
         measure = MeasureFactory()
-        mv1_0 = MeasureVersionFactory(guid="guid", version="1.0", measure=measure)
-        mv1_1 = MeasureVersionFactory(guid="guid", version="1.1", measure=measure)
-        mv1_2 = MeasureVersionFactory(guid="guid", version="1.2", measure=measure)
-        mv2_0 = MeasureVersionFactory(guid="guid", version="2.0", measure=measure)
-        mv2_1 = MeasureVersionFactory(guid="guid", version="2.1", measure=measure)
-        mv3_0 = MeasureVersionFactory(guid="guid", version="3.0", measure=measure)
+        mv1_0 = MeasureVersionFactory(version="1.0", measure=measure)
+        mv1_1 = MeasureVersionFactory(version="1.1", measure=measure)
+        mv1_2 = MeasureVersionFactory(version="1.2", measure=measure)
+        mv2_0 = MeasureVersionFactory(version="2.0", measure=measure)
+        mv2_1 = MeasureVersionFactory(version="2.1", measure=measure)
+        mv3_0 = MeasureVersionFactory(version="3.0", measure=measure)
 
         assert mv1_0.get_previous_version() is None
         assert mv1_1.get_previous_version() is mv1_0

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -357,27 +357,21 @@ class TestPageService:
 
     def test_create_new_version_of_page_duplicates_dimensions(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        # given an existing page with a dimension
         measure_version = MeasureVersionWithDimensionFactory(latest=True)
+
         assert measure_version.latest
         assert measure_version.dimensions.count() > 0
         old_dimension = measure_version.dimensions[0]
-        original_guid = old_dimension.guid
-        original_version = old_dimension.page_version
+        old_dimension_guid = old_dimension.guid
 
-        # when we copy the page
         new_version = page_service.create_measure_version(measure_version, NewVersionType.MINOR_UPDATE, user=user)
 
-        # then
         assert new_version.dimensions.count() > 0
         new_dimension = new_version.dimensions[0]
-        # new dimension should be a copy
-        assert new_dimension.title == old_dimension.title
 
-        # with guid and versions updated
-        assert new_dimension.guid != original_guid
-        assert new_dimension.page_version != original_version
-        assert new_dimension.page_version == new_version.version
+        assert old_dimension.title == new_dimension.title
+        assert old_dimension_guid != new_dimension.guid
+        assert measure_version is not new_dimension.measure_version
 
     def test_create_new_version_of_page_duplicates_dimension_categorisations(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
@@ -411,7 +405,7 @@ class TestPageService:
         assert measure_version.latest
 
         first_copy = page_service.create_measure_version(measure_version, NewVersionType.NEW_MEASURE, user=user)
-        first_copy_guid = first_copy.guid
+        first_copy_measure_id = first_copy.measure_id
         first_copy_title = first_copy.title
         first_copy_slug = first_copy.measure.slug
 
@@ -435,7 +429,7 @@ class TestPageService:
         assert user.email == first_copy.created_by
         assert second_copy.latest
 
-        assert first_copy_guid != second_copy.guid
+        assert first_copy_measure_id != second_copy.measure_id
         assert second_copy.title == f"COPY OF {first_copy_title}"
         assert second_copy.measure.slug == f"{first_copy_slug}-copy"
 

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -307,12 +307,7 @@ def test_order_measures_in_subtopic(test_app_client, logged_in_rdu_user):
     ids = [0, 1, 2, 3, 4]
     for id_ in ids:
         MeasureVersionFactory(
-            id=id_,
-            guid=str(id_),
-            measure__position=id_,
-            measure__id=id_,
-            measure__subtopics=[subtopic],
-            measure__slug=str(id_),
+            id=id_, measure__position=id_, measure__id=id_, measure__subtopics=[subtopic], measure__slug=str(id_)
         )
 
     assert subtopic.measures[0].slug == "0"
@@ -347,12 +342,7 @@ def test_reorder_measures_triggers_build(test_app_client, logged_in_rdu_user):
     reversed_ids = ids[::-1]
     for id_ in ids:
         MeasureVersionFactory(
-            id=id_,
-            guid=str(id_),
-            measure__position=id_,
-            measure__id=id_,
-            measure__subtopics=[subtopic],
-            measure__slug=str(id_),
+            id=id_, measure__position=id_, measure__id=id_, measure__subtopics=[subtopic], measure__slug=str(id_)
         )
 
     builds = Build.query.all()

--- a/tests/application/data/test_dimensions.py
+++ b/tests/application/data/test_dimensions.py
@@ -41,7 +41,6 @@ def test_table_object_builder_does_build_with_page_level_data_from_simple_table(
     )
     measure_version = MeasureVersionWithDimensionFactory(
         title="Test Measure Page",
-        guid="test-measure-page-guid",
         area_covered=[UKCountry.ENGLAND],
         data_sources=[data_source],
         dimensions__table=simple_table(),
@@ -56,7 +55,6 @@ def test_table_object_builder_does_build_with_page_level_data_from_simple_table(
 
     # then the measure level info should be brought through
     assert dimension_object["context"]["measure"] == "Test Measure Page"
-    assert dimension_object["context"]["measure_guid"] == "test-measure-page-guid"
     assert dimension_object["context"]["measure_slug"] == "test-measure-page-slug"
     assert dimension_object["context"]["location"] == "England"
     assert dimension_object["context"]["title"] == "DWP Stats"
@@ -70,7 +68,6 @@ def test_dimension_object_builder_does_build_with_page_level_data_from_grouped_t
     )
     measure_version = MeasureVersionWithDimensionFactory(
         title="Test Measure Page",
-        guid="test-measure-page-guid",
         area_covered=[UKCountry.ENGLAND],
         data_sources=[data_source],
         dimensions__table=grouped_table(),
@@ -85,7 +82,6 @@ def test_dimension_object_builder_does_build_with_page_level_data_from_grouped_t
 
     # then the measure level info should be brought through
     assert dimension_object["context"]["measure"] == "Test Measure Page"
-    assert dimension_object["context"]["measure_guid"] == "test-measure-page-guid"
     assert dimension_object["context"]["measure_slug"] == "test-measure-page-slug"
     assert dimension_object["context"]["location"] == "England"
     assert dimension_object["context"]["title"] == "DWP Stats"
@@ -96,7 +92,6 @@ def test_dimension_object_builder_does_build_with_page_level_data_from_grouped_t
 def test_table_object_builder_does_build_with_dimension_level_data_from_simple_table():
     measure_version = MeasureVersionWithDimensionFactory(
         title="Test Measure Page",
-        guid="test-measure-page-guid",
         area_covered=[UKCountry.ENGLAND],
         dimensions__title="Dimension title",
         dimensions__guid="dimension-guid",

--- a/tests/application/review/test_views.py
+++ b/tests/application/review/test_views.py
@@ -2,7 +2,7 @@ import pytest
 
 from bs4 import BeautifulSoup
 from flask import url_for
-from itsdangerous import SignatureExpired, BadSignature, URLSafeTimedSerializer
+from itsdangerous import SignatureExpired, BadSignature
 
 from application.utils import decode_review_token
 from application.auth.models import TypeOfUser
@@ -55,23 +55,6 @@ def test_review_token_decoded_if_not_expired(app):
 
     assert decoded_guid == str(measure_version.id)
     assert decoded_version is None
-
-
-def test_old_style_review_token_decoded_if_not_expired(app):
-
-    serializer = URLSafeTimedSerializer(app.config["SECRET_KEY"])
-    measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW", guid="test-measure-page")
-    old_style_token = serializer.dumps(f"{measure_version.guid}|{measure_version.version}")
-    measure_version.review_token = old_style_token
-
-    expires_tomorrow = 1
-    decoded_guid, decoded_version = decode_review_token(
-        measure_version.review_token,
-        {"SECRET_KEY": app.config["SECRET_KEY"], "PREVIEW_TOKEN_MAX_AGE_DAYS": expires_tomorrow},
-    )
-
-    assert decoded_guid == measure_version.guid
-    assert decoded_version == measure_version.version
 
 
 def test_review_token_expired_throws_signature_expired(app):

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -220,7 +220,6 @@ def test_view_export_page(test_app_client, logged_in_rdu_user):
     measure_version = MeasureVersionFactory(
         status="DRAFT",
         title="Test Measure Page",
-        guid="test-measure-page-guid",
         area_covered=[UKCountry.ENGLAND],
         lowest_level_of_geography__name="UK",
         time_covered="4 months",
@@ -455,7 +454,6 @@ def test_view_measure_page(test_app_client, logged_in_rdu_user):
     measure_version = MeasureVersionFactory(
         status="DRAFT",
         title="Test Measure Page",
-        guid="test-measure-page-guid",
         area_covered=[UKCountry.ENGLAND],
         lowest_level_of_geography__name="UK",
         time_covered="4 months",
@@ -548,13 +546,7 @@ def test_homepage_topics_display_in_rows_with_three_columns(
         topic = TopicFactory(slug=f"topic-{i}", title=f"Test topic page #{i}")
         subtopic = SubtopicFactory(slug=f"subtopic-{i}", title=f"Test subtopic page #{i}", topic=topic)
         measure = MeasureFactory(slug=f"measure-{i}", subtopics=[subtopic])
-        MeasureVersionFactory(
-            guid=f"measure_version_{i}",
-            status="APPROVED",
-            title=f"Test measure page #{i}",
-            version="1.0",
-            measure=measure,
-        )
+        MeasureVersionFactory(status="APPROVED", title=f"Test measure page #{i}", version="1.0", measure=measure)
 
     resp = test_app_client.get(url_for("static_site.index"))
     assert resp.status_code == 200

--- a/tests/models.py
+++ b/tests/models.py
@@ -340,7 +340,7 @@ class MeasureVersionWithDimensionFactory(MeasureVersionFactory):
         else:
             # self.dimensions.append(DimensionFactory(page=self, **kwargs))
             factory_method = _get_factory_generator_for_strategy(DimensionFactory, create)
-            factory_method(page=self, **kwargs)
+            factory_method(measure_version=self, **kwargs)
 
 
 class EthnicityFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -464,9 +464,9 @@ class DimensionFactory(factory.alchemy.SQLAlchemyModelFactory):
     table_builder_version = 2
     table_2_source_data = {}
 
-    measure_version_id = factory.Maybe("page", factory.SelfAttribute("page.id"))
-    page_id = factory.Maybe("page", factory.SelfAttribute("page.guid"))
-    page_version = factory.Maybe("page", factory.SelfAttribute("page.version"))
+    measure_version_id = factory.Maybe("measure_version", factory.SelfAttribute("measure_version.id"))
+    # page_id = factory.Maybe("page", factory.SelfAttribute("page.guid"))
+    # page_version = factory.Maybe("page", factory.SelfAttribute("page.version"))
 
     position = factory.Sequence(lambda x: x)
 
@@ -491,7 +491,7 @@ class DimensionFactory(factory.alchemy.SQLAlchemyModelFactory):
             factory_method = _get_factory_generator_for_strategy(DimensionClassificationFactory, create)
             self.classification_links = [factory_method(dimension=self, **kwargs)]
 
-    page = None  # Don't generate relationships 'towards' MeasureVersionFactory; see tests/README.md
+    measure_version = None  # Don't generate relationships 'towards' MeasureVersionFactory; see tests/README.md
 
 
 def __get_all_subclasses(cls):

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,8 +10,8 @@ import itertools
 import random
 
 from faker import Faker
-import factory
 
+import factory
 from application.auth.models import CAPABILITIES, TypeOfUser, User
 from application.cms.models import (
     publish_status,
@@ -140,9 +140,9 @@ class DataSourceFactory(factory.alchemy.SQLAlchemyModelFactory):
     # array-based relationships
     @factory.post_generation
     def measure_versions(self, create, extracted, **kwargs):
-        # If some measure_versions were passed in to the create invocation: eg factory.create(measure_versions=[page1])
+        # If some measure_versions were passed in to the create invocation: eg factory.create(measure_versions=[mv1])
         if extracted is not None:
-            # Attach those pages to this newly-created instance.
+            # Attach those measure versions to this newly-created instance.
             for measure_version in extracted:
                 self.measure_versions.append(measure_version)
 
@@ -158,9 +158,7 @@ class UploadFactory(factory.alchemy.SQLAlchemyModelFactory):
     description = factory.Faker("paragraph", nb_sentences=3)
     size = factory.LazyFunction(lambda: random.randint(0, 100_000))
 
-    measure_version_id = factory.Maybe("page", factory.SelfAttribute("page.id"))
-    page_id = factory.Maybe("page", factory.SelfAttribute("page.guid"))
-    page_version = factory.Maybe("page", factory.SelfAttribute("page.version"))
+    measure_version_id = factory.Maybe("measure_version", factory.SelfAttribute("measure_version.id"))
 
     # scalar relationships
     measure_version = None  # Don't generate relationships 'towards' MeasureVersionFactory; see tests/README.md
@@ -253,9 +251,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     # columns
     id = factory.Sequence(lambda x: x)
     measure_id = factory.SelfAttribute("measure.id")
-    guid = factory.Faker("uuid4")
     version = factory.LazyFunction(lambda: "1.0")
-    internal_reference = factory.Faker("sentence", nb_words=2)
     latest = True  # TODO: Add smarter logic
     review_token = factory.LazyAttribute(
         lambda o: generate_review_token(o.id)
@@ -338,7 +334,6 @@ class MeasureVersionWithDimensionFactory(MeasureVersionFactory):
                 self.dimensions.append(dimension)
 
         else:
-            # self.dimensions.append(DimensionFactory(page=self, **kwargs))
             factory_method = _get_factory_generator_for_strategy(DimensionFactory, create)
             factory_method(measure_version=self, **kwargs)
 
@@ -465,8 +460,6 @@ class DimensionFactory(factory.alchemy.SQLAlchemyModelFactory):
     table_2_source_data = {}
 
     measure_version_id = factory.Maybe("measure_version", factory.SelfAttribute("measure_version.id"))
-    # page_id = factory.Maybe("page", factory.SelfAttribute("page.guid"))
-    # page_version = factory.Maybe("page", factory.SelfAttribute("page.version"))
 
     position = factory.Sequence(lambda x: x)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -139,12 +139,12 @@ class DataSourceFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     # array-based relationships
     @factory.post_generation
-    def pages(self, create, extracted, **kwargs):
-        # If some pages were passed into the create invocation: eg factory.create(pages=[page1, page2])
+    def measure_versions(self, create, extracted, **kwargs):
+        # If some measure_versions were passed in to the create invocation: eg factory.create(measure_versions=[page1])
         if extracted is not None:
             # Attach those pages to this newly-created instance.
-            for page in extracted:
-                self.pages.append(page)
+            for measure_version in extracted:
+                self.measure_versions.append(measure_version)
 
 
 class UploadFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -321,7 +321,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
 
         else:
             factory_method = _get_factory_generator_for_strategy(DataSourceFactory, create)
-            factory_method(pages=[self], **kwargs)
+            factory_method(measure_versions=[self], **kwargs)
 
     # By default, do not create any dimensions. See alternative factory, `MeasureVersionWithDimensionFactory`
     dimensions = factory.LazyFunction(lambda: [])


### PR DESCRIPTION
Add a migration that will finally remove all of the old, now-unused data
model fields after we've done some normalisation work. This migration
*deletes* some data, so reversing it would be pretty difficult. However,
we are currently running the site entirely from the new data model, so
there should be limited risk that we still carry.

A lot of this patch is cleaning up tests so that they no longer
generate or use guids for measure versions.

 ## Ticket
https://trello.com/c/7LiYYoyb/1239