### PR TITLE
Write chart/table titles in new column

### DIFF
--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -49,10 +49,12 @@ class DimensionService(Service):
         if "chartObject" in post_data:
             data["chart"] = post_data["chartObject"]
             data["chart_settings_and_source_data"] = post_data["source"]
+            data["chart_title"] = post_data["source"]["chartFormat"]["chart_title"]
 
         if "tableObject" in post_data:
             data["table"] = post_data["tableObject"]
             data["table_settings_and_source_data"] = post_data["source"]
+            data["table_title"] = post_data["source"]["tableValues"]["table_title"]
 
         if "classificationCode" in post_data:
             if post_data["classificationCode"] == "custom":
@@ -115,10 +117,12 @@ class DimensionService(Service):
             if dimension.dimension_chart is None:
                 dimension.dimension_chart = Chart()
             dimension.dimension_chart.chart_object = data["chart"]
+            dimension.dimension_chart.title = data["chart_title"]
         if "table" in data:
             if dimension.dimension_table is None:
                 dimension.dimension_table = Table()
             dimension.dimension_table.table_object = data["table"]
+            dimension.dimension_table.title = data["table_title"]
 
         if (
             dimension.dimension_chart

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -842,6 +842,8 @@ class ChartAndTableMixin(object):
 
     settings_and_source_data = db.Column(JSON)
 
+    title = db.Column(db.String(255))
+
     @declared_attr
     def classification(cls):
         return db.relationship("Classification")

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -750,6 +750,7 @@ def create_chart(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         measure=measure,
         measure_version=measure_version,
         dimension_dict=dimension_object.to_dict(),
+        dimension_chart=dimension_object.dimension_chart,
     )
 
 
@@ -775,6 +776,7 @@ def create_table(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         measure=measure,
         measure_version=measure_version,
         dimension_dict=dimension_object.to_dict(),
+        dimension_table=dimension_object.dimension_table,
     )
 
 

--- a/application/src/js/chartbuilder/chartbuilder.js
+++ b/application/src/js/chartbuilder/chartbuilder.js
@@ -782,8 +782,6 @@ $(document).ready(function () {
 
         showHideCustomEthnicityPanel()
 
-        $('#chart_title').val(settings.chartFormat.chart_title);
-
         switch (settings.type) {
             case 'line_graph':
                 var columnValue = settings.chartOptions.x_axis_column;

--- a/application/src/js/tablebuilder/tablebuilder.js
+++ b/application/src/js/tablebuilder/tablebuilder.js
@@ -724,7 +724,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
         showHideCustomEthnicityPanel()
 
-        $('#table_title').val(settings.tableValues.table_title);
         document.getElementById('table_title').dispatchEvent(new Event("input"));
 
         $('#complex-table__data-style').val(settings.tableOptions.data_style);

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -405,7 +405,7 @@
                       <span class="govuk-hint">For example, ‘Percentage of households who own their home by ethnicity and socio-economic group’</span>
                       {% include 'forms/extended_hints/_chart_and_table_title.html' %}
                         <textarea id="chart_title" class="govuk-textarea" rows="2" data-module="autoresize no-newlines"
-                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if dimension_dict.chart_settings_and_source_data %}{{ dimension_dict.chart_settings_and_source_data.chartFormat.chart_title }}{% endif %}</textarea>
+                               {% if form_disabled %}disabled="disabled"{% endif %}>{{ dimension_chart.title }}</textarea>
                     </div>
 
                     <h2 class="govuk-heading-m eff-numbered-sections__item">Preview</h2>

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -269,7 +269,7 @@
                       <span class="govuk-hint">For example, ‘Percentage of households who own their home by ethnicity and socio-economic group’</span>
                       {% include 'forms/extended_hints/_chart_and_table_title.html' %}
                         <textarea id="table_title" class="govuk-textarea" rows="2" data-module="autoresize no-newlines"
-                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if dimension_dict.table_settings_and_source_data %}{{ dimension_dict.table_settings_and_source_data.tableValues.table_title }}{% endif %}</textarea>
+                               {% if form_disabled %}disabled="disabled"{% endif %}>{{ dimension_table.title }}</textarea>
                     </div>
 
                     <h2 class="govuk-heading-m eff-numbered-sections__item">Preview</h2>

--- a/migrations/versions/2019_03_21_add_titles_to_charts_and_tables.py
+++ b/migrations/versions/2019_03_21_add_titles_to_charts_and_tables.py
@@ -1,0 +1,36 @@
+"""Add titles to charts and tables
+
+This is in preparation for storing the titles of charts and tables in
+a separate database column, rather than as part of the JSON objects.
+
+Revision ID: 2019_03_21_add_titles
+Revises: 2019_03_20_tidy_up_dimension
+Create Date: 2019-03-14 15:11:33.560576
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_03_21_add_titles"
+down_revision = "2019_03_20_tidy_up_dimension"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("dimension_chart", sa.Column("title", sa.String(length=255), nullable=True))
+    op.add_column("dimension_table", sa.Column("title", sa.String(length=255), nullable=True))
+
+    op.execute(
+        "UPDATE dimension_chart SET title = settings_and_source_data::JSON->'chartFormat'->>'chart_title'::TEXT;"
+    )
+    op.execute(
+        "UPDATE dimension_table SET title = settings_and_source_data::JSON->'tableValues'->>'table_title'::TEXT;"
+    )
+
+
+def downgrade():
+    op.drop_column("dimension_table", "title")
+    op.drop_column("dimension_chart", "title")

--- a/scripts/data_migrations/2019-03-14-copy-chart-and-table-titles.sql
+++ b/scripts/data_migrations/2019-03-14-copy-chart-and-table-titles.sql
@@ -1,0 +1,5 @@
+-- This copies the chart and table titles form the settings object into its own column.
+
+update dimension_chart set title = settings_and_source_data::json->'chartFormat'->>'chart_title'::text;
+
+update dimension_table set title = settings_and_source_data::json->'tableValues'->>'table_title'::text;

--- a/tests/application/cms/test_dimension_service.py
+++ b/tests/application/cms/test_dimension_service.py
@@ -128,7 +128,7 @@ def test_add_chart_to_dimension():
     dimension = measure_version.dimensions[0]
     chart = {"chart_is_just_a": "dictionary"}
 
-    dimension_service.update_dimension(measure_version.dimensions[0], {"chart": chart})
+    dimension_service.update_dimension(measure_version.dimensions[0], {"chart": chart, "chart_title": "chart title"})
 
     assert dimension.guid == "abc123"
     assert dimension.dimension_chart.chart_object == chart
@@ -139,7 +139,7 @@ def test_add_table_to_dimension():
     dimension = measure_version.dimensions[0]
     table = {"table_is_just_a": "dictionary"}
 
-    dimension_service.update_dimension(dimension, {"table": table})
+    dimension_service.update_dimension(dimension, {"table": table, "table_title": "table title"})
 
     assert dimension.guid == "abc123"
     assert dimension.dimension_table.table_object == table
@@ -158,6 +158,7 @@ def test_adding_table_with_data_matching_an_ethnicity_classification(two_classif
         {
             "use_custom": False,
             "table": {"title": "My table title"},
+            "table_title": "My table title",
             "table_settings_and_source_data": {"tableOptions": {}},
             "classification_code": "5A",
             "ethnicity_values": ["All", "Asian", "Black", "Mixed", "White", "Other", "Unknown"],
@@ -189,6 +190,7 @@ def test_adding_chart_with_data_matching_an_ethnicity_classification(two_classif
         {
             "use_custom": False,
             "chart": {"title": "My chart title"},
+            "chart_title": "My chart title",
             "chart_settings_and_source_data": {"chartOptions": {}},
             "classification_code": "5A",
             "ethnicity_values": ["All", "Asian", "Black", "Mixed", "White", "Other", "Unknown"],
@@ -208,7 +210,6 @@ def test_adding_chart_with_data_matching_an_ethnicity_classification(two_classif
 
 
 def test_adding_table_with_custom_data_classification(two_classifications_2A_5A):
-
     # Given an existing dimension with no associated table
     dimension = dimension_service.create_dimension(
         MeasureVersionFactory(), title="test-dimension", time_period="time_period", summary="summary"
@@ -220,6 +221,7 @@ def test_adding_table_with_custom_data_classification(two_classifications_2A_5A)
         {
             "use_custom": True,
             "table": {"title": "My table title"},
+            "table_title": "My table title",
             "table_settings_and_source_data": {"tableOptions": {}},
             "classification_code": "2A",
             "has_parents": True,
@@ -266,6 +268,7 @@ def test_adding_chart_with_custom_data_classification(two_classifications_2A_5A)
         {
             "use_custom": True,
             "chart": {"title": "My chart title"},
+            "chart_title": "My chart title",
             "chart_settings_and_source_data": {"chartOptions": {}},
             "classification_code": "2A",
             "has_parents": True,
@@ -326,6 +329,7 @@ def test_adding_table_with_custom_data_and_existing_more_detailed_chart(two_clas
         {
             "use_custom": True,
             "table": {"title": "My table title"},
+            "table_title": "My table title",
             "table_settings_and_source_data": {"tableOptions": {}},
             "classification_code": "2A",
             "has_parents": True,
@@ -386,6 +390,7 @@ def test_adding_table_with_custom_data_and_existing_less_detailed_chart(two_clas
         {
             "use_custom": True,
             "table": {"title": "My table title"},
+            "table_title": "My table title",
             "table_settings_and_source_data": {"tableOptions": {}},
             "classification_code": "5A",
             "has_parents": False,


### PR DESCRIPTION
We will move chart/table titles out of the object/settings JSON blob into their own column. The title is currently written and read from multiple places, so we want to consolidate this into a single source of truth (although the title will still be rendered into the JSON blob for Highcharts, we will consider that a black box used for display only).

This is PR 1 of (anticipated) 3. This patch will write the titles to the existing place as well as the new column. It will start reading from the new column. The included migration will copy across existing values to populate the new column.

## Ticket