### PR TITLE
Require data file before sending for review

### DIFF
--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -1,9 +1,17 @@
+from dataclasses import dataclass
 from functools import partial
 
 
 from flask import current_app
 
 from application.cms.forms import DataSourceForm
+
+
+@dataclass
+class ErrorSummaryMessage:
+    field: str
+    text: str
+    href: str
 
 
 def copy_form_errors(from_form, to_form):
@@ -14,11 +22,11 @@ def copy_form_errors(from_form, to_form):
         setattr(to_form, key, field)
 
 
-def get_error_summary_data(title="Please see below errors:", forms=None, additional_error_messages=None):
+def get_error_summary_data(title="Please see below errors:", forms=None, extra_non_form_errors=None):
     if not forms:
         forms = []
 
-    if not any(form.errors for form in forms) and not additional_error_messages:
+    if not any(form.errors for form in forms) and not extra_non_form_errors:
         return {}
 
     error_summary_data = {"title": title, "errors": []}
@@ -26,11 +34,11 @@ def get_error_summary_data(title="Please see below errors:", forms=None, additio
         for field_name, error_message in form.errors.items():
             form_field = getattr(form, field_name)
             error_summary_data["errors"].append(
-                {"href": f"#{form_field.id}-label", "field": form_field.label.text, "text": error_message[0]}
+                ErrorSummaryMessage(field=form_field.label.text, text=error_message[0], href=f"#{form_field.id}-label")
             )
 
-    if additional_error_messages:
-        error_summary_data["errors"].extend(additional_error_messages)
+    if extra_non_form_errors:
+        error_summary_data["errors"].extend(extra_non_form_errors)
 
     return error_summary_data
 

--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -14,12 +14,12 @@ def copy_form_errors(from_form, to_form):
         setattr(to_form, key, field)
 
 
-def get_error_summary_data(title="Please see below errors:", forms=None):
-    if not any(form.errors for form in forms):
-        return {}
-
+def get_error_summary_data(title="Please see below errors:", forms=None, additional_error_messages=None):
     if not forms:
         forms = []
+
+    if not any(form.errors for form in forms) and not additional_error_messages:
+        return {}
 
     error_summary_data = {"title": title, "errors": []}
     for form in forms:
@@ -28,6 +28,9 @@ def get_error_summary_data(title="Please see below errors:", forms=None):
             error_summary_data["errors"].append(
                 {"href": f"#{form_field.id}-label", "field": form_field.label.text, "text": error_message[0]}
             )
+
+    if additional_error_messages:
+        error_summary_data["errors"].extend(additional_error_messages)
 
     return error_summary_data
 

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -36,7 +36,7 @@ from application.cms.models import NewVersionType
 from application.cms.models import publish_status, Organisation
 from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
-from application.cms.utils import copy_form_errors, get_data_source_forms, get_error_summary_data
+from application.cms.utils import copy_form_errors, get_data_source_forms, get_error_summary_data, ErrorSummaryMessage
 from application.data.standardisers.ethnicity_classification_finder import Builder2FrontendConverter
 from application.sitebuilder import build_service
 from application.utils import get_bool, user_can, user_has_access
@@ -498,17 +498,17 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
                 dimensions_not_complete_error = True
                 for invalid_dimension in invalid_dimensions:
                     non_form_error_messages.append(
-                        {
-                            "field": invalid_dimension.title,
-                            "text": "This dimension is not complete.",
-                            "href": f"./{invalid_dimension.guid}/edit?validate=true",
-                        }
+                        ErrorSummaryMessage(
+                            field=invalid_dimension.title,
+                            text="This dimension is not complete.",
+                            href=f"./{invalid_dimension.guid}/edit?validate=true",
+                        )
                     )
 
             if not data_file_uploaded:
                 data_not_uploaded_error = True
                 non_form_error_messages.append(
-                    {"field": "Data", "text": "Source data must be uploaded.", "href": "#source-data"}
+                    ErrorSummaryMessage(field="Data", text="Source data must be uploaded.", href="#source-data")
                 )
 
             current_status = measure_version.status
@@ -533,7 +533,7 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
                 "error_summary": get_error_summary_data(
                     title="Cannot submit for review.",
                     forms=[measure_version_form, data_source_form, data_source_2_form],
-                    additional_error_messages=non_form_error_messages,
+                    extra_non_form_errors=non_form_error_messages,
                 ),
                 "data_not_uploaded_error": data_not_uploaded_error,
                 "dimensions_not_complete_error": dimensions_not_complete_error,

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -539,7 +539,7 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
                 "dimensions_not_complete_error": dimensions_not_complete_error,
             }
 
-            return render_template("cms/edit_measure_version.html", **context)
+            return render_template("cms/edit_measure_version.html", **context), 400
 
     message = page_service.move_measure_version_to_next_state(measure_version, updated_by=current_user.email)
     current_app.logger.info(message)

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -40,7 +40,7 @@
                         {{ form.description(disabled=form_disabled, rows='7',cols='100') }}
 
                     {% endblock fields %}
-                     <button type="submit" class="govuk-button">Save</button>
+                     <button type="submit" class="govuk-button" name="save">Save</button>
                 </form>
             {% endblock %}
         </div>

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -219,7 +219,11 @@
 
      <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h3 class="govuk-heading-m">Dimensions</h3>
+            <div class="govuk-form-group {% if dimensions_not_complete_error %}govuk-form-group--error{% endif %}">
+                <h3 class="govuk-heading-m">Dimensions</h3>
+                {% if dimensions_not_complete_error %}
+                    <span class="govuk-error-message">All dimensions must be complete.</span>
+                {% endif %}
                 {% if measure_version.dimensions %}
                     <table class="govuk-table govuk-!-font-size-16">
                         {% for dimension in measure_version.dimensions %}
@@ -259,13 +263,17 @@
                 {% if new %}
                     <p class="govuk-body">Once this page is saved you will be able to add dimensions</p>
                 {% endif %}
+            </div>
         </div>
     </div>
 
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-
-                    <h3 class="govuk-heading-m">Data</h3>
+                <div class="govuk-form-group {% if data_not_uploaded_error %}govuk-form-group--error{% endif %}">
+                    <h3 class="govuk-heading-m" id="source-data">Data</h3>
+                    {% if data_not_uploaded_error %}
+                        <span class="govuk-error-message">Source data must be uploaded.</span>
+                    {% endif %}
                     {% if measure_version.uploads %}
                         <table class="govuk-table govuk-!-font-size-16">
                             {% for upload in measure_version.uploads %}
@@ -296,7 +304,7 @@
                     {% if new %}
                         <p class="govuk-body">Once this page is saved you will be able to add downloads</p>
                     {% endif %}
-
+                </div>
             </div>
         </div>
 

--- a/tests/application/cms/test_utils.py
+++ b/tests/application/cms/test_utils.py
@@ -50,6 +50,21 @@ class TestGetErrorSummaryDetails:
             "errors": [{"href": "#field-label", "field": "field", "text": "invalid field"}],
         }
 
+    def test_get_error_summary_data_appends_additional_error_messages(self):
+        form = self.FormForTest()
+        form.validate()
+        additional_error_message = {"href": "#other-label", "field": "other-field", "text": "bad field"}
+
+        assert get_error_summary_data(
+            title="Form validation failed", forms=[form], additional_error_messages=[additional_error_message]
+        ) == {
+            "title": "Form validation failed",
+            "errors": [
+                {"href": "#field-label", "field": "field", "text": "invalid field"},
+                {"href": "#other-label", "field": "other-field", "text": "bad field"},
+            ],
+        }
+
     def test_base_template_renders_error_summary(self):
         form = self.FormForTest()
         form.validate()

--- a/tests/application/cms/test_utils.py
+++ b/tests/application/cms/test_utils.py
@@ -6,7 +6,7 @@ from wtforms.validators import DataRequired
 
 from application.cms.forms import DataSourceForm
 from application.form_fields import RDUStringField
-from application.cms.utils import copy_form_errors, get_data_source_forms, get_error_summary_data
+from application.cms.utils import copy_form_errors, get_data_source_forms, get_error_summary_data, ErrorSummaryMessage
 from tests.models import MeasureVersionFactory
 
 
@@ -47,21 +47,21 @@ class TestGetErrorSummaryDetails:
 
         assert get_error_summary_data(title="Form validation failed", forms=[form]) == {
             "title": "Form validation failed",
-            "errors": [{"href": "#field-label", "field": "field", "text": "invalid field"}],
+            "errors": [ErrorSummaryMessage(href="#field-label", field="field", text="invalid field")],
         }
 
-    def test_get_error_summary_data_appends_additional_error_messages(self):
+    def test_get_error_summary_data_appends_extra_non_form_errors(self):
         form = self.FormForTest()
         form.validate()
-        additional_error_message = {"href": "#other-label", "field": "other-field", "text": "bad field"}
+        additional_error_message = ErrorSummaryMessage(href="#other-label", field="other-field", text="bad field")
 
         assert get_error_summary_data(
-            title="Form validation failed", forms=[form], additional_error_messages=[additional_error_message]
+            title="Form validation failed", forms=[form], extra_non_form_errors=[additional_error_message]
         ) == {
             "title": "Form validation failed",
             "errors": [
-                {"href": "#field-label", "field": "field", "text": "invalid field"},
-                {"href": "#other-label", "field": "other-field", "text": "bad field"},
+                ErrorSummaryMessage(href="#field-label", field="field", text="invalid field"),
+                ErrorSummaryMessage(href="#other-label", field="other-field", text="bad field"),
             ],
         }
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -60,8 +60,10 @@ def driver(_driver, request):
     yield _driver
     if prev_failed_tests != request.session.testsfailed:
         filename = str(Path.cwd() / "screenshots" / "{}_{}.png".format(datetime.utcnow(), request.function.__name__))
-        _driver.save_screenshot(str(filename))
-        print("Error screenshot saved to " + filename)
+        if _driver.save_screenshot(str(filename)):
+            print("Screenshot of the error saved to " + filename)
+        else:
+            print("Failed to save screenshot to " + filename)
 
 
 @pytest.fixture(scope="function")

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -88,6 +88,7 @@ class EditMeasureLocators:
 
     PREVIEW_LINK = (By.NAME, "preview")
     ADD_DIMENSION_LINK = (By.LINK_TEXT, "Add dimension")
+    ADD_SOURCE_DATA_LINK = (By.LINK_TEXT, "Add source data")
 
     PUBLISHED_AT_DATE_PICKER = (By.NAME, "published_at")
     PUBLISHED_LABEL = (By.NAME, "published")
@@ -142,6 +143,13 @@ class DimensionPageLocators:
     UPDATE_BUTTON = (By.NAME, "update")
     CREATE_CHART = (By.ID, "create_chart")
     CREATE_TABLE = (By.ID, "create_table")
+
+
+class SourceDataPageLocators:
+    FILE_UPLOAD_INPUT = (By.NAME, "upload")
+    TITLE_INPUT = (By.NAME, "title")
+    DESCRIPTION_TEXTAREA = (By.NAME, "description")
+    SAVE_BUTTON = (By.NAME, "save")
 
 
 class ChartBuilderPageLocators:

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -1,3 +1,4 @@
+import os
 import random
 import time
 
@@ -27,6 +28,7 @@ from tests.functional.locators import (
     ChartBuilderPageLocators,
     TableBuilderPageLocators,
     TopicPageLocators,
+    SourceDataPageLocators,
 )
 
 
@@ -408,6 +410,11 @@ class MeasureEditPage(BasePage):
         self.scroll_to(element)
         element.click()
 
+    def click_add_source_data(self):
+        element = self.wait_for_invisible_element(EditMeasureLocators.ADD_SOURCE_DATA_LINK)
+        self.scroll_to(element)
+        element.click()
+
     def click_preview(self):
         element = self.wait_for_element(EditMeasureLocators.PREVIEW_LINK)
         self.scroll_and_click(element)
@@ -653,6 +660,36 @@ class DimensionEditPage(BasePage):
         element = self.wait_for_element(DimensionPageLocators.SUMMARY_TEXTAREA)
         element.clear()
         element.send_keys(summary)
+
+
+class AddSourceDataPage(BasePage):
+    def __init__(self, driver):
+        super().__init__(driver=driver, base_url=driver.current_url)
+
+    def set_title(self, title):
+        element = self.wait_for_element(SourceDataPageLocators.TITLE_INPUT)
+        element.clear()
+        element.send_keys(title)
+
+    def set_description(self, value):
+        element = self.wait_for_element(SourceDataPageLocators.DESCRIPTION_TEXTAREA)
+        element.clear()
+        element.send_keys(value)
+
+    def set_upload_file(self):
+        element = self.wait_for_element(SourceDataPageLocators.FILE_UPLOAD_INPUT)
+        element.clear()
+        file_abs_path = os.path.abspath("./tests/test_data/csv_with_no_quotes.csv")
+        element.send_keys(file_abs_path)
+
+    def click_save(self):
+        element = self.wait_for_element(SourceDataPageLocators.SAVE_BUTTON)
+        self.scroll_and_click(element)
+
+    def fill_source_data_page(self, upload):
+        self.set_upload_file()
+        self.set_title(upload.title)
+        self.set_description(upload.description)
 
 
 class MeasurePreviewPage(BasePage):

--- a/tests/functional/test_cms_measure_lifecycle.py
+++ b/tests/functional/test_cms_measure_lifecycle.py
@@ -10,7 +10,7 @@ from tests.functional.utils import (
     driver_login,
 )
 from tests.models import UserFactory, MeasureVersionFactory, DataSourceFactory
-from tests.functional.pages import MeasureCreateVersionPage
+from tests.functional.pages import MeasureCreateVersionPage, AddSourceDataPage
 
 """
 
@@ -140,13 +140,21 @@ def test_create_a_measure_as_editor(driver, live_server, government_departments,
     # THEN we get validation errors (edit summary)
     assert "Cannot submit for review" in driver.page_source
 
-    # WHEN we provide an edit summary and approve the major edit
+    # WHEN we add an upload file
+    measure_edit_page.click_add_source_data()
+    add_source_data_page = AddSourceDataPage(driver)
+    add_source_data_page.fill_source_data_page(sample_measure_version.uploads[0])
+    add_source_data_page.click_save()
+
+    # AND provide an edit summary
     measure_edit_page.fill_measure_page_major_edit_fields(sample_measure_version)
+
+    # AND approve the major edit
     measure_edit_page.click_save_and_send_to_review()
     measure_edit_page.click_department_review()
     measure_edit_page.click_approved()
 
-    # AND the status should be published
+    # THEN the status should be published
     assert measure_edit_page.get_status() == EXPECTED_STATUSES["published"]
 
     measure_edit_page.log_out()

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -2,7 +2,7 @@ from random import shuffle
 
 import selenium
 
-from tests.functional.pages import HomePage, LogInPage, MeasureCreatePage, MeasureEditPage, TopicPage
+from tests.functional.pages import HomePage, LogInPage, MeasureCreatePage, MeasureEditPage, TopicPage, AddSourceDataPage
 from tests.utils import get_page_with_title
 
 EXPECTED_STATUSES = {
@@ -61,7 +61,14 @@ def create_measure_starting_at_topic_page(
     measure_edit_page.fill_measure_page(sample_measure_version, sample_data_source)
     measure_edit_page.click_save()
     """
-    CREATE v1 5: Now it has been added we ought to have a generated GUID which we will need so
+    CREATE v1 5: Upload a source data file
+    """
+    measure_edit_page.click_add_source_data()
+    add_source_data_page = AddSourceDataPage(driver)
+    add_source_data_page.fill_source_data_page(sample_measure_version.uploads[0])
+    add_source_data_page.click_save()
+    """
+    CREATE v1 6: Now it has been added we ought to have a generated GUID which we will need so
     we may have to retrieve the page again
     """
     created_measure_version = get_page_with_title(sample_measure_version.title)

--- a/tests/models.py
+++ b/tests/models.py
@@ -298,7 +298,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     @factory.post_generation
     def uploads(self, create, extracted, **kwargs):
         # If some uploads were passed into the create invocation: eg factory.create(uploads=[upload1, upload2])
-        if extracted:
+        if extracted is not None:
             # Attach those uploads to this newly-created instance.
             for upload in extracted:
                 self.uploads.append(upload)
@@ -310,7 +310,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     @factory.post_generation
     def data_sources(self, create, extracted, **kwargs):
         # If some uploads were passed into the create invocation: eg factory.create(data_sources=[data_source1])
-        if extracted:
+        if extracted is not None:
             # Attach those uploads to this newly-created instance.
             for data_source in extracted:
                 self.data_sources.append(data_source)


### PR DESCRIPTION
For this ticket: https://trello.com/c/uzQKcGIe/1424-data-file-should-be-mandatory-for-sending-to-review-1

As the presence of an Upload belonging to the measure version can't be detected as part of form validation we need to add a check for the existence of an upload in `_send_to_review()` and add an error message if there isn't one there.

In doing this I noticed that errors to do with incomplete dimensions are currently being reported in a separate green flash message rather than in the main validation error message, which seems weird.  So I've now consolidated all error messages into the main red validation banner - see screenshots below.

Making the upload compulsory broke several functional tests which published measure versions without any uploads.  I've added a step to the measure lifecycle functional tests to upload a file when necessary.

# BEFORE

![Screenshot from 2019-03-27 16-26-35](https://user-images.githubusercontent.com/6525554/55093891-34fbeb00-50ad-11e9-9b1d-7a294fb8bf94.png)

# AFTER

![Screenshot from 2019-03-27 12-11-01](https://user-images.githubusercontent.com/6525554/55093923-43e29d80-50ad-11e9-8618-d21720fea5d9.png)

# NEW RED STUFF!

![Screenshot from 2019-03-27 12-11-11](https://user-images.githubusercontent.com/6525554/55093951-4e9d3280-50ad-11e9-8a16-f4699fe594cd.png)
