### PR TITLE
Allow non-uppercase N/A in tables

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -660,8 +660,8 @@ function adjustChartObjectForMissingData(chartObject) {
 }
 
 function htmlContentForMissingDataSymbol(symbol) {
-    switch (symbol.trim()) {
-        case 'N/A':
+    switch (symbol.trim().lower()) {
+        case 'n/a':
             return 'N/A<sup>*</sup>';
         default:
             return '';
@@ -669,15 +669,14 @@ function htmlContentForMissingDataSymbol(symbol) {
 }
 
 function classNameForMissingDataSymbol(symbol) {
-
-    switch (symbol.trim()) {
+    switch (symbol.trim().lower()) {
         case '!':
             return 'missing-data confidential';
         case '?':
             return 'missing-data sample-too-small';
         case '-':
             return 'missing-data not-collected';
-        case 'N/A':
+        case 'n/a':
             return 'not-applicable';
         default:
             return '';

--- a/application/static_site/filters.py
+++ b/application/static_site/filters.py
@@ -22,7 +22,7 @@ def filesize(string):
 def value_filter(value):
 
     icon_html = {
-        "N/A": '<span class="not-applicable">N/A<sup>*</sup></span>',
+        "n/a": '<span class="not-applicable">N/A<sup>*</sup></span>',
         "?": (
             __missing_data_icon("sample-too-small")
             + __icon_explanation("withheld because a small sample size makes it unreliable")
@@ -31,8 +31,8 @@ def value_filter(value):
         "-": __missing_data_icon("not-collected") + __icon_explanation("not collected"),
     }
 
-    if value is not None and value.strip() in icon_html:
-        return icon_html[value.strip()]
+    if value is not None and value.strip().lower() in icon_html:
+        return icon_html[value.strip().lower()]
     else:
         return jinja2.escape(value)
 

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -104,7 +104,7 @@
           {% set row_loop = loop %}
           {% for value in data['values'] %}
             {% set sort_value = value %}
-            
+
             {% if data.sort_values %}
               {% if data.sort_values[loop.index0] in missing_data_sort_order_values %}
                 {% set sort_value = missing_data_sort_order_values[data.sort_values[loop.index0]] %}
@@ -142,7 +142,7 @@
     <p class="missing-data-explanation">
         {% set table_data = dimension.table.data | flatten %}
 
-        {% if "N/A" in table_data %}
+        {% if "N/A" in table_data or "n/a" in table_data %}
             <span class="explanation"><sup>*</sup> Not applicable</span>
         {% endif %}
 


### PR DESCRIPTION
Sometimes we don't have data for certain cells in a table, and in some
of those cases we use N/A to represent this lack of data. When N/A is
entered in capitals, we add a footnate explaining what this means. But
this check is case-sensitive, so sometimes when 'n/a' is entered, this
footnate isn't generated. This patch will make sure that the footnate is
shown for all case variations of 'N/A'.