### PR TITLE
Scroll past sticky banner

### DIFF
--- a/application/cms/form_fields.py
+++ b/application/cms/form_fields.py
@@ -66,6 +66,9 @@ class _RDUTextInput(_FormFieldTemplateRenderer):
     def __call__(self, field, class_="", diffs=None, disabled=False, textarea=False, **kwargs):
         value = {"value": field.data}
 
+        field_params = {} if textarea else {"type": self.input_type}
+        field_params = {**field_params, **kwargs}
+
         return super().__call__(
             field=field,
             id_=field.id,
@@ -74,7 +77,7 @@ class _RDUTextInput(_FormFieldTemplateRenderer):
             diffs=diffs,
             disabled=disabled,
             render_params={"textarea": textarea, **value},
-            field_params={"type": self.input_type, **kwargs},
+            field_params=field_params,
         )
 
 

--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -22,7 +22,7 @@ def flash_message_with_form_errors(lede="Please see below errors:", forms=None):
     for form_with_errors in forms:
         for field_name, error_message in form_with_errors.errors.items():
             form_field = getattr(form_with_errors, field_name)
-            message += f"* [{form_field.label.text}](#{form_field.id}): {error_message[0]}\n"
+            message += f"* [{form_field.label.text}](#{form_field.id}-label): {error_message[0]}\n"
 
     flash(message, "error")
 

--- a/application/src/js/cms/_scroll_past_sticky_status_banner.js
+++ b/application/src/js/cms/_scroll_past_sticky_status_banner.js
@@ -1,0 +1,47 @@
+/*
+   ErrorSummaryWithStickyBanner
+
+   Used to make the browser scroll past any present sticky header when clicking anchor links in validation boxes
+   at the top of the page, so that the full question label is always visible.
+ */
+
+function ErrorSummaryWithStickyBanner($module, $banner) {
+    this.$module = $module;
+    this.$banner = $banner;
+}
+
+ErrorSummaryWithStickyBanner.prototype.init = function () {
+    if (!this.$module || !this.$banner) {
+        return
+    }
+
+    var hrefAnchorRegex = /\#(.+)$/;
+    var errorLinks = this.$module.querySelectorAll('a');
+    var $banner = this.$banner;
+
+    var scrollForStickyHeader = function (event) {
+        /* We use a timeout here so that this code runs after the default click event, which adds an anchor
+         * to the URL and scrolls to the right place. */
+        window.setTimeout(function () {
+            var anchorRegexResult = hrefAnchorRegex.exec(this.getAttribute('href'));
+            if (anchorRegexResult.length === 2) {
+                var targetElement = document.getElementById(anchorRegexResult[1]);
+
+                targetElement.scrollIntoView();
+
+                var statusBannerHeight = $banner.clientHeight;
+                window.scrollBy(0, -statusBannerHeight);
+            }
+        }.bind(this), 0)
+    };
+
+    for (var i = 0; i < errorLinks.length; i++) {
+        errorLinks[i].addEventListener('click', scrollForStickyHeader);
+    }
+}
+
+var $validationErrorBox = document.querySelector('.flash-message .alert-box.error');
+var $stickyStatusBanner = document.querySelector('.status-banner.sticky-js');
+if ($validationErrorBox != null && $stickyStatusBanner != null) {
+    new ErrorSummaryWithStickyBanner($validationErrorBox, $stickyStatusBanner).init();
+}

--- a/application/src/sass/_status_banner.scss
+++ b/application/src/sass/_status_banner.scss
@@ -1,17 +1,6 @@
-// TODO: figure out how to make this responsive
-.status.sticky-js-fixed {
-  max-width: 960px;
-  width: 960px;
-  top: 0px;
-  position: fixed;
-  z-index: 2;
-}
-
 .status {
-  margin-top: 0;
   background-color: $white;
   box-sizing: border-box;
-  margin-top: 10px;
   border: 4px solid $border-colour;
   padding: 8px;
 }
@@ -57,4 +46,17 @@
       margin-left: 10px;
     }
   }
+}
+
+.status-banner.sticky-js {
+  padding-top: 10px;
+}
+
+// TODO: figure out how to make this responsive
+.status-banner.sticky-js-fixed {
+  max-width: 960px;
+  width: 960px;
+  top: 0px;
+  position: fixed;
+  z-index: 2;
 }

--- a/application/templates/_shared/_flash_messages.html
+++ b/application/templates/_shared/_flash_messages.html
@@ -6,7 +6,7 @@
             <div class="flash-message">
               {% for category, message in messages %}
               <div data-alert class="alert-box {% if category in ['error', 'dimension-error'] %}error{% else %}{{ category }}{% endif %}">
-                <span>{{ message|render_markdown }}</span>
+                {{- message|render_markdown -}}
               </div>
               {% endfor %}
             </div>

--- a/application/templates/_shared/_status_banner_macro.html
+++ b/application/templates/_shared/_status_banner_macro.html
@@ -1,8 +1,8 @@
 {% macro status_banner(sticky=True) -%}
 
-  <div class="grid-row status-banner">
+  <div class="grid-row status-banner {% if sticky %}sticky-js{% endif %}">
     <div class="column-full">
-      <div class="status {% if sticky %}sticky-js{% endif %}">
+      <div class="status">
         <div class="status-inner">
           {{ caller() }}
         </div>

--- a/application/templates/_shared/_status_banner_macro.html
+++ b/application/templates/_shared/_status_banner_macro.html
@@ -1,6 +1,6 @@
 {% macro status_banner(sticky=True) -%}
 
-  <div class="grid-row">
+  <div class="grid-row status-banner">
     <div class="column-full">
       <div class="status {% if sticky %}sticky-js{% endif %}">
         <div class="status-inner">

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -200,7 +200,7 @@
                     {{ form.further_technical_information(disabled=form_disabled, diffs=diffs) }}
 
                     <h3 class="heading-medium">Updates and corrections</h3>
-                    <div class="{% if new or measure_version.version == '1.0' %} hidden{% endif %}">
+                    {% if new or measure_version.version == '1.0' %}<div class="hidden">{% endif %}
                         {% if form.is_minor_update %}
                             {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, fieldset_class="inline") }}
                         {% endif %}
@@ -208,7 +208,7 @@
                         {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
 
                         {{ form.internal_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}
-                    </div>
+                    {% if new or measure_version.version == '1.0' %}</div>{% endif %}
 
                     {{ form.internal_reference(disabled=form_disabled, diffs=diffs, class_='short') }}
 

--- a/application/templates/forms/_choice_input.html
+++ b/application/templates/forms/_choice_input.html
@@ -1,6 +1,6 @@
 {# Required parameters: field, id_, name, class, value, field_params #}
 
 <div class="multiple-choice">
-  <input id="{{ id_ }}" name="{{ name }}" class="{{ class_ }}" value="{{ value }}" {% if field.checked %} checked{% endif%} {{ field_params }}>
+  <input id="{{ id_ }}" name="{{ name }}" class="{{ class_ }}" value="{{ value }}" {{ field_params }}>
   {{ field.label }}
 </div>

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -5,7 +5,7 @@
     {{ fields[0](disabled=disabled) }}
   {% else %}
   <fieldset {% if fieldset_class %}class="{{ fieldset_class }}"{% endif %}>
-    <legend>
+    <legend id="{{ id_ + '-label'}}">
       {{- field.label.text }} {% if errors %}<span class="error-message">{{ errors[0] }}</span>{% endif -%}
     </legend>
     {% if field.hint or hint %}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -1,6 +1,6 @@
 {# Required parameters: id_, name, class_, fieldset_class, field_class, legend, fields, errors, label_class, disabled #}
 
-<div id="{{ id_ }}" name="{{ name }}" class="form-group {{ class_ }} {% if errors %}form-group-error{% endif %}">
+<div id="{{ id_ }}" class="form-group {{ class_ }} {% if errors %}form-group-error{% endif %}">
   {% if fields|length == 1 %}
     {{ fields[0](disabled=disabled) }}
   {% else %}

--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -4,7 +4,7 @@
 <div class="govuk-character-count" data-module="character-count" data-maxlength="{{ field.character_count_limit }}">
 {% endif %}
 
-{{ field.label }}
+{{ field.label(id=field.id + '-label') }}
 
 {% if field.hint or hint %}
   <span class="form-hint">{{ field.hint or hint }}</span>

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -87,7 +87,7 @@ def test_admin_user_can_deactivate_user_account(test_app_client, logged_in_admin
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == f"User account for: {user.email} deactivated"
+    assert page.find("div", class_="alert-box").string == f"User account for: {user.email} deactivated"
     assert user.active is False
 
 
@@ -99,7 +99,7 @@ def test_admin_user_can_grant_or_remove_rdu_user_admin_rights(test_app_client, l
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "User %s is now an admin user" % rdu_user.email
+    assert page.find("div", class_="alert-box").string == "User %s is now an admin user" % rdu_user.email
 
     assert rdu_user.is_admin_user()
 
@@ -107,7 +107,7 @@ def test_admin_user_can_grant_or_remove_rdu_user_admin_rights(test_app_client, l
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "User %s is now a standard RDU user" % rdu_user.email
+    assert page.find("div", class_="alert-box").string == "User %s is now a standard RDU user" % rdu_user.email
 
     assert rdu_user.is_rdu_user()
 
@@ -120,7 +120,7 @@ def test_admin_user_cannot_grant_departmental_user_admin_rights(test_app_client,
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "Only RDU users can be made admin"
+    assert page.find("div", class_="alert-box").string == "Only RDU users can be made admin"
 
     assert not dept_user.is_admin_user()
 
@@ -132,7 +132,7 @@ def test_admin_user_cannot_remove_their_own_admin_rights(test_app_client, logged
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "You can't remove your own admin rights"
+    assert page.find("div", class_="alert-box").string == "You can't remove your own admin rights"
 
     assert logged_in_admin_user.is_admin_user()
 
@@ -326,6 +326,6 @@ def test_admin_user_can_delete_non_admin_user_account(test_app_client, logged_in
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "User account for: someuser@somedept.gov.uk deleted"
+    assert page.find("div", class_="alert-box").string == "User account for: someuser@somedept.gov.uk deleted"
 
     assert User.query.filter_by(email="someuser@somedept.gov.uk").first() is None

--- a/tests/application/cms/test_utils.py
+++ b/tests/application/cms/test_utils.py
@@ -48,7 +48,9 @@ class TestFlashMessageWithFormErrors:
 
         flash_message_with_form_errors(forms=[form])
 
-        assert session.get("_flashes") == [("error", "Please see below errors:\n\n* [field](#field): invalid field\n")]
+        assert session.get("_flashes") == [
+            ("error", "Please see below errors:\n\n* [field](#field-label): invalid field\n")
+        ]
 
 
 class TestGetDataSourceForms:

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -44,7 +44,7 @@ class TestGetCreateMeasurePage:
 
         assert response.status_code == 200
         page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        assert page.find("div", class_="alert-box").span.string == "Created page %s" % stub_measure_data["title"]
+        assert page.find("div", class_="alert-box").string == "Created page %s" % stub_measure_data["title"]
 
     def test_create_measure_page_creates_data_source_entries(
         self, test_app_client, logged_in_rdu_user, stub_measure_data
@@ -143,7 +143,7 @@ def test_admin_user_can_publish_page_in_dept_review(test_app_client, logged_in_a
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == 'Sent page "Test Measure Page" to APPROVED'
+    assert page.find("div", class_="alert-box").string == 'Sent page "Test Measure Page" to APPROVED'
 
     assert measure_version.status == "APPROVED"
     assert measure_version.last_updated_by == logged_in_admin_user.email
@@ -614,7 +614,7 @@ def test_dept_user_should_be_able_to_delete_upload_from_shared_page(test_app_cli
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == "Deleted upload ‘upload title’"
+    assert page.find("div", class_="alert-box").string == "Deleted upload ‘upload title’"
     assert len(measure_version.uploads.all()) == 0
 
 
@@ -697,7 +697,7 @@ def test_dept_user_should_be_able_to_edit_shared_page(test_app_client, logged_in
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    assert page.find("div", class_="alert-box").span.string == 'Updated page "this is the update"'
+    assert page.find("div", class_="alert-box").string == 'Updated page "this is the update"'
     assert measure_version.title == "this is the update"
 
 


### PR DESCRIPTION
When using validation error anchors to jump to the problematic question,
we want to aim to have the label+question fully visible in the viewport.
This effort is frustrated by the sticky banner that we have on the edit
measure page.

This javascript adds a scroll after clicking the validation links which
calculates the height of the sticky header, if present, and scrolls past
it so that the label should be fully visible.

https://trello.com/c/16fidoGF/1359

---

Includes some other minor refactoring, mostly around generating valid HTML