### PR TITLE
ObjectBuilders read title from chart/table model

### DIFF
--- a/application/data/charts.py
+++ b/application/data/charts.py
@@ -1,7 +1,12 @@
+from application.cms.models import Chart
+
+
 class ChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
+    def build(dimension_chart: Chart):
+        chart_object = dimension_chart.chart_object
         builder = None
+
         if chart_object["type"] == "bar" or chart_object["type"] == "small_bar":
             builder = BarChartObjectDataBuilder
         elif chart_object["type"] == "line":
@@ -14,26 +19,24 @@ class ChartObjectDataBuilder:
             builder = PanelLineChartObjectDataBuilder
 
         if builder:
-            return builder.build(chart_object)
+            return builder.build(dimension_chart, chart_object)
         else:
             return None
 
 
 class PanelBarChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
-
+    def build(dimension_chart, chart_object):
         return {
             "type": chart_object["type"],
-            "title": chart_object["title"]["text"],
+            "title": dimension_chart.title,
             "x-axis": chart_object["xAxis"]["title"].get("text", ""),
             "y-axis": chart_object["yAxis"]["title"].get("text", ""),
-            "data": PanelBarChartObjectDataBuilder.panel_bar_chart_data(chart_object),
+            "data": PanelBarChartObjectDataBuilder.panel_bar_chart_data(dimension_chart, chart_object),
         }
 
     @staticmethod
-    def panel_bar_chart_data(chart_object):
-
+    def panel_bar_chart_data(dimension_chart, chart_object):
         panels = chart_object["panels"]
 
         if len(panels) > 0:
@@ -47,7 +50,7 @@ class PanelBarChartObjectDataBuilder:
             rows = []
             for panel in panels:
                 panel_name = panel["title"]["text"]
-                panel_rows = BarChartObjectDataBuilder.build(panel)["data"][1:]
+                panel_rows = BarChartObjectDataBuilder.build(dimension_chart, panel)["data"][1:]
                 for row in panel_rows:
                     rows = rows + [[panel_name] + row]
 
@@ -58,10 +61,10 @@ class PanelBarChartObjectDataBuilder:
 
 class PanelLineChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
+    def build(dimension_chart, chart_object):
         panel_object = {
             "type": chart_object["type"],
-            "title": chart_object["title"]["text"],
+            "title": dimension_chart.title,
             "x-axis": "",
             "y-axis": "",
             "data": [],
@@ -74,13 +77,12 @@ class PanelLineChartObjectDataBuilder:
         panel = panels[0]
         panel_object["x-axis"] = panel["xAxis"]["title"].get("text", "")
         panel_object["y-axis"] = panel["yAxis"]["title"].get("text", "")
-        panel_object["data"] = PanelLineChartObjectDataBuilder.panel_line_chart_data(chart_object)
+        panel_object["data"] = PanelLineChartObjectDataBuilder.panel_line_chart_data(dimension_chart, chart_object)
 
         return panel_object
 
     @staticmethod
-    def panel_line_chart_data(chart_object):
-
+    def panel_line_chart_data(dimension_chart, chart_object):
         panels = chart_object["panels"]
 
         if len(panels) > 0:
@@ -93,7 +95,7 @@ class PanelLineChartObjectDataBuilder:
 
             rows = []
             for panel in panels:
-                panel_rows = LineChartObjectDataBuilder.build(panel)["data"][1:]
+                panel_rows = LineChartObjectDataBuilder.build(dimension_chart, panel)["data"][1:]
                 for row in panel_rows:
                     rows = rows + [row]
 
@@ -104,11 +106,10 @@ class PanelLineChartObjectDataBuilder:
 
 class ComponentChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
-
+    def build(dimension_chart, chart_object):
         return {
             "type": chart_object["type"],
-            "title": chart_object["title"]["text"],
+            "title": dimension_chart.title,
             "x-axis": chart_object["xAxis"]["title"].get("text", ""),
             "y-axis": chart_object["yAxis"]["title"].get("text", ""),
             "data": ComponentChartObjectDataBuilder.component_chart_data(chart_object),
@@ -134,11 +135,10 @@ class ComponentChartObjectDataBuilder:
 
 class LineChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
-
+    def build(dimension_chart, chart_object):
         return {
             "type": chart_object["type"],
-            "title": chart_object["title"]["text"],
+            "title": dimension_chart.title,
             "x-axis": chart_object["xAxis"]["title"].get("text", ""),
             "y-axis": chart_object["yAxis"]["title"].get("text", ""),
             "data": LineChartObjectDataBuilder.line_chart_data(chart_object),
@@ -164,7 +164,7 @@ class LineChartObjectDataBuilder:
 
 class BarChartObjectDataBuilder:
     @staticmethod
-    def build(chart_object):
+    def build(dimension_chart, chart_object):
         if chart_object["series"].__len__() > 1:
             data = BarChartObjectDataBuilder.multi_series_bar_chart_data(chart_object)
         else:
@@ -172,7 +172,7 @@ class BarChartObjectDataBuilder:
 
         return {
             "type": chart_object["type"],
-            "title": chart_object["title"]["text"],
+            "title": dimension_chart.title,
             "x-axis": chart_object["xAxis"]["title"].get("text", ""),
             "y-axis": chart_object["yAxis"]["title"].get("text", ""),
             "data": data,

--- a/application/data/dimensions.py
+++ b/application/data/dimensions.py
@@ -16,13 +16,13 @@ class DimensionObjectBuilder:
         dimension_object = {"context": DimensionObjectBuilder.get_context(dimension)}
 
         if dimension.dimension_table and dimension.dimension_table.table_object:
-            dimension_object["table"] = TableObjectDataBuilder.build(dimension.dimension_table.table_object)
+            dimension_object["table"] = TableObjectDataBuilder.build(dimension.dimension_table)
 
         if dimension.dimension_chart and dimension.dimension_chart.chart_object:
-            dimension_object["chart"] = ChartObjectDataBuilder.build(dimension.dimension_chart.chart_object)
+            dimension_object["chart"] = ChartObjectDataBuilder.build(dimension.dimension_chart)
 
         if dimension.dimension_table and dimension.dimension_table.table_object:
-            dimension_object["tabular"] = TableObjectTableBuilder.build(dimension.dimension_table.table_object)
+            dimension_object["tabular"] = TableObjectTableBuilder.build(dimension.dimension_table)
 
         return dimension_object
 

--- a/application/data/tables.py
+++ b/application/data/tables.py
@@ -1,10 +1,15 @@
+from application.cms.models import Table
+
+
 class TableObjectDataBuilder:
     """
     Generates table objects that can be used to generate tables on the front end and data download files
     """
 
     @staticmethod
-    def build(table_object):
+    def build(dimension_table: Table):
+        table_object = dimension_table.table_object
+
         if "category_caption" in table_object:
             category_caption = table_object["category_caption"]
         else:
@@ -17,7 +22,7 @@ class TableObjectDataBuilder:
 
         return {
             "type": table_object["type"],
-            "title": table_object["header"],
+            "title": dimension_table.title,
             "primary_category_column": category_caption,
             "secondary_category_column": group_column,
             "value_columns": table_object["columns"],
@@ -71,11 +76,13 @@ class TableObjectDataBuilder:
 
 class TableObjectTableBuilder:
     @staticmethod
-    def build(table_object):
+    def build(dimension_table: Table):
+        table_object = dimension_table.table_object
+
         if table_object["type"] == "simple":
-            return TableObjectDataBuilder.build(table_object)
+            return TableObjectDataBuilder.build(dimension_table)
         else:
-            table = TableObjectDataBuilder.build(table_object)
+            table = TableObjectDataBuilder.build(dimension_table)
             table["data"] = TableObjectTableBuilder.get_data_table(table_object)
             return table
 

--- a/tests/application/data/test_dimensions.py
+++ b/tests/application/data/test_dimensions.py
@@ -8,7 +8,10 @@ from tests.test_data.chart_and_table import simple_table, grouped_table
 
 
 def test_table_object_builder_does_build_object_from_simple_table():
-    measure_version = MeasureVersionWithDimensionFactory(dimensions__dimension_table__table_object=simple_table())
+    measure_version = MeasureVersionWithDimensionFactory(
+        dimensions__dimension_table__title="My dimension table",
+        dimensions__dimension_table__table_object=simple_table(),
+    )
     # given - a table without a category_caption value
     builder = DimensionObjectBuilder()
     dimension = measure_version.dimensions[0]
@@ -16,13 +19,17 @@ def test_table_object_builder_does_build_object_from_simple_table():
     # when we process the object
     table_object = builder.build(dimension)
 
-    # then the header for the returned table should match the ones from the simple table
+    # then the title should come from the dimension table, and the type should come from the table_object
     assert table_object is not None
-    assert table_object.get("table").get("title") == "Title of simple table"
+    assert table_object["table"]["type"] == "simple"
+    assert table_object["table"]["title"] == "My dimension table"
 
 
 def test_table_object_builder_does_build_object_from_grouped_table():
-    measure_version = MeasureVersionWithDimensionFactory(dimensions__dimension_table__table_object=grouped_table())
+    measure_version = MeasureVersionWithDimensionFactory(
+        dimensions__dimension_table__title="My dimension table",
+        dimensions__dimension_table__table_object=grouped_table(),
+    )
     # given - a table without a category_caption value
     builder = DimensionObjectBuilder()
     dimension = measure_version.dimensions[0]
@@ -32,7 +39,8 @@ def test_table_object_builder_does_build_object_from_grouped_table():
 
     # then the header for the returned table should match the ones from the grouped table
     assert table_object is not None
-    assert table_object.get("table").get("title") == "Title of grouped table"
+    assert table_object["table"]["type"] == "grouped"
+    assert table_object["table"]["title"] == "My dimension table"
 
 
 def test_table_object_builder_does_build_with_page_level_data_from_simple_table():

--- a/tests/test_data/chart_and_table.py
+++ b/tests/test_data/chart_and_table.py
@@ -301,7 +301,6 @@ def simple_table():
     return {
         "type": "simple",
         "parent_child": False,
-        "header": "Title of simple table",
         "subtitle": "",
         "footer": "",
         "category": "Ethnicity",
@@ -349,7 +348,6 @@ def grouped_table():
                 "sort_values": [16.6, 0.166, 10, 0.1],
             },
         ],
-        "header": "Title of grouped table",
         "subtitle": "",
         "footer": "",
         "groups": [


### PR DESCRIPTION
Missed a couple of places where chart/table titles are being read from the JSON blob (`title->text` for charts, `header` for tables). This patch does the minimum refactoring possible to get these `Builder` classes to be able to read directly from the dedicated title column.

These sections of the code are probably due for a refactor in the coming months.