### PR TITLE
BUGFIX: Reordering measures status message overwrites topic title

### DIFF
--- a/application/src/sass/_govuk/measure.scss
+++ b/application/src/sass/_govuk/measure.scss
@@ -10,7 +10,7 @@ ul.links {
 }
 
 ul.links li {
-  margin-bottom: 10px;
+  padding-bottom: 10px;
 }
 
 

--- a/application/src/sass/_reorderable_list_items.scss
+++ b/application/src/sass/_reorderable_list_items.scss
@@ -25,6 +25,7 @@ ul.reorderable li.being-dragged {
 }
 
 .reordering-save-status {
+  font-size: 16px;
   transition: opacity 0s linear;
   transition-delay: 0s;
 }

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -39,6 +39,7 @@
                                         <h2 class="heading-medium">
                                             {{- subtopic.title -}}{% if subtopic.has_published_measures == false %} (not published){% endif %}
                                         </h2>
+                                        <span class="reordering-save-status"></span>
                                     </div>
                                     <div class="accordion-section-body {% if not static_mode %}eff-!-padding-bottom-40{% endif %}">
                                         {% if not static_mode %}
@@ -99,7 +100,8 @@
 
             var orderMeasures = function(list) {
 
-                var status = list.parentElement.previousElementSibling;
+                // childNodes[1] is the topic title, [2] is whitespace, [3] is the <span class="reordering-save-status">
+                var status = list.parentElement.previousElementSibling.childNodes[3];
                 var savingIntervalId;
 
                 var stillSaving = function () {

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -39,7 +39,6 @@
                                         <h2 class="heading-medium">
                                             {{- subtopic.title -}}{% if subtopic.has_published_measures == false %} (not published){% endif %}
                                         </h2>
-                                        <span class="reordering-save-status"></span>
                                     </div>
                                     <div class="accordion-section-body {% if not static_mode %}eff-!-padding-bottom-40{% endif %}">
                                         {% if not static_mode %}
@@ -48,6 +47,7 @@
                                             {% endif %}
                                         {% endif %}
                                         {% if measures_by_subtopic[subtopic.id] %}
+                                                <div class="reordering-save-status">&nbsp;</div>
                                                 <ul class="links js-reorderable">
                                                     {% for measure in measures_by_subtopic[subtopic.id] %}
                                                         {% with measure_version = measure.latest_version %}
@@ -100,8 +100,7 @@
 
             var orderMeasures = function(list) {
 
-                // childNodes[1] is the topic title, [2] is whitespace, [3] is the <span class="reordering-save-status">
-                var status = list.parentElement.previousElementSibling.childNodes[3];
+                var status = list.parentElement.querySelector('.reordering-save-status')
                 var savingIntervalId;
 
                 var stillSaving = function () {

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -104,26 +104,31 @@
                 var savingIntervalId;
 
                 var stillSaving = function () {
-                    switch (status.textContent) {
-                        case 'Saving new order':
-                            status.textContent = 'Saving new order.';
-                            break;
-                        case 'Saving new order.':
-                            status.textContent = 'Saving new order..';
-                            break;
-                        case 'Saving new order..':
-                            status.textContent = 'Saving new order...';
-                            break;
-                        case 'Saving new order...':
-                            status.textContent = 'Saving new order';
-                            break;
+                    if (status) {
+                        switch (status.textContent) {
+                            case 'Saving new order':
+                                status.textContent = 'Saving new order.';
+                                break;
+                            case 'Saving new order.':
+                                status.textContent = 'Saving new order..';
+                                break;
+                            case 'Saving new order..':
+                                status.textContent = 'Saving new order...';
+                                break;
+                            case 'Saving new order...':
+                                status.textContent = 'Saving new order';
+                                break;
+                        }
                     }
                 };
 
                 var saved = function (savingIntervalId) {
                     clearInterval(savingIntervalId);
-                    status.textContent = 'Saved';
-                    status.classList.add('status-invisible');
+
+                    if (status) {
+                        status.textContent = 'Saved';
+                        status.classList.add('status-invisible');
+                    }
                 };
 
                 var positions = [];
@@ -133,8 +138,10 @@
                                      "subtopic_id": list.children[i].dataset.subtopicId})
                 }
 
-                status.classList.remove('status-invisible');
-                status.textContent = 'Saving new order';
+                if (status) {
+                    status.classList.remove('status-invisible');
+                    status.textContent = 'Saving new order';
+                }
                 savingIntervalId = setInterval(stillSaving, 300);
                 list.classList.toggle('reorderable');
 

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -47,8 +47,8 @@
                                             {% endif %}
                                         {% endif %}
                                         {% if measures_by_subtopic[subtopic.id] %}
-                                                <div class="reordering-save-status">&nbsp;</div>
-                                                <ul class="links js-reorderable">
+                                                {% if not static_mode and current_user.is_authenticated and current_user.can(ORDER_MEASURES) %}<div class="reordering-save-status">&nbsp;</div>{% endif %}
+                                                <ul class="links {% if not static_mode and current_user.is_authenticated and current_user.can(ORDER_MEASURES) %}js-reorderable{% endif %}">
                                                     {% for measure in measures_by_subtopic[subtopic.id] %}
                                                         {% with measure_version = measure.latest_version %}
                                                             <li data-measure-id="{{ measure.id }}" data-subtopic-id="{{ subtopic.id }}" itemprop="dataset" itemscope itemtype="http://schema.org/Dataset">


### PR DESCRIPTION
Ticket: https://trello.com/c/VaSDtTUf/1361-reordering-measures-within-a-subtopic-wipes-out-the-subtopic-name-and-replaces-it-with-the-saving-saved-text-1

We rejigged the HTML on this page recently but didn't rejig the JS
selector for the status message when measures get reordered, so
reordering measures overwrote the topic title.

This reintroduces an element to specifically show the status message
when a measure is repositioned in the list.

I found the "reordering-save-status" class from this commit, that originally removed the status `<div>`.
https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/commit/4923d6c2037ea7b8b41c9c54f821db5ba831b447#diff-4bda9d74c3bc2c322ba78c9f0903551f
