### PR TITLE
Remove GOV.UK Frontend Toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,12 +2436,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.7.0.tgz",
       "integrity": "sha512-IZvho72ExUAOmMOZHbE7s//HdtpSoO1aLn3fcXTnuIUi20UTsz6j+5i1Ztyqr4KUEb8OB/jNMYt4kuYyJnEMRQ=="
     },
-    "govuk_frontend_toolkit": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-5.2.0.tgz",
-      "integrity": "sha1-9fbFrkjkMey5fYuAix6Nt3gqvH8=",
-      "dev": true
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2472,7 +2466,7 @@
         "gulp-cli": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
-          "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+          "integrity": "sha1-eEfiIMs2YvK+im1XK/FOF75amUs=",
           "requires": {
             "ansi-colors": "^1.0.1",
             "archy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "govuk_frontend_toolkit": "^5.2.0",
     "mocha": "^5.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
This is deprecated and no longer required.