### PR TITLE
Migrate charts and tables from Dimension to Chart and Table

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -570,15 +570,17 @@ class Dimension(db.Model):
     created_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME, nullable=False)
     updated_at = db.Column(db.DateTime, server_default=__SQL_CURRENT_UTC_TIME, nullable=False)
 
+    # TODO: Delete these once chart and table data has been copied over and code updated to look in Chart and Table
     chart = db.Column(JSON)
-    table = db.Column(JSON)
     chart_builder_version = db.Column(db.Integer)
     chart_source_data = db.Column(JSON)
     chart_2_source_data = db.Column(JSON)
 
+    table = db.Column(JSON)
     table_source_data = db.Column(JSON)
     table_builder_version = db.Column(db.Integer)
     table_2_source_data = db.Column(JSON)
+    # TODO: End delete
 
     measure_version_id = db.Column(db.Integer, nullable=False)
 
@@ -867,6 +869,9 @@ class ChartAndTableMixin(object):
     includes_parents = db.Column(db.Boolean, nullable=False)
     includes_all = db.Column(db.Boolean, nullable=False)
     includes_unknown = db.Column(db.Boolean, nullable=False)
+
+    built_object = db.Column(JSON)
+    builder_settings_and_source_data = db.Column(JSON)
 
     @classmethod
     def get_by_id(cls, id):

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -777,13 +777,13 @@ class Upload(db.Model, CopyableModel):
 association_table = db.Table(
     "ethnicity_in_classification",
     db.metadata,
-    db.Column("classification_id", db.Integer, ForeignKey("classification.id"), nullable=False),
+    db.Column("classification_id", db.String(255), ForeignKey("classification.id"), nullable=False),
     db.Column("ethnicity_id", db.Integer, ForeignKey("ethnicity.id"), nullable=False),
 )
 parent_association_table = db.Table(
     "parent_ethnicity_in_classification",
     db.metadata,
-    db.Column("classification_id", db.Integer, ForeignKey("classification.id"), nullable=False),
+    db.Column("classification_id", db.String(255), ForeignKey("classification.id"), nullable=False),
     db.Column("ethnicity_id", db.Integer, ForeignKey("ethnicity.id"), nullable=False),
 )
 
@@ -851,7 +851,7 @@ class DimensionClassification(db.Model):
 
     # columns
     dimension_guid = db.Column(db.String(255), primary_key=True)
-    classification_id = db.Column("classification_id", db.Integer, primary_key=True)
+    classification_id = db.Column("classification_id", db.String(255), primary_key=True)
 
     includes_parents = db.Column(db.Boolean, nullable=False)
     includes_all = db.Column(db.Boolean, nullable=False)
@@ -865,10 +865,10 @@ class DimensionClassification(db.Model):
 # This encapsulates common fields and functionality for chart and table models
 class ChartAndTableMixin(object):
     id = db.Column(db.Integer, primary_key=True)
-    classification_id = db.Column("classification_id", db.Integer, nullable=False)
-    includes_parents = db.Column(db.Boolean, nullable=False)
-    includes_all = db.Column(db.Boolean, nullable=False)
-    includes_unknown = db.Column(db.Boolean, nullable=False)
+    classification_id = db.Column("classification_id", db.String(255), nullable=True)
+    includes_parents = db.Column(db.Boolean, nullable=True)
+    includes_all = db.Column(db.Boolean, nullable=True)
+    includes_unknown = db.Column(db.Boolean, nullable=True)
 
     built_object = db.Column(JSON)
     builder_settings_and_source_data = db.Column(JSON)

--- a/migrations/versions/2019_03_04_new_chart_and_table_columns_for_settings_and_objects.py
+++ b/migrations/versions/2019_03_04_new_chart_and_table_columns_for_settings_and_objects.py
@@ -1,0 +1,37 @@
+"""Add new columnsto the Chart and Table models, to store chart/table settings objects and built chart/table objects
+   The data to populate these will be moved from the Dimension model by a data migration.
+
+Revision ID: 2019_03_04_chart_table_settings
+Revises: 2019_02_22_clean_data_model
+Create Date: 2019-03-05 12:49:58.938371
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2019_03_04_chart_table_settings"
+down_revision = "2019_02_22_clean_data_model"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "dimension_chart",
+        sa.Column("builder_settings_and_source_data", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column("dimension_chart", sa.Column("built_object", postgresql.JSON(astext_type=sa.Text()), nullable=True))
+    op.add_column(
+        "dimension_table",
+        sa.Column("builder_settings_and_source_data", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column("dimension_table", sa.Column("built_object", postgresql.JSON(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade():
+    op.drop_column("dimension_table", "built_object")
+    op.drop_column("dimension_table", "builder_settings_and_source_data")
+    op.drop_column("dimension_chart", "built_object")
+    op.drop_column("dimension_chart", "builder_settings_and_source_data")

--- a/migrations/versions/2019_03_04_optional_chart_and_table_classifications.py.py
+++ b/migrations/versions/2019_03_04_optional_chart_and_table_classifications.py.py
@@ -1,0 +1,41 @@
+"""Make some fields on Chart and Table nullable
+
+We want to copy chart and table data across to these tables but have no way to add a
+classification for each one, so we'll have to live with some nulls in here.
+
+Revision ID: 2019_03_04_make_fields_nullable
+Revises: 2019_03_04_chart_table_settings
+Create Date: 2019-03-05 16:38:12.835894
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_03_04_make_fields_nullable"
+down_revision = "2019_03_04_chart_table_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("dimension_chart", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.alter_column("dimension_chart", "includes_all", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_chart", "includes_parents", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_chart", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_table", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.alter_column("dimension_table", "includes_all", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_table", "includes_parents", existing_type=sa.BOOLEAN(), nullable=True)
+    op.alter_column("dimension_table", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=True)
+
+
+def downgrade():
+    op.alter_column("dimension_table", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "includes_parents", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "includes_all", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_table", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False)
+    op.alter_column("dimension_chart", "includes_unknown", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "includes_parents", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "includes_all", existing_type=sa.BOOLEAN(), nullable=False)
+    op.alter_column("dimension_chart", "classification_id", existing_type=sa.VARCHAR(length=255), nullable=False)

--- a/scripts/data_migrations/2019-03-04-copy-chart-and-table-objects-to-chart-and-table-tables.py
+++ b/scripts/data_migrations/2019-03-04-copy-chart-and-table-objects-to-chart-and-table-tables.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+import sys
+from flask import current_app
+
+sys.path.insert(0, ".")  # noqa: E402
+
+from application import db
+from application.cms.models import Dimension, Chart, Table
+from application.config import Config
+from application.data.charts import ChartObjectDataBuilder
+from application.data.tables import TableObjectDataBuilder
+from application.factory import create_app
+
+
+def copy_chart_and_table_data(app):  # noqa: C901
+    with app.app_context():
+        try:
+            count = 0
+            chart_failures = 0
+            table_failures = 0
+            for dimension in Dimension.query.all():
+                # If there is a chart object, copy it to the chart table
+                if dimension.chart:
+                    # Create a Chart() if necessary
+                    if dimension.dimension_chart is None:
+                        dimension.dimension_chart = Chart()
+
+                    # Don't overwrite if it already exists
+                    if dimension.dimension_chart.built_object is None:
+                        dimension.dimension_chart.built_object = dimension.chart
+
+                    if dimension.chart_2_source_data is not None:
+                        # If there is already a version 2 chart settings, copy settings straight across
+                        # But don't overwrite if it already exists
+                        if dimension.dimension_chart.builder_settings_and_source_data is None:
+                            dimension.dimension_chart.builder_settings_and_source_data = dimension.chart_2_source_data
+                    else:
+                        # Assume there are version 1 settings if no version 2; convert it and copy it across
+                        try:
+                            version_2_settings = ChartObjectDataBuilder.upgrade_v1_to_v2(
+                                dimension.chart, dimension.chart_source_data
+                            )
+                            # Don't overwrite if it already exists
+                            if dimension.dimension_chart.builder_settings_and_source_data is None:
+                                dimension.dimension_chart.builder_settings_and_source_data = version_2_settings
+                        except Exception as e:
+                            chart_failures += 1
+                            print(f"Error copying chart for {dimension.title} ({dimension.guid})")
+                            print(f"  CHART EXCEPTION: {type(e)}: {e}")
+
+                # If there is a table object, copy it to the table table
+                if dimension.table:
+                    # Create a Table() if necessary
+                    if dimension.dimension_table is None:
+                        dimension.dimension_table = Table()
+
+                    # Don't overwrite if it already exists
+                    if dimension.dimension_table.built_object is None:
+                        dimension.dimension_table.built_object = dimension.table
+
+                    if dimension.table_2_source_data is not None:
+                        # If there is already a version 2 table settings, copy settings straight across
+                        # But don't overwrite if it already exists
+                        if dimension.dimension_table.builder_settings_and_source_data is None:
+                            dimension.dimension_table.builder_settings_and_source_data = dimension.table_2_source_data
+                    else:
+                        # Assume there are version 1 settings if no version 2; convert it and copy it across
+                        try:
+                            version_2_settings = TableObjectDataBuilder.upgrade_v1_to_v2(
+                                dimension.table, dimension.table_source_data, current_app.dictionary_lookup
+                            )
+                            # Don't overwrite if it already exists
+                            if dimension.dimension_table.builder_settings_and_source_data is None:
+                                dimension.dimension_table.builder_settings_and_source_data = version_2_settings
+                        except Exception as e:
+                            table_failures += 1
+                            print(f"Error copying table for {dimension.title} ({dimension.guid})")
+                            print(f"  TABLE EXCEPTION: {type(e)}: {e}")
+
+                count += 1
+
+            db.session.commit()
+            print(f"Total: {count}, Chart failures: {chart_failures}, Table failures: {table_failures}")
+
+        except Exception as e:
+            print(e)
+            db.session.rollback()
+            raise e
+
+        finally:
+            db.session.close()
+
+
+if __name__ == "__main__":
+    app = create_app(Config())
+    copy_chart_and_table_data(app)


### PR DESCRIPTION
This is the first step to removing chart and table builder versioning.

I think we can get this in now, and then run the data migration when the rest of the code is ready. (i.e. once everything is reading/writing to the new Chart and Table fields).

Possibly controverial, but I have changed the classification field in Chart and Table to be nullable.  This is because we can't reliably determine the classification used by a chart or table from the chart/table objects themselves. Tthe code we currently have for determining classifications works on posted form data rather than the final saved objects :man_facepalming: , and while we could write something here that would be able to automaticaly determine the classificaton for some of our existing charts and tables, I'm pretty sure there is no way it could work for all of them.  So even if we patched some of them in we'd still need these fields to be nullable.

For the data migration, I've found that not all charts and tables convert smoothly with our existing v1_to_v2 code, and this script will just skip the failures.

There are currently 3 tables and 2 charts that fail to convert, and
these are all on dimensions that belong to measures that already have
published updates.  So it's fine if we no longer have builder settings
for these, as they will never feature in any future update.

The script is cautious in how it copies objects across - it will not
overwrite any existing values, and only fills in NULL fields.  This
means we should be able to safely run the script more than once if needs
be, without risking overwriting more recent versions of charts or tables.