### PR TITLE
Use the JS .toLowerCase() rather than .lower() which doesn't exist

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -660,7 +660,7 @@ function adjustChartObjectForMissingData(chartObject) {
 }
 
 function htmlContentForMissingDataSymbol(symbol) {
-    switch (symbol.trim().lower()) {
+    switch (symbol.trim().toLowerCase()) {
         case 'n/a':
             return 'N/A<sup>*</sup>';
         default:
@@ -669,7 +669,7 @@ function htmlContentForMissingDataSymbol(symbol) {
 }
 
 function classNameForMissingDataSymbol(symbol) {
-    switch (symbol.trim().lower()) {
+    switch (symbol.trim().toLowerCase()) {
         case '!':
             return 'missing-data confidential';
         case '?':


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/IflWq61l/1425-fix-javascript-errors-on-measure-pages-1

Avoids this error on measure pages:
`Uncaught TypeError: t.trim(...).lower is not a function`