### PR TITLE
Only include charts.js on pages that need them

### DIFF
--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -125,9 +125,6 @@
 
         {% if not static_mode %}
             <script>var user_csrf_token = "{{ csrf_token() }}"</script>
-
-            <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'charts.js' | version_filter }}"></script>
-
             <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'cms.js' | version_filter }}"></script>
         {% endif %}
     {% endblock %}

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -266,6 +266,7 @@
 
 {% block bodyEnd %}
   {{ super() }}
+  <script type="text/javascript" src="/static/javascripts/{{ 'charts.js' | version_filter }}"></script>
 <script type="text/javascript">
     $(document).ready(function() {
         const excluded_headers = exclude = ['Measure', 'Value', 'Numerator', 'Denominator',

--- a/application/templates/cms/create_chart_2.html
+++ b/application/templates/cms/create_chart_2.html
@@ -424,5 +424,6 @@
 {% block bodyEnd %}
   {{ super() }}
 
+  <script type="text/javascript" src="/static/javascripts/{{ 'charts.js' | version_filter }}"></script>
   <script src="{{ url_for('static', filename='javascripts/') }}{{ 'chartbuilder2.js' | version_filter }}"></script>
 {% endblock %}

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -147,6 +147,7 @@
 
 {% block bodyEnd %}
   {{ super() }}
+    <script src="{{ url_for('static', filename='javascripts/') }}{{ 'chartbuilder2.js' | version_filter }}"></script>
 
 <script type="text/javascript">
     $(document).ready(function() {

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -147,7 +147,7 @@
 
 {% block bodyEnd %}
   {{ super() }}
-    <script src="{{ url_for('static', filename='javascripts/') }}{{ 'chartbuilder2.js' | version_filter }}"></script>
+    <script type="text/javascript" src="/static/javascripts/{{ 'charts.js' | version_filter }}"></script>
 
 <script type="text/javascript">
     $(document).ready(function() {

--- a/application/templates/cms/create_table_2.html
+++ b/application/templates/cms/create_table_2.html
@@ -266,5 +266,6 @@
 {% block bodyEnd %}
   {{ super() }}
 
+  <script src="{{ url_for('static', filename='javascripts/') }}{{ 'chartbuilder2.js' | version_filter }}"></script>
   <script src="{{ url_for('static', filename='javascripts/') }}{{ 'tablebuilder2.js' | version_filter }}"></script>
 {% endblock %}

--- a/application/templates/cms/create_table_2.html
+++ b/application/templates/cms/create_table_2.html
@@ -266,6 +266,6 @@
 {% block bodyEnd %}
   {{ super() }}
 
-  <script src="{{ url_for('static', filename='javascripts/') }}{{ 'chartbuilder2.js' | version_filter }}"></script>
+  <script type="text/javascript" src="/static/javascripts/{{ 'charts.js' | version_filter }}"></script>
   <script src="{{ url_for('static', filename='javascripts/') }}{{ 'tablebuilder2.js' | version_filter }}"></script>
 {% endblock %}


### PR DESCRIPTION
This also stops the script being loaded twice on measure pages in Flask mode.

Bugfix for https://trello.com/c/YJjucHWf/1370-highcharts-error-on-publisher-preview-pages