### PR TITLE
Bump review app postgresql plan

### DIFF
--- a/app.json
+++ b/app.json
@@ -113,7 +113,7 @@
   },
   "addons": [
     "attachment-scanner",
-    {"plan": "heroku-postgresql", "options":  {"version": "10"}},
+    {"plan": "heroku-postgresql:hobby-basic", "options":  {"version": "10"}},
     "scheduler"
   ],
   "buildpacks": [


### PR DESCRIPTION
Our review apps have tumbled over 10k rows, which is where free plans
start to get limited/write-blocked. By upgrading to the cheapest
non-free option, we increase our row limit to 1m which should do us
pretty much forever. It costs $9 a month at current rates, so we'll
probably increase costs by <$30 a month overall (as each review app
rarely lasts more than a few days, and the DB charges are prorated).

 ## Ticket
https://trello.com/c/2bhiOxUN