### PR TITLE
BUGFIX: Chart or table classifications could be NULL

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -630,11 +630,29 @@ class Dimension(db.Model):
 
         chart_or_table = None
 
-        if self.dimension_chart and (self.dimension_table is None):
+        # If there is a chart classification but no table classification, use the chart
+        if (
+            self.dimension_chart
+            and self.dimension_chart.classification
+            and (self.dimension_table is None or self.dimension_table.classification is None)
+        ):
             chart_or_table = self.dimension_chart
-        elif self.dimension_table and (self.dimension_chart is None):
+
+        # If there is a table classification but no chart classification, use the table
+        elif (
+            self.dimension_table
+            and self.dimension_table.classification
+            and (self.dimension_chart is None or self.dimension_chart.classification is None)
+        ):
             chart_or_table = self.dimension_table
-        elif self.dimension_table and self.dimension_chart:
+
+        # If there is both a table classification and chart classification, use the most specific
+        elif (
+            self.dimension_table
+            and self.dimension_table.classification
+            and self.dimension_chart
+            and self.dimension_chart.classification
+        ):
             if (
                 self.dimension_chart.classification.ethnicities_count
                 > self.dimension_table.classification.ethnicities_count


### PR DESCRIPTION
Up until recently if there was a dimension_chart or dimension_table
object associated with a Dimension then they were guaranteed to include
a classification (as the classification fields were not nullable).

Since the addition of more fields to dimension_chart and dimension_table
and the migration of chart and table object data to those tables it is
possiblr for the classification to be null.

This adds a check that the classification exists before trying to
dereference `xxx.classification.ethnicities_count`, which prevents
hitting
 ```
 AttributeError: 'NoneType' object has no attribute 'ethnicities_count'
 ```