### PR TITLE
Remove unused filters and change "page" to "measure_version" in tests

### DIFF
--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -7,10 +7,6 @@ def format_approve_button(s):
     return messages.get(s, "")
 
 
-def format_date_time(date):
-    return date.strftime("%Y-%m-%d %H:%M:%S")
-
-
 def format_friendly_date(date):
     if date is None:
         return ""

--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -25,12 +25,6 @@ def format_friendly_short_date(date):
     return date.strftime("%d %b").lstrip("0")
 
 
-def format_versions(number):
-    if number == 1:
-        return "%s&nbsp;version" % number
-    return "%s&nbsp;versions" % number
-
-
 def index_of_last_initial_zero(list_):
     index_of_last_zero = None
     for index, value in enumerate(list_):

--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -1,8 +1,3 @@
-def format_page_guid(page_guid):
-    _, name = page_guid.split("_")
-    return "{}".format(name).capitalize()
-
-
 def format_approve_button(s):
     messages = {
         "INTERNAL_REVIEW": "Save &amp; Send to review",

--- a/application/factory.py
+++ b/application/factory.py
@@ -22,7 +22,6 @@ from application.cms.filters import (
     format_friendly_date,
     format_friendly_short_date,
     format_friendly_short_date_with_year,
-    format_versions,
     format_status,
     index_of_last_initial_zero,
     yesno,
@@ -134,7 +133,6 @@ def create_app(config_object):
     app.add_template_filter(format_friendly_date)
     app.add_template_filter(format_friendly_short_date)
     app.add_template_filter(format_friendly_short_date_with_year)
-    app.add_template_filter(format_versions)
     app.add_template_filter(format_status)
     app.add_template_filter(value_filter)
     app.add_template_filter(flatten)

--- a/application/factory.py
+++ b/application/factory.py
@@ -19,7 +19,6 @@ from application.cms.exceptions import InvalidPageHierarchy, PageNotFoundExcepti
 from application.cms.file_service import FileService
 from application.cms.filters import (
     format_approve_button,
-    format_date_time,
     format_friendly_date,
     format_friendly_short_date,
     format_friendly_short_date_with_year,
@@ -130,7 +129,6 @@ def create_app(config_object):
     app.jinja_env.add_extension(jinja_do)
 
     app.add_template_filter(format_approve_button)
-    app.add_template_filter(format_date_time)
     app.add_template_filter(render_markdown)
     app.add_template_filter(filesize)
     app.add_template_filter(format_friendly_date)

--- a/application/factory.py
+++ b/application/factory.py
@@ -18,7 +18,6 @@ from application.data.standardisers.ethnicity_dictionary_lookup import Ethnicity
 from application.cms.exceptions import InvalidPageHierarchy, PageNotFoundException
 from application.cms.file_service import FileService
 from application.cms.filters import (
-    format_page_guid,
     format_approve_button,
     format_date_time,
     format_friendly_date,
@@ -130,7 +129,6 @@ def create_app(config_object):
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.add_extension(jinja_do)
 
-    app.add_template_filter(format_page_guid)
     app.add_template_filter(format_approve_button)
     app.add_template_filter(format_date_time)
     app.add_template_filter(render_markdown)

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -198,7 +198,7 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     dept_user = UserFactory(user_type=TypeOfUser.DEPT_USER)
     admin_user = UserFactory(user_type=TypeOfUser.ADMIN_USER)
 
-    measure_page = MeasureVersionFactory(status="DRAFT")
+    measure_version = MeasureVersionFactory(status="DRAFT")
     with test_app_client.session_transaction() as session:
         session["user_id"] = dept_user.id
 
@@ -206,10 +206,10 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "static_site.measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 
@@ -218,10 +218,10 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 
@@ -231,12 +231,12 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     with test_app_client.session_transaction() as session:
         session["user_id"] = admin_user.id
 
-    data = {"measure-picker": measure_page.id}
+    data = {"measure-picker": measure_version.id}
 
     resp = test_app_client.post(
         url_for("admin.share_page_with_user", user_id=dept_user.id), data=data, follow_redirects=True
     )
-    assert measure_page.measure.shared_with == [dept_user]
+    assert measure_version.measure.shared_with == [dept_user]
     assert resp.status_code == 200
 
     # dept user can view or edit page
@@ -246,10 +246,10 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "static_site.measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 
@@ -258,10 +258,10 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 
@@ -272,7 +272,7 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(test_app_client):
     dept_user = UserFactory(user_type=TypeOfUser.DEPT_USER)
     admin_user = UserFactory(user_type=TypeOfUser.ADMIN_USER)
 
-    measure_page = MeasureVersionFactory(status="DRAFT", measure__shared_with=[dept_user])
+    measure_version = MeasureVersionFactory(status="DRAFT", measure__shared_with=[dept_user])
 
     with test_app_client.session_transaction() as session:
         session["user_id"] = dept_user.id
@@ -280,10 +280,10 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "static_site.measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 
@@ -294,7 +294,7 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(test_app_client):
         session["user_id"] = admin_user.id
 
     resp = test_app_client.get(
-        url_for("admin.remove_shared_page_from_user", measure_id=measure_page.measure_id, user_id=dept_user.id),
+        url_for("admin.remove_shared_page_from_user", measure_id=measure_version.measure_id, user_id=dept_user.id),
         follow_redirects=True,
     )
 
@@ -307,10 +307,10 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(test_app_client):
     resp = test_app_client.get(
         url_for(
             "static_site.measure_version",
-            topic_slug=measure_page.measure.subtopic.topic.slug,
-            subtopic_slug=measure_page.measure.subtopic.slug,
-            measure_slug=measure_page.measure.slug,
-            version=measure_page.version,
+            topic_slug=measure_version.measure.subtopic.topic.slug,
+            subtopic_slug=measure_version.measure.subtopic.slug,
+            measure_slug=measure_version.measure.slug,
+            version=measure_version.version,
         )
     )
 

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -665,23 +665,23 @@ class TestMeasureVersion:
     def test_page_sort_by_version(self):
 
         measure = MeasureFactory()
-        first_page = MeasureVersionFactory(measure=measure, version="1.0")
-        second_page = MeasureVersionFactory(measure=measure, version="1.1")
-        third_page = MeasureVersionFactory(measure=measure, version="2.0")
-        fourth_page = MeasureVersionFactory(measure=measure, version="2.2")
-        fifth_page = MeasureVersionFactory(measure=measure, version="2.10")
-        sixth_page = MeasureVersionFactory(measure=measure, version="2.20")
+        first_version = MeasureVersionFactory(measure=measure, version="1.0")
+        second_version = MeasureVersionFactory(measure=measure, version="1.1")
+        third_version = MeasureVersionFactory(measure=measure, version="2.0")
+        fourth_version = MeasureVersionFactory(measure=measure, version="2.2")
+        fifth_version = MeasureVersionFactory(measure=measure, version="2.10")
+        sixth_version = MeasureVersionFactory(measure=measure, version="2.20")
 
-        pages = [fourth_page, sixth_page, fifth_page, second_page, first_page, third_page]
+        versions = [fourth_version, sixth_version, fifth_version, second_version, first_version, third_version]
 
-        pages.sort()
+        versions.sort()
 
-        assert pages[0] == first_page
-        assert pages[1] == second_page
-        assert pages[2] == third_page
-        assert pages[3] == fourth_page
-        assert pages[4] == fifth_page
-        assert pages[5] == sixth_page
+        assert versions[0] == first_version
+        assert versions[1] == second_version
+        assert versions[2] == third_version
+        assert versions[3] == fourth_version
+        assert versions[4] == fifth_version
+        assert versions[5] == sixth_version
 
     def test_page_has_minor_update(self):
         measure = MeasureFactory()
@@ -703,23 +703,23 @@ class TestMeasureVersion:
         assert minor_version_4.has_no_later_published_versions() is True
 
     def test_is_minor_or_minor_version(self):
-        page = MeasureVersionFactory(version="1.0")
+        measure_version = MeasureVersionFactory(version="1.0")
 
-        assert page.version == "1.0"
-        assert page.is_major_version() is True
-        assert page.is_minor_version() is False
+        assert measure_version.version == "1.0"
+        assert measure_version.is_major_version() is True
+        assert measure_version.is_minor_version() is False
 
-        page.version = page.next_minor_version()
+        measure_version.version = measure_version.next_minor_version()
 
-        assert page.version == "1.1"
-        assert page.is_major_version() is False
-        assert page.is_minor_version() is True
+        assert measure_version.version == "1.1"
+        assert measure_version.is_major_version() is False
+        assert measure_version.is_minor_version() is True
 
-        page.version = page.next_major_version()
+        measure_version.version = measure_version.next_major_version()
 
-        assert page.version == "2.0"
-        assert page.is_major_version() is True
-        assert page.is_minor_version() is False
+        assert measure_version.version == "2.0"
+        assert measure_version.is_major_version() is True
+        assert measure_version.is_minor_version() is False
 
     @pytest.mark.parametrize(
         "page_versions, expected_order",


### PR DESCRIPTION
I *think* the `format_page_guid` filter is the really very last place that page guid is mentioned int he code.

Also found a couple of unused filters I've removed.  And updated some test variable names to be more precise ("measure version" rather than "page").