### PR TITLE
Update references to more chart titles

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -74,7 +74,7 @@ function barchartHighchartObject(chartObject) {
             height: setHeight(chartObject)
         },
         title: {
-            text: chartObject.title.text,
+            text: chartObject.chart_title,
             style: {
               color: "black"
             }
@@ -205,7 +205,7 @@ function linechartHighchartObject(chartObject) {
         },
         colors: setColour(chartObject),
         title: {
-            text: chartObject.title.text
+            text: chartObject.chart_title
         },
         xAxis: {
             categories: chartObject.xAxis.categories,
@@ -259,7 +259,7 @@ function componentChart(container_id, chartObject) {
         },
         colors: setColour(chartObject),
         title: {
-            text:  chartObject.title.text
+            text:  chartObject.chart_title
         },
         xAxis: {
             categories: chartObject.xAxis.categories,
@@ -407,7 +407,7 @@ function smallBarchart(container_id, chartObject, max) {
                 }
             },
             title: {
-                text: chartObject.title.text
+                text: chartObject.chart_title
             },
             xAxis: {
                 categories: chartObject.xAxis.categories,
@@ -593,7 +593,7 @@ function smallLinechart(container_id, chartObject, max, min) {
         },
         colors: setColour(chartObject),
         title: {
-            text: chartObject.title.text,
+            text: chartObject.chart_title,
             useHTML: true
         },
         legend: {

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -43,7 +43,7 @@
                             {% if dimension.dimension_chart and dimension.dimension_chart.chart_object is not none and dimension.dimension_chart.chart_object != '""' %}
                                 <tr class="govuk-table__row">
                                     <td class="govuk-table__header" scope="row">Chart</td>
-                                    <td class="govuk-table__cell">{{ dimension.dimension_chart.chart_object.title.text }}</td>
+                                    <td class="govuk-table__cell">{{ dimension.dimension_chart.title }}</td>
                                     <td class="govuk-table__cell"><a class="govuk-link" id="edit_chart"
                                            href="{{ url_for('cms.create_chart', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure_version.available_actions() %}edit{% else %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -698,6 +698,10 @@
     for (var d in dimensions) {
       var chartObject = dimensions[d].chart;
       if(chartObject) {
+          // TODO: Pass through the entire `dimension_chart` object, not just the model's `chart_object` blob.
+          // TODO: Then we wouldn't need to inject the title at the last minute.
+          chartObject.chart_title = dimensions[d].chart_title;
+
           // code writes title as html and creates sub-container
           var chartContainer = 'chart_' + dimensions[d].guid;
           var chartHtml = '<div class="govuk-grid-column-full">';


### PR DESCRIPTION
When constructing the Highcharts JSON blob, we should also be reading the title from the dedicated column and not pointing to a (now) invalid key in the chart blob. In order to expose the title from the dedicated column, we inject it at the last second. TODO logged for the next ticket, which separates out the chart/table type.