### PR TITLE
Allow nhs.net email domain for users

### DIFF
--- a/application/admin/forms.py
+++ b/application/admin/forms.py
@@ -34,7 +34,7 @@ def is_gov_email(email):
     email = email.lower()
     if email in whitelist:
         return True
-    valid_domains = [r"gov\.uk"]
+    valid_domains = [r"gov\.uk|nhs\.net"]
     email_regex = r"[\.|@]({})$".format("|".join(valid_domains))
     return bool(re.search(email_regex, email))
 


### PR DESCRIPTION
We need to set up departmental user accounts for people with `nhs.net` email addresses.  Rather than add each specific email to a whitelist we should allow users to be created with any email address on that domain.