### PR TITLE
Hide chart footers when there is no Javascript

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -260,7 +260,7 @@
               </div>
             </div>
 
-              <div class="chart-and-footer">
+              <div class="chart-and-footer hidden">
                 <div class="govuk-grid-row">
                   <div class="rd_chart" id="chart_{{ dimension_dict.guid }}" style="clear: both; overflow: hidden"></div>
                 </div>
@@ -712,6 +712,10 @@
       }
     };
 
+    var chart_divs = document.getElementsByClassName('chart-and-footer');
+    for (var i=0, chart_div; chart_div = chart_divs[i]; i++) {
+        chart_div.classList.remove('hidden');
+    };
 
     $('.download-png').click(function(evt){
         var dimensionGuid = $(evt.currentTarget).attr('id').replace('download-', ''),


### PR DESCRIPTION
For this ticket: https://trello.com/c/i2b0muiK/1423-hide-entire-chart-div-if-js-is-not-enabled-1

Charts don't display without Javascript, but the chart footers currently
do.

This adds a hidden class to the divs enclosing the chart and footer that is removed by Javascript
when the page loads, if Javascript is enabled in the browser.