### PR TITLE
 Fix `setup_review_app.sh`

### DIFF
--- a/app.json
+++ b/app.json
@@ -113,7 +113,7 @@
   },
   "addons": [
     "attachment-scanner",
-    "heroku-postgresql",
+    {"plan": "heroku-postgresql", "options":  {"version": "10"}},
     "scheduler"
   ],
   "buildpacks": [

--- a/scripts/setup_review_app.sh
+++ b/scripts/setup_review_app.sh
@@ -3,20 +3,22 @@
 set -o pipefail
 
 function display_result {
-  EXIT_STATUS=$1
+  RESULT=$1
+  EXIT_STATUS=$2
+  ACTION=$3
 
-  if [ $RESULT -ne 0 ]; then
-    echo -e "\033[31m$Setup failed\033[0m"
+  if [[ $RESULT -ne 0 ]]; then
+    echo -e "\033[31m$ACTION failed\033[0m"
     exit $EXIT_STATUS
   else
-    echo -e "\033[32m$Setup successful\033[0m"
+    echo -e "\033[32m$ACTION successful\033[0m"
   fi
 }
 
-psql -d $DATABASE_URL -c "drop schema public cascade;"
+psql -d $DATABASE_URL -c "drop schema public cascade; create schema public;"
 display_result $? 1 "Drop schema as PR may have migrations not yet applied to master"
 
-pg_dump -F custom --no-acl --no-owner -d $DB_FOR_REVIEW_APPS | pg_restore -c -d $DATABASE_URL
+pg_dump -F custom --schema public -d $DB_FOR_REVIEW_APPS | pg_restore --no-owner --no-acl --schema public -d $DATABASE_URL
 display_result $? 1 "Copy over db from dev/master"
 
 ./manage.py db upgrade


### PR DESCRIPTION
* `display_result` is fundamentally broken, contains references to
  variables that don't exist, and therefore never exits and alerts when
  it fails.
* `--no-owner` and `--no-acl` need to be specified on `pg_restore`
rather than (or in addition to) `pg_dump`.
* Re-create the `public` schema before copying data into it.
* Specify postgres version for review apps