### PR TITLE
Edit description of an upload without uploading a new file

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -324,6 +324,10 @@ class DimensionForm(FlaskForm):
 
 
 class UploadForm(FlaskForm):
+    """
+    This is used for editing an existing upload to a measure version; a file already exists, so only title is required
+    """
+
     guid = StringField()
     upload = FileField(label="File in CSV format", validators=[])
     title = RDUStringField(label="Title", hint="For example, ‘Household income data’", validators=[DataRequired()])
@@ -338,6 +342,10 @@ class UploadForm(FlaskForm):
 
 
 class NewUploadForm(UploadForm):
+    """
+    This is used for adding a new upload to a measure version, so a file upload is required
+    """
+
     upload = FileField(
         label="File in CSV format", validators=[DataRequired(message="Please choose a file for users to download.")]
     )

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -325,9 +325,7 @@ class DimensionForm(FlaskForm):
 
 class UploadForm(FlaskForm):
     guid = StringField()
-    upload = FileField(
-        label="File in CSV format", validators=[DataRequired(message="Please choose a file for users to download")]
-    )
+    upload = FileField(label="File in CSV format", validators=[])
     title = RDUStringField(label="Title", hint="For example, ‘Household income data’", validators=[DataRequired()])
     description = RDUTextAreaField(
         hint=(
@@ -336,6 +334,12 @@ class UploadForm(FlaskForm):
                 "measure, ethnicity, year, gender, age group, value, confidence intervals (upper bound, lower bound)."
             )
         )
+    )
+
+
+class NewUploadForm(UploadForm):
+    upload = FileField(
+        label="File in CSV format", validators=[DataRequired(message="Please choose a file for users to download.")]
     )
 
 

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -24,7 +24,14 @@ from application.cms.exceptions import (
     UploadAlreadyExists,
     PageUnEditable,
 )
-from application.cms.forms import DimensionForm, DimensionRequiredForm, MeasureVersionForm, NewVersionForm, UploadForm
+from application.cms.forms import (
+    DimensionForm,
+    DimensionRequiredForm,
+    MeasureVersionForm,
+    NewUploadForm,
+    NewVersionForm,
+    UploadForm,
+)
 from application.cms.models import NewVersionType
 from application.cms.models import publish_status, Organisation
 from application.cms.page_service import page_service
@@ -366,9 +373,8 @@ def create_upload(topic_slug, subtopic_slug, measure_slug, version):
         topic_slug, subtopic_slug, measure_slug, version
     )
 
-    form = UploadForm()
     if request.method == "POST":
-        form = UploadForm(CombinedMultiDict((request.files, request.form)))
+        form = NewUploadForm(CombinedMultiDict((request.files, request.form)))
         if form.validate():
             file_data = form.upload.data
             try:
@@ -405,6 +411,8 @@ def create_upload(topic_slug, subtopic_slug, measure_slug, version):
                     version=measure_version.version,
                 )
             )
+    else:
+        form = NewUploadForm()
 
     context = {
         "form": form,

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -25,10 +25,10 @@
                       action="{{ url_for('cms.create_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group {% if form.upload.errors %}govuk-form-group--error{% endif %}">
                         {{ form.upload.label(class='govuk-label') }}
                         {% if form.upload.errors %}
-                            - {{ form.upload.errors[0] }}
+                            <span class="govuk-error-message">{{ form.upload.errors[0] }}</span>
                             {{ form.upload(class="govuk-file-upload error") }}
                         {% else %}
                             {{ form.upload(class="govuk-file-upload") }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,7 +2919,7 @@
         "gulp-cli": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
-          "integrity": "sha1-eEfiIMs2YvK+im1XK/FOF75amUs=",
+          "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
           "requires": {
             "ansi-colors": "^1.0.1",
             "archy": "^1.0.0",


### PR DESCRIPTION
For this ticket: https://trello.com/c/T0Vipa1J/1113-add-ability-to-edit-description-of-a-download-file-2

Currently if users try to edit the title or description of an upload
they are forced to re-upload a data file.  If a file has already been
uploaded then users shouldn't have to re-upload a file just to tweak
the description.

However, when creating a new upload users should be forced to add a
file.  The NewUploadForm added here enforces this (which is the current
behaviour) but the UploadForm for editing uploads no longer has the
validator on the upload field.

This also adds styling to the error message shown when the user fails
to add a file when creating an upload.  It now looks like this:

![Screenshot from 2019-03-21 14-42-20](https://user-images.githubusercontent.com/6525554/54761982-1b5d2e00-4beb-11e9-9278-cf1398943de7.png)
