### PR TITLE
 Extend the measure lifecycle test

### DIFF
--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -126,10 +126,7 @@
 
                     {{ form.title(disabled=form_disabled, diffs=diffs) }}
 
-                    <div class="govuk-character-count" data-module="character-count" data-maxlength="160">
-                        {{ form.description(disabled=form_disabled, diffs=diffs,rows="3", class_="govuk-textarea js-character-count") }}
-                    </div>
-
+                    {{ form.description(disabled=form_disabled, diffs=diffs,rows="3") }}
 
                     <div class="form-group">
                         <label class="form-label" for="subtopic">Topic</label>

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -18,7 +18,7 @@ def _driver():
         profile.set_preference("general.useragent.override", "Selenium")
         driver = webdriver.Firefox(profile, executable_path="/usr/local/bin/geckodriver")
         driver.set_window_position(0, 0)
-        driver.set_window_size(1280, 720)
+        driver.set_window_size(1920, 1080)
 
     elif driver_name == "chrome":
         d = DesiredCapabilities.CHROME
@@ -39,6 +39,7 @@ def _driver():
         options.add_argument("--headless")
         options.binary_location = GOOGLE_CHROME_SHIM
         driver = webdriver.Chrome(options=options, executable_path=CHROMEDRIVER_PATH)
+        driver.set_window_size(1920, 1080)
 
     elif driver_name == "phantomjs":
         driver = webdriver.PhantomJS()

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -83,6 +83,7 @@ class EditMeasureLocators:
     REJECT_BUTTON = (By.ID, "reject-measure")
     SEND_TO_DRAFT_BUTTON = (By.ID, "send-back-to-draft")
     SEND_TO_APPROVED = (By.ID, "send-to-approved")
+    UPDATE_MEASURE = (By.LINK_TEXT, "Update")
     DEPARTMENT_REVIEW_LINK = (By.ID, "review-link-url")
 
     PREVIEW_LINK = (By.NAME, "preview")
@@ -117,6 +118,9 @@ class EditMeasureLocators:
     TYPE_OF_STATISTIC_INPUT = (By.NAME, "type_of_statistic")
     QMI_URL_INPUT = (By.NAME, "qmi_url")
     FURTHER_TECHNICAL_INFORMATION_INPUT = (By.NAME, "further_technical_information")
+
+    UPDATE_CORRECTS_DATA_MISTAKE = (By.NAME, "update_corrects_data_mistake")
+    EXTERNAL_EDIT_SUMMARY = (By.ID, "external_edit_summary")
 
 
 class DimensionPageLocators:

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -325,6 +325,26 @@ class MeasureCreatePage(BasePage):
         self.scroll_and_click(element)
 
 
+class MeasureCreateVersionPage(BasePage):
+    def __init__(self, driver):
+        super().__init__(driver=driver, base_url=driver.current_url)
+
+    def get(self):
+        self.driver.get(self.base_url)
+
+    def click_minor_update(self):
+        element = self.driver.find_element_by_xpath("//input[@value='minor']")
+        element.click()
+
+    def click_major_update(self):
+        element = self.driver.find_element_by_xpath("//input[@value='major']")
+        element.click()
+
+    def click_create(self):
+        element = self.driver.find_element_by_xpath("//div[contains(@class, 'new-version')]//form//button")
+        element.click()
+
+
 class MeasureVersionsPage(BasePage):
     def __init__(self, driver, live_server, topic_page, subtopic_page, measure_page_slug):
         super().__init__(
@@ -407,6 +427,10 @@ class MeasureEditPage(BasePage):
     def click_approved(self):
         element = self.wait_for_element(EditMeasureLocators.SEND_TO_APPROVED)
         self.scroll_and_click(element)
+
+    def click_update(self):
+        element = self.wait_for_element(EditMeasureLocators.UPDATE_MEASURE)
+        element.click()
 
     def set_text_field(self, locator, value):
         element = self.wait_for_element(locator)
@@ -491,6 +515,11 @@ class MeasureEditPage(BasePage):
     def set_methodology(self, value):
         self.set_text_field(EditMeasureLocators.METHODOLOGY_TEXTAREA, value)
 
+    def set_update_corrects_data_mistake(self, value):
+        element = self.driver.find_element(*EditMeasureLocators.UPDATE_CORRECTS_DATA_MISTAKE)
+        radio = element.find_element_by_xpath(f"//input[@value='{value}']")
+        self.select_checkbox_or_radio(radio)
+
     def fill_measure_page(self, measure_version, data_source):
         self.set_time_period_covered(measure_version.time_covered)
         self.set_area_covered(area="England")
@@ -512,6 +541,14 @@ class MeasureEditPage(BasePage):
         self.set_purpose(data_source.purpose)
         self.set_primary_source_type_of_data(0)
         self.set_methodology(measure_version.methodology)
+
+    def fill_measure_page_minor_edit_fields(self, measure_version):
+        self.set_update_corrects_data_mistake(measure_version.update_corrects_data_mistake)
+
+        self.set_text_field(EditMeasureLocators.EXTERNAL_EDIT_SUMMARY, measure_version.external_edit_summary)
+
+    def fill_measure_page_major_edit_fields(self, measure_version):
+        self.set_text_field(EditMeasureLocators.EXTERNAL_EDIT_SUMMARY, measure_version.external_edit_summary)
 
 
 class DimensionAddPage(BasePage):


### PR DESCRIPTION
Include updating a measure version with minor and major updates in the
measure lifecycle functional test, as we recently added a bug that broke
the updating process and we had no tests that covered this vital piece
of our core user journey.

 ## Ticket
https://trello.com/c/eir6CzJM/1332
