### PR TITLE
 Include testing topic in edit measure page

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -26,6 +26,8 @@ publish_status = bidict(
     REJECTED=0, DRAFT=1, INTERNAL_REVIEW=2, DEPARTMENT_REVIEW=3, APPROVED=4, UNPUBLISH=5, UNPUBLISHED=6
 )
 
+TESTING_SPACE_SLUG = "testing-space"
+
 
 class NewVersionType(enum.Enum):
     NEW_MEASURE = "new_measure"
@@ -374,7 +376,7 @@ class MeasureVersion(db.Model, CopyableModel):
             return current_status
 
     def available_actions(self):
-        if self.measure.subtopic.topic.slug == "testing-space":
+        if self.measure.subtopic.topic.slug == TESTING_SPACE_SLUG:
             return ["UPDATE"]
 
         if self.status == "DRAFT":

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -18,7 +18,16 @@ from application.cms.exceptions import (
     StaleUpdateException,
     CannotChangeSubtopicOncePublished,
 )
-from application.cms.models import DataSource, Measure, MeasureVersion, Subtopic, Topic, publish_status, NewVersionType
+from application.cms.models import (
+    DataSource,
+    Measure,
+    MeasureVersion,
+    Subtopic,
+    Topic,
+    publish_status,
+    NewVersionType,
+    TESTING_SPACE_SLUG,
+)
 from application.cms.service import Service
 from application.cms.upload_service import upload_service
 from application.sitebuilder.build_service import request_build
@@ -56,7 +65,7 @@ class PageService(Service):
         topic_query = Topic.query
 
         if not include_testing_space:
-            topic_query = topic_query.filter(Topic.slug != "testing-space")
+            topic_query = topic_query.filter(Topic.slug != TESTING_SPACE_SLUG)
 
         return sorted(topic_query.all(), key=lambda topic: topic.title)
 

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -52,8 +52,13 @@ class PageService(Service):
             raise PageNotFoundException()
 
     @staticmethod
-    def get_all_topics():
-        return sorted(Topic.query.filter(Topic.slug != "testing-space").all(), key=lambda topic: topic.title)
+    def get_topics(include_testing_space):
+        topic_query = Topic.query
+
+        if not include_testing_space:
+            topic_query = topic_query.filter(Topic.slug != "testing-space")
+
+        return sorted(topic_query.all(), key=lambda topic: topic.title)
 
     @staticmethod
     def get_subtopic(topic_slug, subtopic_slug):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -98,7 +98,7 @@ def create_measure(topic_slug, subtopic_slug):
         measure_version={},
         new=True,
         organisations_by_type=Organisation.select_options_by_type(),
-        topics=page_service.get_all_topics(),
+        topics=page_service.get_topics(include_testing_space=True),
     )
 
 
@@ -356,7 +356,7 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
         "next_approval_state": approval_state if "APPROVE" in available_actions else None,
         "diffs": diffs,
         "organisations_by_type": Organisation.select_options_by_type(),
-        "topics": page_service.get_all_topics(),
+        "topics": page_service.get_topics(include_testing_space=True),
     }
 
     return render_template("cms/edit_measure_version.html", **context)
@@ -517,7 +517,7 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
                 "available_actions": available_actions,
                 "next_approval_state": approval_state if "APPROVE" in available_actions else None,
                 "organisations_by_type": Organisation.select_options_by_type(),
-                "topics": page_service.get_all_topics(),
+                "topics": page_service.get_topics(include_testing_space=True),
             }
 
             return render_template("cms/edit_measure_version.html", **context)

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -46,7 +46,7 @@ def published():
 @login_required
 @user_can(VIEW_DASHBOARDS)
 def measures_list():
-    topics = page_service.get_all_topics()
+    topics = page_service.get_topics(include_testing_space=False)
     return render_template("dashboards/measures.html", topics=topics)
 
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -30,6 +30,7 @@ from application.cms.filters import (
     yesno,
 )
 from application.cms.dimension_service import dimension_service
+from application.cms.models import TESTING_SPACE_SLUG
 from application.cms.page_service import page_service
 from application.cms.scanner_service import scanner_service
 from application.cms.upload_service import upload_service
@@ -196,6 +197,7 @@ def create_app(config_object):
             READ=READ,
             UPDATE_MEASURE=UPDATE_MEASURE,
             VIEW_DASHBOARDS=VIEW_DASHBOARDS,
+            TESTING_SPACE_SLUG=TESTING_SPACE_SLUG,
             get_content_security_policy=get_content_security_policy,
         )
 

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -120,7 +120,7 @@ def build_homepage_and_topic_hierarchy(build_dir, config):
     os.makedirs(build_dir, exist_ok=True)
     from application.cms.page_service import page_service
 
-    topics = page_service.get_all_topics()
+    topics = page_service.get_topics(include_testing_space=False)
     content = render_template("static_site/index.html", topics=topics, static_mode=True)
 
     file_path = os.path.join(build_dir, "index.html")

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -27,7 +27,7 @@ from application.utils import (
 def index():
     return render_template(
         "static_site/index.html",
-        topics=page_service.get_all_topics(),
+        topics=page_service.get_topics(include_testing_space=False),
         static_mode=get_bool(request.args.get("static_mode", False)),
     )
 

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -10,7 +10,7 @@
             <span><a href="https://www.ethnicity-facts-figures.service.gov.uk">Live website</a></span>
 
             {% if not current_user.is_anonymous and not preview %}
-              <span><a href="{{ url_for('static_site.topic', topic_slug='testing-space') }}">Testing space</a></span>
+              <span><a href="{{ url_for('static_site.topic', topic_slug=TESTING_SPACE_SLUG) }}">Testing space</a></span>
 
               {% if current_user.is_authenticated and current_user.can(MANAGE_USERS) %}
                 <span><a href="{{ url_for('admin.index') }}">Admin</a></span>

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -575,3 +575,20 @@ class TestPageService:
         assert measures[0] == measure
         assert measure.versions_to_publish == [latest_publishable_version]
         assert measure_2.versions_to_publish == []
+
+    @pytest.mark.parametrize(
+        "topic_slugs, include_testing_space, expected_topic_count",
+        (
+            (["british-population", "health"], False, 2),
+            (["british-population", "health"], True, 2),
+            (["british-population", "health", "testing-space"], False, 2),
+            (["british-population", "health", "testing-space"], True, 3),
+        ),
+    )
+    def test_get_topics(self, topic_slugs, include_testing_space, expected_topic_count):
+        for topic_slug in topic_slugs:
+            TopicFactory(slug=topic_slug)
+
+        topics = page_service.get_topics(include_testing_space=include_testing_space)
+
+        assert len(topics) == expected_topic_count

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -365,6 +365,34 @@ def test_reorder_measures_triggers_build(test_app_client, logged_in_rdu_user):
     assert len(builds) == 1
 
 
+def test_view_edit_measure_page_subtopic_dropdown_includes_testing_space_topic(test_app_client, logged_in_rdu_user):
+    measure_version = MeasureVersionFactory(
+        status="DRAFT",
+        measure__subtopics__topic__slug="testing-space",
+        measure__subtopics__topic__title="Testing space",
+    )
+
+    response = test_app_client.get(
+        url_for(
+            "cms.edit_measure_version",
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
+        )
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+    import ipdb
+
+    ipdb.set_trace()
+
+    subtopic = page.find("select", attrs={"id": "subtopic"})
+    assert subtopic.find("optgroup", label="Testing space")
+
+
 def test_view_edit_measure_page(test_app_client, logged_in_rdu_user, stub_measure_data):
     data_source = DataSourceFactory.build(
         title="DWP Stats",

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -11,7 +11,7 @@ from werkzeug.datastructures import ImmutableMultiDict
 
 from application.auth.models import TypeOfUser
 from application.cms.forms import MeasureVersionForm
-from application.cms.models import DataSource
+from application.cms.models import DataSource, TESTING_SPACE_SLUG
 from application.cms.utils import get_data_source_forms
 from application.sitebuilder.models import Build
 from tests.models import (
@@ -368,7 +368,7 @@ def test_reorder_measures_triggers_build(test_app_client, logged_in_rdu_user):
 def test_view_edit_measure_page_subtopic_dropdown_includes_testing_space_topic(test_app_client, logged_in_rdu_user):
     measure_version = MeasureVersionFactory(
         status="DRAFT",
-        measure__subtopics__topic__slug="testing-space",
+        measure__subtopics__topic__slug=TESTING_SPACE_SLUG,
         measure__subtopics__topic__title="Testing space",
     )
 
@@ -384,10 +384,6 @@ def test_view_edit_measure_page_subtopic_dropdown_includes_testing_space_topic(t
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-
-    import ipdb
-
-    ipdb.set_trace()
 
     subtopic = page.find("select", attrs={"id": "subtopic"})
     assert subtopic.find("optgroup", label="Testing space")

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from application.auth.models import TypeOfUser
-from application.cms.models import UKCountry, TypeOfData
+from application.cms.models import UKCountry, TypeOfData, TESTING_SPACE_SLUG
 from application.config import Config
 from tests.models import (
     MeasureVersionFactory,
@@ -396,7 +396,7 @@ def test_view_index_page_only_contains_one_topic(test_app_client, logged_in_rdu_
 
 def test_view_sandbox_topic(test_app_client, logged_in_rdu_user):
 
-    sandbox_topic = TopicFactory(slug="testing-space", title="Test sandbox topic")
+    sandbox_topic = TopicFactory(slug=TESTING_SPACE_SLUG, title="Test sandbox topic")
     resp = test_app_client.get(url_for("static_site.topic", topic_slug=sandbox_topic.slug))
 
     assert resp.status_code == 200


### PR DESCRIPTION
The testing topics no longer appear in the dropdown on the edit measure
page that allows users to move measures between topics/subtopics. This
was caught yesterday in the department training session, when users
created topics in the testing space. When they came to save them,
because the testing space subtopics weren't there, the dropdown chose an
arbitrary alternative, which moved the measures into the public side of
the site. Testing space topics will now appear in the dropdown once
more.

 ## Ticket
https://trello.com/c/VmfSTXOm/1350