### PR TITLE
2/3: Stop writing old titles

### DIFF
--- a/application/cms/dimension_service.py
+++ b/application/cms/dimension_service.py
@@ -49,12 +49,12 @@ class DimensionService(Service):
         if "chartObject" in post_data:
             data["chart"] = post_data["chartObject"]
             data["chart_settings_and_source_data"] = post_data["source"]
-            data["chart_title"] = post_data["source"]["chartFormat"]["chart_title"]
+            data["chart_title"] = post_data["chartTitle"]
 
         if "tableObject" in post_data:
             data["table"] = post_data["tableObject"]
             data["table_settings_and_source_data"] = post_data["source"]
-            data["table_title"] = post_data["source"]["tableValues"]["table_title"]
+            data["table_title"] = post_data["tableTitle"]
 
         if "classificationCode" in post_data:
             if post_data["classificationCode"] == "custom":

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -683,10 +683,12 @@ class Dimension(db.Model):
             "time_period": self.time_period,
             "summary": self.summary,
             "chart": self.dimension_chart.chart_object if self.dimension_chart else None,
+            "chart_title": self.dimension_chart.title if self.dimension_chart else None,
             "chart_settings_and_source_data": self.dimension_chart.settings_and_source_data
             if self.dimension_chart
             else None,
             "table": self.dimension_table.table_object if self.dimension_table else None,
+            "table_title": self.dimension_table.title if self.dimension_table else None,
             "table_settings_and_source_data": self.dimension_table.settings_and_source_data
             if self.dimension_table
             else None,

--- a/application/src/js/chartbuilder/chartbuilder.js
+++ b/application/src/js/chartbuilder/chartbuilder.js
@@ -336,6 +336,7 @@ $(document).ready(function () {
                 data: JSON.stringify({
                     'chartObject': chartObject,
                     'source': src,
+                    'chartTitle': getChartTitle(),
                     'classificationCode': getPresetCode(),
                     'customClassificationCode': getCustomClassificationCode(),
                     'customClassification': getCustomObject(),
@@ -410,7 +411,6 @@ $(document).ready(function () {
 
     function getChartFormat() {
         return {
-            'chart_title': $('#chart_title').val(),
             'x_axis_label': $('#x_axis_label').val(),
             'y_axis_label': $('#y_axis_label').val(),
             'number_format': $('#number_format').val(),
@@ -419,6 +419,10 @@ $(document).ready(function () {
             'number_format_min': $('#number_format_min').val(),
             'number_format_max': $('#number_format_max').val()
         }
+    }
+
+    function getChartTitle() {
+        return document.getElementById('chart_title').value;
     }
 
     function getPresetCode() {

--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -775,17 +775,6 @@ function setHeight(chartObject, padding) {
   return ( seriesLength * bar ) + padding;
 }
 
-function tooltipWithText(chart, series, text) {
-    var formatter = chart.series.length > 1 ? series.name + ': <b>' : '<b>';
-    formatter = formatter + text + '</b>';
-    return formatter;
-}
-function tooltipWithNumber(chart, series, prefix, suffix, decimalPlaces, number) {
-    var formatter = chart.series.length > 1 ? series.name + ': <b>' : '<b>';
-    formatter = formatter + prefix + formatNumberWithDecimalPlaces(number, decimalPlaces) + suffix + '</b>';
-    return formatter;
-}
-
 function decimalPointFormat(label, dp) {
     if(dp && dp > 0) {
         return '{' + label + ':.' + dp + 'f}';

--- a/application/src/js/cms/rd-table.js
+++ b/application/src/js/cms/rd-table.js
@@ -194,23 +194,6 @@ function appendGroupTableHeader(table_html, tableObject) {
 // ---------------------------------------------------------------------------
 // OTHER
 // ---------------------------------------------------------------------------
-
-function appendTableTitle(table_html, tableObject) {
-    if (tableObject.header && tableObject.header !== '') {
-        return table_html + "<div class='table-title heading-small'>" + tableObject.header + "</div>";
-    } else {
-        return table_html;
-    }
-}
-
-function appendTableSubtitle(table_html, tableObject) {
-    if (tableObject.subtitle && tableObject.subtitle !== '') {
-        return table_html + "<div class='table-subtitle'>" + tableObject.subtitle + "</div>";
-    } else {
-        return table_html;
-    }
-}
-
 function insertTableFooter(table_html, tableObject) {
     if (tableObject.footer && tableObject.footer !== '') {
         return table_html + "<div class='table-footer'>" + tableObject.footer + "</div>";

--- a/application/src/js/tablebuilder/tablebuilder.js
+++ b/application/src/js/tablebuilder/tablebuilder.js
@@ -354,6 +354,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 data: JSON.stringify({
                     'tableObject': tableObject,
                     'source': src,
+                    'tableTitle': getTableTitle(),
                     'classificationCode': getPresetCode(),
                     'customClassificationCode': getCustomClassificationCode(),
                     'customClassification': getCustomObject(),
@@ -399,7 +400,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function getTableValues() {
         return {
-            'table_title': $('#table_title').val(),
             'table_column_1': $('#table_column_1').val(),
             'table_column_1_name': $('#table_column_1_name').val(),
             'table_column_2': $('#table_column_2').val(),
@@ -412,6 +412,10 @@ document.addEventListener('DOMContentLoaded', function() {
             'table_column_5_name': $('#table_column_5_name').val(),
             'table_index_column_name': $('#index_column_name').val(),
         }
+    }
+
+    function getTableTitle() {
+        return document.getElementById('table_title').value;
     }
 
     function getPresetCode() {

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -61,7 +61,7 @@
                             {% if dimension.dimension_table and dimension.dimension_table.table_object is not none and dimension.dimension_table.table_object != '""' %}
                                 <tr class="govuk-table__row">
                                     <td class="govuk-table__header" scope="row">Table</td>
-                                    <td class="govuk-table__cell">{{ dimension.dimension_table.table_object.header }}</td>
+                                    <td class="govuk-table__cell">{{ dimension.dimension_table.title }}</td>
                                     <td class="govuk-table__cell"><a class="govuk-link" id="edit_table"
                                            href="{{ url_for('cms.create_table', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure_version.available_actions() %}edit{% else %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -1,7 +1,5 @@
-
-{{ dimension_dict.header }}
-{% if dimension_dict.table.header %}
-  <h3 class="govuk-heading-s">{{ dimension_dict.table.header }}</h3>
+{% if dimension_dict.table_title %}
+  <h3 class="govuk-heading-s">{{ dimension_dict.table_title }}</h3>
 {% endif %}
 
 {% set missing_data_sort_order_values = {

--- a/application/templates/static_site/export/measure_export.html
+++ b/application/templates/static_site/export/measure_export.html
@@ -347,12 +347,12 @@
                         <h4 class="govuk-heading-s">Charts and tables</h4>
                         <ul>
                             {% if dimension_dict.chart and dimension_dict.table %}
-                                <li>Chart - {{ dimension_dict.chart.title.text }}</li>
-                                <li>Table - {{ dimension_dict.table.header }}</li>
+                                <li>Chart - {{ dimension_dict.chart_title }}</li>
+                                <li>Table - {{ dimension_dict.table_title }}</li>
                             {% elif dimension_dict.chart %}
-                                <li>Chart - {{ dimension_dict.chart.title.text }}</li>
+                                <li>Chart - {{ dimension_dict.chart_title }}</li>
                             {% elif dimension_dict.table %}
-                                <li>Table - {{ dimension_dict.table.header }}</li>
+                                <li>Table - {{ dimension_dict.table_title }}</li>
 
                             {% else %}
                                 <li>None</li>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -292,8 +292,8 @@
 
                     {% if chart_and_downloadable %}
                         <p class="chart-download">
-                            <a class="govuk-link download-png" href="#" data-on="click" data-event-category="Image downloaded" data-event-action="Image of the chart" data-event-label="{{ dimension_dict.chart.title.text }}" class="download-png"
-                               id="download-{{ dimension_dict.guid }}" data-title="{{ dimension_dict.chart.title.text }}">
+                            <a class="govuk-link download-png" href="#" data-on="click" data-event-category="Image downloaded" data-event-action="Image of the chart" data-event-label="{{ dimension_dict.chart_title }}" class="download-png"
+                               id="download-{{ dimension_dict.guid }}" data-title="{{ dimension_dict.chart_title }}">
                                 Download chart (PNG)
                             </a>
                         </p>
@@ -312,7 +312,7 @@
                       {% if tabular_download_viable %}
                       <p class="chart-download">
                           {% if static_mode %}
-                              <a class="govuk-link" href="/{{ topic_slug }}/{{ subtopic_slug }}/{{ measure_version.measure.slug }}/{{ version }}/downloads/{{ dimension_dict.static_table_file_name }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension_dict.table.header}}"
+                              <a class="govuk-link" href="/{{ topic_slug }}/{{ subtopic_slug }}/{{ measure_version.measure.slug }}/{{ version }}/downloads/{{ dimension_dict.static_table_file_name }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{ dimension_dict.table_title }}"
                                  download="{{ dimension_dict.static_table_file_name }}">Download table data (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_table_download',
@@ -320,19 +320,19 @@
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension_dict.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension_dict.table.header}}">Download table data (CSV)</a>
+                                   dimension_guid=dimension_dict.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{ dimension_dict.table_title }}">Download table data (CSV)</a>
                           {% endif %}
 
                           {% if static_mode %}
                               <a class="govuk-link" href="/{{ topic_slug }}/{{ subtopic_slug }}/{{ measure_version.measure.slug }}/{{ version }}/downloads/{{ dimension_dict.static_file_name }}" data-on="click"
-                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension_dict.table.header}}">Source data (CSV)</a>
+                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{ dimension_dict.table_title }}">Source data (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_download',
                                    topic_slug=topic_slug,
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension_dict.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension_dict.table.header}}">Source data (CSV)</a>
+                                   dimension_guid=dimension_dict.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{ dimension_dict.table_title }}">Source data (CSV)</a>
                           {% endif %}
                       </p>
                     {% endif %}
@@ -695,13 +695,13 @@
   var dimensions = {{ dimensions|tojson }};
 
   $(document).ready(function () {
-    for (d in dimensions) {
+    for (var d in dimensions) {
       var chartObject = dimensions[d].chart;
       if(chartObject) {
           // code writes title as html and creates sub-container
           var chartContainer = 'chart_' + dimensions[d].guid;
           var chartHtml = '<div class="govuk-grid-column-full">';
-          chartHtml = chartObject.title.text ? chartHtml + '<h3 class="govuk-heading-s">' + chartObject.title.text + '</h3>': chartHtml;
+          chartHtml = dimensions[d].chart_title ? chartHtml + '<h3 class="govuk-heading-s">' + dimensions[d].chart_title + '</h3>': chartHtml;
           chartHtml = chartHtml + '<div id="' + chartContainer + '_image"></div>';
           chartHtml = chartHtml + '</div>';
           $('#' + chartContainer).html(chartHtml);

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -730,23 +730,6 @@
         chart.highcharts().exportChart({"filename" : chartTitle});
         evt.preventDefault();
     });
-
-
-    function getSourceText(source){
-        var regex = /\[(.*?)\]\(.*?\)/;
-        if(regex.test(source)){
-            var match = regex.exec(source);
-            if(match.length == 2) {
-               return match[1];
-            }
-            else {
-                return source;
-            }
-        } else {
-            return source;
-        }
-    };
-
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
Now that we're writing chart/table titles to their new dedicated column, we no longer need to store the duplicate in the `chartFormat`/`tableValues` blob.

Also updates some templates that are still reading from either the old title location or directly from the highcharts object, which we would ideally avoid. They now read from the new dedicated columns.

This also removes some dead JS code that isn't referenced anywhere in the code.