### PR TITLE
Return "remove secondary source" button

### DIFF
--- a/application/src/js/all/_secondary_sources.js
+++ b/application/src/js/all/_secondary_sources.js
@@ -51,18 +51,22 @@ function SecondarySource(fieldset, secondary_sources) {
       }
     };
 
-    that.add_secondary_source_button = document.createElement('button')
+    that.add_secondary_source_button = document.createElement('a')
     that.add_secondary_source_button.classList.add('govuk-link')
+    that.add_secondary_source_button.classList.add('eff-link__secondary-source')
     that.add_secondary_source_button.classList.add('hidden')
+    that.add_secondary_source_button.href = '#'
     that.add_secondary_source_button.textContent = 'Add secondary source'
     that.add_secondary_source_button.addEventListener('click', that.addSourceButtonClicked.bind(that))
     var parent = that.fieldset.parentElement
     parent.insertBefore(that.add_secondary_source_button, that.fieldset)
 
 
-    var remove_secondary_source_button = document.createElement('button')
-    remove_secondary_source_button.classList.add('delete')
-    remove_secondary_source_button.classList.add('govuk-link link')
+    var remove_secondary_source_button = document.createElement('a')
+    remove_secondary_source_button.classList.add('govuk-link')
+    remove_secondary_source_button.classList.add('eff-link__secondary-source')
+    remove_secondary_source_button.classList.add('eff-link__secondary-source--delete')
+    remove_secondary_source_button.href = '#'
     remove_secondary_source_button.textContent = 'Remove source'
     remove_secondary_source_button.addEventListener('click', that.removeSourceButtonClicked.bind(that))
 

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -16,6 +16,7 @@ $govuk-assets-path: '/static/assets/';
 @import 'components/header_search_box';
 @import 'components/hero';
 @import 'components/line_chart';
+@import 'components/link';
 @import 'components/list';
 @import 'components/metadata';
 @import 'components/missing_data_explanation';

--- a/application/src/sass/components/_link.scss
+++ b/application/src/sass/components/_link.scss
@@ -1,0 +1,14 @@
+.eff-link__secondary-source {
+  @include govuk-font(19);
+  @include govuk-responsive-margin(3, $direction: "bottom");
+
+  display: block;
+}
+
+.eff-link__secondary-source--delete {
+  color: govuk-colour("red");
+
+  &:link, &:visited {
+    color: govuk-colour("red");
+  }
+}

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -61,19 +61,19 @@ class EditMeasureLocators:
         return (By.ID, "lowest_level_of_geography_id-%s" % str(index_value))
 
     @staticmethod
-    def frequency_radio_button(index_value):
+    def frequency_radio_button(index_value, data_source_index=1):
         # index_value should be in the range 0 to 11 - (as per `frequency_of_release` table per 2018-11-19)
-        return (By.ID, "data-source-1-frequency_of_release_id-%s" % str(index_value))
+        return (By.ID, "data-source-%s-frequency_of_release_id-%s" % (data_source_index, str(index_value)))
 
     @staticmethod
-    def type_of_data_checkbox(index_value):
+    def type_of_data_checkbox(index_value, data_source_index=1):
         # index_value should be in the range 0 to 1 - (as per application.cms.models.TypeOfData per 2018-11-19)
-        return (By.ID, "data-source-1-type_of_data-%s" % str(index_value))
+        return (By.ID, "data-source-%s-type_of_data-%s" % (data_source_index, str(index_value)))
 
     @staticmethod
-    def type_of_statistic_radio_button(index_value):
+    def type_of_statistic_radio_button(index_value, data_source_index=1):
         # index_value should be in the range 0 to 4 - (as per `type_of_statistic` table per 2018-11-19)
-        return (By.ID, "data-source-1-type_of_statistic_id-%s" % str(index_value))
+        return (By.ID, "data-source-%s-type_of_statistic_id-%s" % (data_source_index, str(index_value)))
 
     STATUS_LABEL = (By.ID, "status")
     LOWEST_LEVEL_OF_GEOGRAPHY_RADIO = (By.XPATH, "//*[@type='radio']")
@@ -103,13 +103,19 @@ class EditMeasureLocators:
     NEED_TO_KNOW_TEXTAREA = (By.NAME, "need_to_know")
     ETHNICITY_DEFINITION_DETAIL_TEXTAREA = (By.NAME, "ethnicity_definition_detail")
     ETHNICITY_SUMMARY_DETAIL_TEXTAREA = (By.NAME, "ethnicity_definition_summary")
-    DATA_SOURCE_TITLE_TEXTAREA = (By.NAME, "data-source-1-title")
-    DATA_SOURCE_SOURCE_URL_INPUT = (By.NAME, "data-source-1-source_url")
-    DATA_SOURCE_PUBLISHER_ID_INPUT = (By.ID, "data-source-1-publisher_id")
-    DATA_SOURCE_PUBLICATION_DATE_INPUT = (By.NAME, "data-source-1-publication_date")
-    FREQUENCY_INPUT = (By.NAME, "data-source-1-frequency_of_release_id")
+    DATA_SOURCE_1_TITLE_TEXTAREA = (By.NAME, "data-source-1-title")
+    DATA_SOURCE_1_SOURCE_URL_INPUT = (By.NAME, "data-source-1-source_url")
+    DATA_SOURCE_1_PUBLISHER_ID_INPUT = (By.ID, "data-source-1-publisher_id")
+    DATA_SOURCE_1_PUBLICATION_DATE_INPUT = (By.NAME, "data-source-1-publication_date")
+    DATA_SOURCE_1_FREQUENCY_INPUT = (By.NAME, "data-source-1-frequency_of_release_id")
+    DATA_SOURCE_1_PURPOSE_TEXTAREA = (By.NAME, "data-source-1-purpose")
+    DATA_SOURCE_2_TITLE_TEXTAREA = (By.NAME, "data-source-2-title")
+    DATA_SOURCE_2_SOURCE_URL_INPUT = (By.NAME, "data-source-2-source_url")
+    DATA_SOURCE_2_PUBLISHER_ID_INPUT = (By.ID, "data-source-2-publisher_id")
+    DATA_SOURCE_2_PUBLICATION_DATE_INPUT = (By.NAME, "data-source-2-publication_date")
+    DATA_SOURCE_2_FREQUENCY_INPUT = (By.NAME, "data-source-2-frequency_of_release_id")
+    DATA_SOURCE_2_PURPOSE_TEXTAREA = (By.NAME, "data-source-2-purpose")
     RELATED_PUBLICATIONS_TEXTAREA = (By.NAME, "related_publications")
-    DATA_SOURCE_PURPOSE_TEXTAREA = (By.NAME, "data-source-1-purpose")
     METHODOLOGY_TEXTAREA = (By.NAME, "methodology")
     DATA_TYPE_INPUT = (By.NAME, "data_type")
     SUPPRESSION_RULES_TEXTAREA = (By.NAME, "suppression_rules")

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -471,16 +471,16 @@ class MeasureEditPage(BasePage):
         self.select_checkbox_or_radio(element)
 
     def set_primary_title(self, value):
-        self.set_text_field(EditMeasureLocators.DATA_SOURCE_TITLE_TEXTAREA, value)
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_1_TITLE_TEXTAREA, value)
 
     def set_description(self, value):
         self.set_text_field(EditMeasureLocators.DESCRIPTION_TEXTAREA, value)
 
     def set_primary_publisher(self, value):
-        self.set_auto_complete_field(EditMeasureLocators.DATA_SOURCE_PUBLISHER_ID_INPUT, value)
+        self.set_auto_complete_field(EditMeasureLocators.DATA_SOURCE_1_PUBLISHER_ID_INPUT, value)
 
     def set_primary_url(self, value):
-        self.set_text_field(EditMeasureLocators.DATA_SOURCE_SOURCE_URL_INPUT, value)
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_1_SOURCE_URL_INPUT, value)
 
     def set_last_update(self, value):
         self.set_text_field(EditMeasureLocators.LAST_UPDATE_INPUT, value)
@@ -504,13 +504,40 @@ class MeasureEditPage(BasePage):
         element = self.driver.find_element(locator[0], locator[1])
         self.select_checkbox_or_radio(element)
 
-    def set_primary_source_type_of_data(self, data_id):
+    def set_primary_source_type_of_data(self):
         locator = EditMeasureLocators.type_of_data_checkbox(0)
         element = self.driver.find_element(locator[0], locator[1])
         self.select_checkbox_or_radio(element)
 
-    def set_purpose(self, value):
-        self.set_text_field(EditMeasureLocators.DATA_SOURCE_PURPOSE_TEXTAREA, value)
+    def set_primary_data_source_purpose(self, value):
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_1_PURPOSE_TEXTAREA, value)
+
+    def set_secondary_title(self, value):
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_2_TITLE_TEXTAREA, value)
+
+    def set_secondary_publisher(self, value):
+        self.set_auto_complete_field(EditMeasureLocators.DATA_SOURCE_2_PUBLISHER_ID_INPUT, value)
+
+    def set_secondary_url(self, value):
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_2_SOURCE_URL_INPUT, value)
+
+    def set_secondary_data_source_purpose(self, value):
+        self.set_text_field(EditMeasureLocators.DATA_SOURCE_2_PURPOSE_TEXTAREA, value)
+
+    def set_secondary_frequency(self):
+        locator = EditMeasureLocators.frequency_radio_button(0, data_source_index=2)
+        element = self.driver.find_element(locator[0], locator[1])
+        self.scroll_and_click(element)
+
+    def set_secondary_type_of_statistic(self):
+        locator = EditMeasureLocators.type_of_statistic_radio_button(0, data_source_index=2)
+        element = self.driver.find_element(locator[0], locator[1])
+        self.select_checkbox_or_radio(element)
+
+    def set_secondary_source_type_of_data(self):
+        locator = EditMeasureLocators.type_of_data_checkbox(0, data_source_index=2)
+        element = self.driver.find_element(locator[0], locator[1])
+        self.select_checkbox_or_radio(element)
 
     def set_methodology(self, value):
         self.set_text_field(EditMeasureLocators.METHODOLOGY_TEXTAREA, value)
@@ -538,9 +565,18 @@ class MeasureEditPage(BasePage):
         self.set_things_you_need_to_know(measure_version.need_to_know)
         self.set_what_the_data_measures(measure_version.measure_summary)
         self.set_ethnicity_categories(measure_version.ethnicity_definition_summary)
-        self.set_purpose(data_source.purpose)
-        self.set_primary_source_type_of_data(0)
+        self.set_primary_data_source_purpose(data_source.purpose)
+        self.set_primary_source_type_of_data()
         self.set_methodology(measure_version.methodology)
+
+    def fill_secondary_data_source(self, data_source):
+        self.set_secondary_title(value=data_source.title)
+        self.set_secondary_publisher(value=f"{data_source.publisher.name}\n")
+        self.set_secondary_url(value=data_source.source_url)
+        self.set_secondary_frequency()
+        self.set_secondary_type_of_statistic()
+        self.set_secondary_data_source_purpose(data_source.purpose)
+        self.set_secondary_source_type_of_data()
 
     def fill_measure_page_minor_edit_fields(self, measure_version):
         self.set_update_corrects_data_mistake(measure_version.update_corrects_data_mistake)

--- a/tests/functional/test_secondary_sources.py
+++ b/tests/functional/test_secondary_sources.py
@@ -1,0 +1,49 @@
+import random
+
+from application.auth.models import TypeOfUser
+
+from tests.functional.utils import create_measure_starting_at_topic_page, navigate_to_topic_page, driver_login
+from tests.models import UserFactory, MeasureVersionFactory, DataSourceFactory
+
+
+def test_secondary_source_can_be_added_and_removed(driver, live_server, government_departments, frequencies_of_release):
+    rdu_user = UserFactory(user_type=TypeOfUser.RDU_USER, active=True)
+    approved_measure_version = MeasureVersionFactory(
+        status="APPROVED",
+        data_sources__publisher=random.choice(government_departments),
+        data_sources__frequency_of_release=random.choice(frequencies_of_release),
+    )
+    sample_measure_version = MeasureVersionFactory.build(data_sources=[])
+    sample_data_source = DataSourceFactory.build(
+        publisher__name=random.choice(government_departments).name,
+        frequency_of_release__description=random.choice(frequencies_of_release).description,
+    )
+
+    # GIVEN a setup with Topic and Subtopic
+    driver_login(driver, live_server, rdu_user)
+    navigate_to_topic_page(driver, live_server, approved_measure_version.measure.subtopic.topic)
+
+    # WHEN an editor creates and saves a new measure page
+    measure_edit_page, page = create_measure_starting_at_topic_page(
+        driver,
+        live_server,
+        approved_measure_version.measure.subtopic.topic,
+        approved_measure_version.measure.subtopic,
+        sample_measure_version,
+        sample_data_source,
+    )
+
+    # Add and save a secondary data source
+    add_secondary_source = driver.find_element_by_link_text("Add secondary source")
+    measure_edit_page.scroll_and_click(add_secondary_source)
+    measure_edit_page.fill_secondary_data_source(sample_data_source)
+    measure_edit_page.click_save()
+
+    # Remove the secondary source
+    remove_secondary_source = driver.find_element_by_link_text("Remove source")
+    measure_edit_page.scroll_and_click(remove_secondary_source)
+    measure_edit_page.click_save()
+
+    # Check that you can re-add a secondary source
+    add_secondary_source = driver.find_element_by_link_text("Add secondary source")
+    assert add_secondary_source


### PR DESCRIPTION
The javascript controlling the 'remove source' button broke due to
trying to add two classes simultaneously via a method that is designed
to add classes one at a time.

After fixing this, the styling on the button was visibly broken, and
`govuk-link` isn't made to override the default button styling, so the
element is now just a link (hooked into a JS function).

A functional test has been added to validate that you can
add/edit/delete secondary sources.

 ## Ticket
https://trello.com/c/9fo6P53K