### PR TITLE
Don't copy data files for MAJOR version updates

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -299,10 +299,13 @@ class PageService(Service):
         new_version.latest = True
 
         new_version.uploads = []
-        for upload in measure_version.uploads:
-            new_upload = upload.copy()
-            new_upload.guid = create_guid(upload.file_name)
-            new_version.uploads.append(new_upload)
+
+        # We don't copy uploads for major updates, as major updates should always have new data
+        if update_type != NewVersionType.MAJOR_UPDATE:
+            for upload in measure_version.uploads:
+                new_upload = upload.copy()
+                new_upload.guid = create_guid(upload.file_name)
+                new_version.uploads.append(new_upload)
 
         db.session.add(new_version)
         db.session.flush()

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -414,7 +414,7 @@ class TestPageService:
 
     def test_create_new_minor_version_duplicates_uploads(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionWithDimensionFactory(latest=True)
+        measure_version = MeasureVersionFactory(latest=True)
         assert measure_version.uploads.count() == 1
         original_upload = measure_version.uploads[0]
 
@@ -429,7 +429,7 @@ class TestPageService:
 
     def test_create_new_major_version_does_not_duplicate_uploads(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
-        measure_version = MeasureVersionWithDimensionFactory(latest=True)
+        measure_version = MeasureVersionFactory(latest=True)
 
         new_version = page_service.create_measure_version(measure_version, NewVersionType.MAJOR_UPDATE, user=user)
 

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -412,6 +412,30 @@ class TestPageService:
         assert new_link.includes_all is True
         assert new_link.includes_unknown is True
 
+    def test_create_new_minor_version_duplicates_uploads(self):
+        user = UserFactory(user_type=TypeOfUser.RDU_USER)
+        measure_version = MeasureVersionWithDimensionFactory(latest=True)
+        assert measure_version.uploads.count() == 1
+        original_upload = measure_version.uploads[0]
+
+        new_version = page_service.create_measure_version(measure_version, NewVersionType.MINOR_UPDATE, user=user)
+
+        assert new_version.uploads.count() == 1
+        new_upload = new_version.uploads[0]
+        assert new_upload.guid != original_upload.guid
+        assert new_upload.file_name == original_upload.file_name
+        assert new_upload.title == original_upload.title
+        assert new_upload.description == original_upload.description
+
+    def test_create_new_major_version_does_not_duplicate_uploads(self):
+        user = UserFactory(user_type=TypeOfUser.RDU_USER)
+        measure_version = MeasureVersionWithDimensionFactory(latest=True)
+
+        new_version = page_service.create_measure_version(measure_version, NewVersionType.MAJOR_UPDATE, user=user)
+
+        assert measure_version.uploads.count() == 1
+        assert new_version.uploads.count() == 0
+
     def test_create_copy_of_page(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
         measure_version = MeasureVersionFactory(latest=True, measure__slug="slug")


### PR DESCRIPTION
For this ticket: https://trello.com/c/9zyti0US/1255-dont-copy-data-files-for-major-updates-3

Major updates should always involve a new data file.  By not copying the
old file across we eliminate the risk that users of Publisher forget to
update the data file.