### PR TITLE
Don't render pre/code markdown blocks

### DIFF
--- a/application/cms/form_fields.py
+++ b/application/cms/form_fields.py
@@ -223,21 +223,21 @@ class RDUStringField(StringField):
     def __init__(
         self, label=None, validators=None, hint=None, extended_hint=None, character_count_limit=None, **kwargs
     ):
+        kwargs["filters"] = kwargs.get("filters", [])
+
         # Automatically coalesce `None` values to blank strings
         # If we get null values from the database, we don't want to render these as 'None' strings in form fields.
-        kwargs["filters"] = kwargs.get("filters", [])
-        if _coerce_none_to_blank_string not in kwargs["filters"]:
-            kwargs["filters"].append(_coerce_none_to_blank_string)
+        kwargs["filters"].append(_coerce_none_to_blank_string)
 
+        # Strip whitespace depending on the field type
         if self.__class__ is RDUStringField or self.__class__ is RDUURLField:
-            if _strip_whitespace_basic not in kwargs["filters"]:
-                kwargs["filters"].append(_strip_whitespace_basic)
+            kwargs["filters"].append(_strip_whitespace_basic)
 
         elif self.__class__ is RDUTextAreaField:
-            if _strip_whitespace_extended not in kwargs["filters"]:
-                kwargs["filters"].append(_strip_whitespace_extended)
+            kwargs["filters"].append(_strip_whitespace_extended)
 
         super().__init__(label, validators, **kwargs)
+
         self.hint = hint
         self.character_count_limit = character_count_limit
         self.extended_hint = Markup(render_template(f"forms/extended_hints/{extended_hint}")) if extended_hint else None

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -158,19 +158,15 @@ class MeasureVersionForm(FlaskForm):
         label="Title",
         validators=[DataRequired(), Length(max=255)],
         hint="For example, ‘Self-harm by young people in custody’",
-        strip_whitespace=True,
     )
     internal_reference = RDUStringField(
-        label="Measure code (optional)",
-        hint="This is for internal use by the Race Disparity Unit",
-        strip_whitespace=True,
+        label="Measure code (optional)", hint="This is for internal use by the Race Disparity Unit"
     )
     published_at = DateField(label="Publication date", format="%Y-%m-%d", validators=[Optional()])
     time_covered = RDUStringField(
         label="Time period covered",
         validators=[RequiredForReviewValidator()],
         hint="For example, ‘2016 to 2017’, or ‘2014/15 to 2016/17’",
-        strip_whitespace=True,
     )
 
     area_covered = RDUCheckboxField(label="Areas covered", enum=UKCountry, validators=[RequiredForReviewValidator()])
@@ -184,12 +180,9 @@ class MeasureVersionForm(FlaskForm):
         label="Suppression rules and disclosure control (optional)",
         hint="If any data has been excluded from the analysis, explain why",
         extended_hint="_suppression_and_disclosure.html",
-        strip_whitespace=True,
     )
     estimation = RDUTextAreaField(
-        label="Rounding (optional)",
-        hint="For example, ‘Percentages are rounded to one decimal place’",
-        strip_whitespace=True,
+        label="Rounding (optional)", hint="For example, ‘Percentages are rounded to one decimal place’"
     )
 
     summary = RDUTextAreaField(
@@ -197,7 +190,6 @@ class MeasureVersionForm(FlaskForm):
         validators=[RequiredForReviewValidator()],
         hint="Summarise the main findings and highlight any serious caveats in the quality of the data",
         extended_hint="_summary.html",
-        strip_whitespace=True,
     )
 
     measure_summary = RDUTextAreaField(
@@ -207,7 +199,6 @@ class MeasureVersionForm(FlaskForm):
             "Explain what the data is analysing, what’s included in categories labelled as ‘Other’ and define any "
             "terms users might not understand"
         ),
-        strip_whitespace=True,
     )
 
     description = RDUTextAreaField(
@@ -219,7 +210,6 @@ class MeasureVersionForm(FlaskForm):
         ),
         extended_hint="_description.html",
         character_count_limit=160,
-        strip_whitespace=True,
     )
 
     need_to_know = RDUTextAreaField(
@@ -227,7 +217,6 @@ class MeasureVersionForm(FlaskForm):
         validators=[RequiredForReviewValidator()],
         hint="Outline how the data was collected and explain any limitations",
         extended_hint="_things_you_need_to_know.html",
-        strip_whitespace=True,
     )
 
     ethnicity_definition_summary = RDUTextAreaField(
@@ -239,7 +228,6 @@ class MeasureVersionForm(FlaskForm):
             '<a href="https://guide.ethnicity-facts-figures.service.gov.uk/a-z#ethnic-categories" target="_blank"'
             'class="govuk-link">Style guide A to Z</a> (this will open a new page).'
         ),
-        strip_whitespace=True,
     )
 
     methodology = RDUTextAreaField(
@@ -247,15 +235,12 @@ class MeasureVersionForm(FlaskForm):
         validators=[RequiredForReviewValidator()],
         hint="Explain your methods in clear, simple language",
         extended_hint="_methodology.html",
-        strip_whitespace=True,
     )
     related_publications = RDUTextAreaField(
-        label="Related publications (optional)", extended_hint="_related_publications.html", strip_whitespace=True
+        label="Related publications (optional)", extended_hint="_related_publications.html"
     )
-    qmi_url = RDUURLField(label="Link to quality and methodology information", strip_whitespace=True)
-    further_technical_information = RDUTextAreaField(
-        label="Further technical information (optional)", strip_whitespace=True
-    )
+    qmi_url = RDUURLField(label="Link to quality and methodology information")
+    further_technical_information = RDUTextAreaField(label="Further technical information (optional)")
 
     # Edit summaries
     update_corrects_data_mistake = RDURadioField(
@@ -275,12 +260,10 @@ class MeasureVersionForm(FlaskForm):
             "If you’ve corrected the data, explain what’s changed and why. Otherwise, summarise what you’ve updated "
             "(for example, ‘Updated with the latest available data’)."
         ),
-        strip_whitespace=True,
     )
     internal_edit_summary = RDUTextAreaField(
         label="Notes (for internal use - optional)",
         hint="Include any additional information someone might need if they’re working on this page in the future",
-        strip_whitespace=True,
     )
 
     def __init__(self, is_minor_update: bool, sending_to_review=False, *args, **kwargs):

--- a/tests/application/cms/test_form_fields.py
+++ b/tests/application/cms/test_form_fields.py
@@ -181,7 +181,6 @@ class TestRDUStringField:
         string_field_invalid = RDUStringField(
             label="string_field", hint="string_field hint", validators=[DataRequired(message="failed validation")]
         )
-        string_field_strip = RDUStringField(label="string_field_strip", strip_whitespace=True)
 
     def setup(self):
         self.form = self.FormForTest()
@@ -237,12 +236,11 @@ class TestRDUStringField:
 
         assert obj.string_field is None
 
-    def test_can_strip_whitespace(self):
-        formdata = ImmutableMultiDict({"string_field": "   blah   ", "string_field_strip": "   blah   "})
+    def test_strips_leading_and_trailing_whitespace(self):
+        formdata = ImmutableMultiDict({"string_field": "   blah   \n\n   blah   "})
         self.form.process(formdata=formdata)
 
-        assert self.form.string_field.data == "   blah   "
-        assert self.form.string_field_strip.data == "blah"
+        assert self.form.string_field.data == "blah   \n\n   blah"
 
 
 class TestRDUPasswordField:
@@ -297,6 +295,12 @@ class TestRDUPasswordField:
 
         assert obj.password_field == "some data"
 
+    def test_does_not_strip_leading_and_trailing_whitespace(self):
+        formdata = ImmutableMultiDict({"password_field": "   blah   \n\n   blah   "})
+        self.form.process(formdata=formdata)
+
+        assert self.form.password_field.data == "   blah   \n\n   blah   "
+
 
 class TestRDUURLField:
     class FormForTest(FlaskForm):
@@ -349,6 +353,12 @@ class TestRDUURLField:
         self.form.populate_obj(obj)
 
         assert obj.url_field == "some data"
+
+    def test_strips_leading_and_trailing_whitespace(self):
+        formdata = ImmutableMultiDict({"url_field": "   blah   \n\n   blah   "})
+        self.form.process(formdata=formdata)
+
+        assert self.form.url_field.data == "blah   \n\n   blah"
 
 
 class TestRDUTextAreaField:
@@ -425,3 +435,9 @@ class TestRDUTextAreaField:
 
         textarea = doc.xpath("//textarea")[0]
         assert {"govuk-textarea", "js-character-count"} <= set(textarea.get("class", "").split())
+
+    def test_strips_whitespace_from_start_and_end_of_text_and_start_of_each_line(self):
+        formdata = ImmutableMultiDict({"textarea_field": "   blah   \n\n   blah   "})
+        self.form.process(formdata=formdata)
+
+        assert self.form.textarea_field.data == "blah   \n\nblah"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def stub_measure_data():
         "measure_summary": "Unemployment measure summary",
         "estimation": "X people are unemployed",
         "need_to_know": "Need to know this",
-        "summary": "Unemployment Summary\n * This is a summary bullet",
+        "summary": "Unemployment Summary\n* This is a summary bullet",
         "qmi_url": "http://www.quality-street.gov.uk",
         "time_covered": "4 months",
         "methodology": "how we measure unemployment",


### PR DESCRIPTION
When we roll the publisher out to more departments, we want a slightly
tighter control on what markdown we render to users. Specifically, we
don't want to render pre/code blocks if publishers have leading
whitespace on their lines.

We extend our existing `strip_whitespace` functionality on the form
fields to include an `extended` stripping option, which also removes
leading whitespace from each line. This will prevent the markdown
renderer from recognising any code blocks.

 ## Ticket
https://trello.com/c/BRxNXUzP