### PR TITLE
Rationalise dimension interface

### DIFF
--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -58,3 +58,9 @@ def yesno(state):
         return "no"
 
     return state
+
+
+def models_to_dicts(items):
+    """Call `.to_dict()` on each item of a list; useful for converting a list of model instances into a list of
+    dictionaries suitable for e.g. converting to JSON."""
+    return [item.to_dict() for item in items]

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -21,6 +21,7 @@ from application.cms.exceptions import (
     UploadNotFoundException,
 )
 from application.utils import get_token_age, create_guid
+from application.utils import cleanup_filename
 
 publish_status = bidict(
     REJECTED=0, DRAFT=1, INTERNAL_REVIEW=2, DEPARTMENT_REVIEW=3, APPROVED=4, UNPUBLISH=5, UNPUBLISHED=6
@@ -616,6 +617,24 @@ class Dimension(db.Model):
         else:
             return "Manually selected"
 
+    @property
+    def static_file_name(self):
+        if self.title:
+            filename = "%s.csv" % cleanup_filename(self.title)
+        else:
+            filename = "%s.csv" % self.guid
+
+        return filename
+
+    @property
+    def static_table_file_name(self):
+        if self.title:
+            table_filename = "%s-table.csv" % cleanup_filename(self.title)
+        else:
+            table_filename = "%s-table.csv" % self.guid
+
+        return table_filename
+
     def set_updated_at(self):
         """
         This updates the model’s updated_at timestamp to the current time, using the
@@ -679,17 +698,15 @@ class Dimension(db.Model):
         return {
             "guid": self.guid,
             "title": self.title,
-            "measure": self.measure_version.measure.id,
             "time_period": self.time_period,
             "summary": self.summary,
-            "chart": self.dimension_chart.chart_object if self.dimension_chart else None,
-            "chart_settings_and_source_data": self.dimension_chart.settings_and_source_data
-            if self.dimension_chart
-            else None,
-            "table": self.dimension_table.table_object if self.dimension_table else None,
-            "table_settings_and_source_data": self.dimension_table.settings_and_source_data
-            if self.dimension_table
-            else None,
+            "position": self.position,
+            "measure_id": self.measure_version.measure.id,
+            "measure_version_id": self.measure_version.id,
+            "dimension_chart": self.dimension_chart.to_dict() if self.dimension_chart else None,
+            "dimension_table": self.dimension_table.to_dict() if self.dimension_table else None,
+            "static_file_name": self.static_file_name,
+            "static_table_file_name": self.static_table_file_name,
         }
 
     def copy(self):
@@ -892,6 +909,15 @@ class ChartAndTableMixin(object):
             f"includes_unknown:{self.includes_unknown}"
         )
 
+    def to_dict(self):
+        return {
+            "classification_id": self.classification_id,
+            "includes_parents": self.includes_parents,
+            "includes_all": self.includes_all,
+            "includes_unknown": self.includes_unknown,
+            "settings_and_source_data": self.settings_and_source_data,
+        }
+
 
 class Chart(db.Model, ChartAndTableMixin):
     # metadata
@@ -903,6 +929,9 @@ class Chart(db.Model, ChartAndTableMixin):
     # relationships
     dimension = db.relationship("Dimension", back_populates="dimension_chart", uselist=False)
 
+    def to_dict(self):
+        return {**super().to_dict(), "chart_object": self.chart_object}
+
 
 class Table(db.Model, ChartAndTableMixin):
     # metadata
@@ -913,6 +942,9 @@ class Table(db.Model, ChartAndTableMixin):
 
     # relationships
     dimension = db.relationship("Dimension", back_populates="dimension_table", uselist=False)
+
+    def to_dict(self):
+        return {**super().to_dict(), "table_object": self.table_object}
 
 
 class Organisation(db.Model):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -747,7 +747,7 @@ def _get_edit_dimension(topic_slug, subtopic_slug, measure_slug, dimension_guid,
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_chart(topic_slug, subtopic_slug, measure_slug, version, dimension_guid):
-    topic, subtopic, measure, measure_version, dimension_object = page_service.get_measure_version_hierarchy(
+    topic, subtopic, measure, measure_version, dimension = page_service.get_measure_version_hierarchy(
         topic_slug, subtopic_slug, measure_slug, version, dimension_guid=dimension_guid
     )
 
@@ -757,7 +757,7 @@ def create_chart(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         subtopic=subtopic,
         measure=measure,
         measure_version=measure_version,
-        dimension_dict=dimension_object.to_dict(),
+        dimension=dimension,
     )
 
 
@@ -772,7 +772,7 @@ def __get_classification_finder_classifications():
 @user_has_access
 @user_can(UPDATE_MEASURE)
 def create_table(topic_slug, subtopic_slug, measure_slug, version, dimension_guid):
-    topic, subtopic, measure, measure_version, dimension_object = page_service.get_measure_version_hierarchy(
+    topic, subtopic, measure, measure_version, dimension = page_service.get_measure_version_hierarchy(
         topic_slug, subtopic_slug, measure_slug, version, dimension_guid=dimension_guid
     )
 
@@ -782,7 +782,7 @@ def create_table(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         subtopic=subtopic,
         measure=measure,
         measure_version=measure_version,
-        dimension_dict=dimension_object.to_dict(),
+        dimension=dimension,
     )
 
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -26,6 +26,7 @@ from application.cms.filters import (
     format_status,
     index_of_last_initial_zero,
     yesno,
+    models_to_dicts,
 )
 from application.cms.dimension_service import dimension_service
 from application.cms.models import TESTING_SPACE_SLUG
@@ -141,6 +142,7 @@ def create_app(config_object):
     app.add_template_filter(format_iso8601_date)
     app.add_template_filter(index_of_last_initial_zero)
     app.add_template_filter(yesno)
+    app.add_template_filter(models_to_dicts)
 
     # There is a CSS caching problem in chrome
     app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 10

--- a/application/review/views.py
+++ b/application/review/views.py
@@ -25,14 +25,11 @@ def review_page(review_token):
         if measure_version.status not in ["DEPARTMENT_REVIEW", "APPROVED"]:
             return render_template("static_site/not_ready_for_review.html", preview=True)
 
-        dimensions = [dimension.to_dict() for dimension in measure_version.dimensions]
-
         return render_template(
             "static_site/measure.html",
             topic_slug=measure_version.measure.subtopic.topic.slug,
             subtopic_slug=measure_version.measure.subtopic.slug,
             measure_version=measure_version,
-            dimensions=dimensions,
             versions=measure_version.previous_major_versions,
             first_published_date=measure_version.first_published_date,
             edit_history=measure_version.previous_minor_versions,

--- a/application/review/views.py
+++ b/application/review/views.py
@@ -30,9 +30,6 @@ def review_page(review_token):
             topic_slug=measure_version.measure.subtopic.topic.slug,
             subtopic_slug=measure_version.measure.subtopic.slug,
             measure_version=measure_version,
-            versions=measure_version.previous_major_versions,
-            first_published_date=measure_version.first_published_date,
-            edit_history=measure_version.previous_minor_versions,
             preview=True,
         )
 

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import glob
+
 import os
 import shutil
 import subprocess
@@ -8,7 +9,6 @@ from uuid import uuid4
 
 from flask import current_app, render_template
 from git import Repo
-from slugify import slugify
 
 from application.cms.upload_service import upload_service
 from application.data.dimensions import DimensionObjectBuilder
@@ -176,13 +176,13 @@ def write_measure_versions(measure, build_dir, local_build=False):
         )
         os.makedirs(slug, exist_ok=True)
 
-        dimensions = process_dimensions(measure_version, slug)
+        process_dimensions(measure_version, slug)
+
         content = render_template(
             "static_site/measure.html",
             topic_slug=measure.subtopic.topic.slug,
             subtopic_slug=measure.subtopic.slug,
             measure_version=measure_version,
-            dimensions=dimensions,
             versions=measure_version.previous_major_versions,
             first_published_date=measure_version.first_published_date,
             edit_history=measure_version.previous_minor_versions,
@@ -215,14 +215,10 @@ def write_measure_version_downloads(measure_version, slug):
 
 
 def process_dimensions(measure_version, slug):
-
     if measure_version.dimensions:
         download_dir = os.path.join(slug, "downloads")
         os.makedirs(download_dir, exist_ok=True)
-    else:
-        return
 
-    dimensions = []
     for dimension in measure_version.dimensions:
 
         if (
@@ -236,36 +232,21 @@ def process_dimensions(measure_version, slug):
         dimension_obj = DimensionObjectBuilder.build(dimension)
         output = write_dimension_csv(dimension=dimension_obj)
 
-        if dimension.title:
-            filename = "%s.csv" % cleanup_filename(dimension.title)
-            table_filename = "%s-table.csv" % cleanup_filename(dimension.title)
-        else:
-            filename = "%s.csv" % dimension.guid
-            table_filename = "%s-table.csv" % dimension.guid
-
         try:
-            file_path = os.path.join(download_dir, filename)
+            file_path = os.path.join(download_dir, dimension.static_file_name)
             with open(file_path, "w") as dimension_file:
                 dimension_file.write(output)
+
         except Exception as e:
             print(f"Could not write file path {file_path}")
             print(e)
 
-        d_as_dict = dimension.to_dict()
-        d_as_dict["static_file_name"] = filename
-
         if dimension.dimension_table and dimension.dimension_table.table_object:
             table_output = write_dimension_tabular_csv(dimension=dimension_obj)
 
-            table_file_path = os.path.join(download_dir, table_filename)
+            table_file_path = os.path.join(download_dir, dimension.static_table_file_name)
             with open(table_file_path, "w") as dimension_file:
                 dimension_file.write(table_output)
-
-            d_as_dict["static_table_file_name"] = table_filename
-
-        dimensions.append(d_as_dict)
-
-    return dimensions
 
 
 def unpublish_pages(build_dir):
@@ -507,10 +488,6 @@ def create_versioned_assets(build_dir):
 def write_html(file_path, content):
     with open(file_path, "w") as out_file:
         out_file.write(content)
-
-
-def cleanup_filename(filename):
-    return slugify(filename)
 
 
 def get_static_dir():

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -183,9 +183,6 @@ def write_measure_versions(measure, build_dir, local_build=False):
             topic_slug=measure.subtopic.topic.slug,
             subtopic_slug=measure.subtopic.slug,
             measure_version=measure_version,
-            versions=measure_version.previous_major_versions,
-            first_published_date=measure_version.first_published_date,
-            edit_history=measure_version.previous_minor_versions,
         )
 
         file_path = os.path.join(slug, "index.html")

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -6,7 +6,6 @@ from flask import render_template, abort, make_response, send_file, request
 
 from flask_security import current_user
 from flask_security import login_required
-from slugify import slugify
 
 from application.data.dimensions import DimensionObjectBuilder
 from application.cms.exceptions import PageNotFoundException, DimensionNotFoundException, UploadNotFoundException
@@ -20,6 +19,7 @@ from application.utils import (
     write_dimension_tabular_csv,
     user_has_access,
 )
+from application.utils import cleanup_filename
 
 
 @static_site_blueprint.route("")
@@ -159,7 +159,6 @@ def measure_version(topic_slug, subtopic_slug, measure_slug, version):
         topic_slug=topic_slug,
         subtopic_slug=subtopic_slug,
         measure_version=measure_version,
-        dimensions=[dimension.to_dict() for dimension in measure_version.dimensions],
         versions=measure_version.previous_major_versions,
         first_published_date=measure_version.first_published_date,
         edit_history=measure_version.previous_minor_versions,
@@ -241,10 +240,6 @@ def dimension_file_table_download(topic_slug, subtopic_slug, measure_slug, versi
 
     except DimensionNotFoundException:
         abort(404)
-
-
-def cleanup_filename(filename):
-    return slugify(filename)
 
 
 @static_site_blueprint.route("/search")

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -159,9 +159,6 @@ def measure_version(topic_slug, subtopic_slug, measure_slug, version):
         topic_slug=topic_slug,
         subtopic_slug=subtopic_slug,
         measure_version=measure_version,
-        versions=measure_version.previous_major_versions,
-        first_published_date=measure_version.first_published_date,
-        edit_history=measure_version.previous_minor_versions,
         static_mode=get_bool(request.args.get("static_mode", False)),
     )
 

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -2,11 +2,12 @@
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 
 {% set form_disabled = measure_version.status != 'DRAFT' %}
+{% set settings_and_source_data = (dimension.dimension_chart.settings_and_source_data if dimension.dimension_chart else {}) %}
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
     {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title},
-    {"url": url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension_dict.guid), "text": dimension_dict.title},
+    {"url": url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -15,27 +16,22 @@
 {% block headEnd %}
   {{ super() }}
   <script>
-    {% if dimension_dict.chart_settings_and_source_data %}
-    var settings = {{ dimension_dict.chart_settings_and_source_data|tojson|safe }};
-    {% else %}
-    var settings = {};
-    {% endif %}
-
+    var settings = {{ settings_and_source_data | tojson | safe }};
     var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension_dict.guid ) }}";
+    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}";
   </script>
 {% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row eff-numbered-sections">
         <div class="govuk-grid-column-full">
-            <h1 id="builder-title" class="govuk-heading-l">{% if dimension_dict.chart_settings_and_source_data %}Format and view{% else %}Create a{% endif %} chart</h1>
+            <h1 id="builder-title" class="govuk-heading-l">{% if settings_and_source_data %}Format and view{% else %}Create a{% endif %} chart</h1>
         </div>
         {#
         DATA ENTRY PANEL
         This panel appears on create or when editing data
 #}
-        <div id="data-panel" class="data-panel {% if dimension_dict.chart_settings_and_source_data %}hidden{% endif %}">
+        <div id="data-panel" class="data-panel {% if settings_and_source_data %}hidden{% endif %}">
             <div class="govuk-grid-column-full">
                 <h2 class="govuk-heading-m no-top-border eff-numbered-sections__item">Data</h2>
 
@@ -60,7 +56,7 @@
             </div>
         </div>
 
-        <div id="edit-panel" class="edit-panel {% if not dimension_dict.chart_settings_and_source_data %}hidden{% endif %}">
+        <div id="edit-panel" class="edit-panel {% if not settings_and_source_data %}hidden{% endif %}">
             <div class="govuk-grid-column-one-third">
                 {#
                     DATA DISPLAY
@@ -405,7 +401,7 @@
                       <span class="govuk-hint">For example, ‘Percentage of households who own their home by ethnicity and socio-economic group’</span>
                       {% include 'forms/extended_hints/_chart_and_table_title.html' %}
                         <textarea id="chart_title" class="govuk-textarea" rows="2" data-module="autoresize no-newlines"
-                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if dimension_dict.chart_settings_and_source_data %}{{ dimension_dict.chart_settings_and_source_data.chartFormat.chart_title }}{% endif %}</textarea>
+                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if settings_and_source_data %}{{ settings_and_source_data.chartFormat.chart_title }}{% endif %}</textarea>
                     </div>
 
                     <h2 class="govuk-heading-m eff-numbered-sections__item">Preview</h2>

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -2,11 +2,12 @@
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 
 {% set form_disabled = measure_version.status != 'DRAFT' %}
+{% set settings_and_source_data = (dimension.dimension_table.settings_and_source_data if dimension.dimension_table else {}) %}
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
     {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title},
-    {"url": url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension_dict.guid), "text": dimension_dict.title},
+    {"url": url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -15,27 +16,23 @@
 {% block headEnd %}
   {{ super() }}
   <script>
-    {% if dimension_dict.table_settings_and_source_data %}
-    var settings = {{ dimension_dict.table_settings_and_source_data|tojson|safe }};
-    {% else %}
-    var settings = {};
-    {% endif %}
+    var settings = {{ settings_and_source_data | tojson | safe }};
     var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-    var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension_dict.guid ) }}";
+    var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}";
   </script>
 {% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row eff-numbered-sections">
         <div class="govuk-grid-column-full">
-            <h1 id="builder-title" class="govuk-heading-l">{% if dimension_dict.table_settings_and_source_data %}Format and view{% else %}Create a{% endif %} table</h1>
+            <h1 id="builder-title" class="govuk-heading-l">{% if settings_and_source_data %}Format and view{% else %}Create a{% endif %} table</h1>
         </div>
 
         {#
           DATA ENTRY PANEL
           This panel appears on create or when editing data
         #}
-        <div id="data-panel" class="data-panel {% if dimension_dict.table_settings_and_source_data %}hidden{% endif %}">
+        <div id="data-panel" class="data-panel {% if settings_and_source_data %}hidden{% endif %}">
             <div class="govuk-grid-column-full">
                 <h2 class="govuk-heading-m no-top-border eff-numbered-sections__item">Data</h2>
 
@@ -60,7 +57,7 @@
             </div>
         </div>
 
-        <div id="edit-panel" class="edit-panel {% if not dimension_dict.table_settings_and_source_data %}hidden{% endif %}">
+        <div id="edit-panel" class="edit-panel {% if not settings_and_source_data %}hidden{% endif %}">
             <div class="govuk-grid-column-one-third">
                 {#
                     DATA DISPLAY
@@ -269,7 +266,7 @@
                       <span class="govuk-hint">For example, ‘Percentage of households who own their home by ethnicity and socio-economic group’</span>
                       {% include 'forms/extended_hints/_chart_and_table_title.html' %}
                         <textarea id="table_title" class="govuk-textarea" rows="2" data-module="autoresize no-newlines"
-                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if dimension_dict.table_settings_and_source_data %}{{ dimension_dict.table_settings_and_source_data.tableValues.table_title }}{% endif %}</textarea>
+                               {% if form_disabled %}disabled="disabled"{% endif %}>{% if settings_and_source_data %}{{ settings_and_source_data.tableValues.table_title }}{% endif %}</textarea>
                     </div>
 
                     <h2 class="govuk-heading-m eff-numbered-sections__item">Preview</h2>

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -1,7 +1,7 @@
 
-{{ dimension_dict.header }}
-{% if dimension_dict.table.header %}
-  <h3 class="govuk-heading-s">{{ dimension_dict.table.header }}</h3>
+{{ dimension.header }}
+{% if dimension.dimension_table.table_object.header %}
+  <h3 class="govuk-heading-s">{{ dimension.dimension_table.table_object.header }}</h3>
 {% endif %}
 
 {% set missing_data_sort_order_values = {
@@ -16,39 +16,39 @@
     <div class="table-container-inner">
 
       <div class="table-container">
-    <table class="govuk-table eff-table--dense measure-data {{ 'grouped' if dimension_dict.table.type == 'grouped' }} {{ 'grouped-rows no-sort' if dimension_dict.table.parent_child }}">
+    <table class="govuk-table eff-table--dense measure-data {{ 'grouped' if dimension.dimension_table.table_object.type == 'grouped' }} {{ 'grouped-rows no-sort' if dimension.dimension_table.table_object.parent_child }}">
     <thead class="govuk-table__head">
 
-      {% if (dimension_dict.table.type == "grouped") and (dimension_dict.table.columns|length > 1) %}
-        {% set total_cells = (dimension_dict.table.columns|length * (dimension_dict.table.group_columns|length)) + 1 %}
+      {% if (dimension.dimension_table.table_object.type == "grouped") and (dimension.dimension_table.table_object.columns|length > 1) %}
+        {% set total_cells = (dimension.dimension_table.table_object.columns|length * (dimension.dimension_table.table_object.group_columns|length)) + 1 %}
 
         <tr class="govuk-table__row">
           <th class="govuk-table__header first eff-table__header--border-right"> </th>
-          {% for group_column in dimension_dict.table.group_columns %}
+          {% for group_column in dimension.dimension_table.table_object.group_columns %}
               {% if group_column %}
-                  <th colspan="{{ dimension_dict.table.columns|length }}" class="govuk-table__header eff-table__cell--padding-left {{ '' if loop.last else 'eff-table__header--border-right' }}">{{ group_column|safe }}</th>
+                  <th colspan="{{ dimension.dimension_table.table_object.columns|length }}" class="govuk-table__header eff-table__cell--padding-left {{ '' if loop.last else 'eff-table__header--border-right' }}">{{ group_column|safe }}</th>
               {% endif %}
           {% endfor %}
         </tr>
 
       {% else %}
-      {% set total_cells = (dimension_dict.table.columns|length + 1) %}
+      {% set total_cells = (dimension.dimension_table.table_object.columns|length + 1) %}
       {% endif %}
 
       <tr>
         <th class="govuk-table__header first eff-table__header--border-right eff-table__cell--padding-left" aria-sort="none">
-            {% if dimension_dict.table.category_caption %}
-                {{ dimension_dict.table.category_caption }}
+            {% if dimension.dimension_table.table_object.category_caption %}
+                {{ dimension.dimension_table.table_object.category_caption }}
             {% else %}
-                {{ dimension_dict.table.category }}
+                {{ dimension.dimension_table.table_object.category }}
             {% endif %}
         </th>
 
-        {% if dimension_dict.table.type == "grouped" %}
+        {% if dimension.dimension_table.table_object.type == "grouped" %}
 
-          {% if (dimension_dict.table.columns|length == 1) %}
+          {% if (dimension.dimension_table.table_object.columns|length == 1) %}
 
-            {% for group_column in dimension_dict.table.group_columns %}
+            {% for group_column in dimension.dimension_table.table_object.group_columns %}
 
                 {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) %}
 
@@ -59,10 +59,10 @@
 
           {% else %}
 
-            {% for group_column in dimension_dict.table.group_columns %}
+            {% for group_column in dimension.dimension_table.table_object.group_columns %}
                 {% set group_loop = loop %}
                 {% if group_column %}
-                    {% for column in dimension_dict.table.columns %}
+                    {% for column in dimension.dimension_table.table_object.columns %}
                       {% set th_class = "eff-table__header--border-right" if loop.last and (group_loop.index != group_loop.length) %}
                       <th class="govuk-table__header eff-table__cell--padding-left {{ th_class }}" aria-sort="none">{{ column }}</th>
                     {% endfor %}
@@ -70,7 +70,7 @@
             {% endfor %}
           {% endif %}
         {% else %}
-          {% for text in dimension_dict.table.columns %}
+          {% for text in dimension.dimension_table.table_object.columns %}
           <th aria-sort="none" class="govuk-table__header eff-table__cell--padding-left">
             {{ text|safe }}
           </th>
@@ -79,12 +79,12 @@
         {% endif %}
       </tr>
 
-      {% if (dimension_dict.table.type == "grouped") and (dimension_dict.table.columns|length == 1) %}
-        {% for heading in dimension_dict.table.columns %}
+      {% if (dimension.dimension_table.table_object.type == "grouped") and (dimension.dimension_table.table_object.columns|length == 1) %}
+        {% for heading in dimension.dimension_table.table_object.columns %}
           {% if heading != '' %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell eff-table__cell--border-right eff-table__cell--padding-left"></td>
-              {% for group_column in dimension_dict.table.group_columns %}
+              {% for group_column in dimension.dimension_table.table_object.group_columns %}
                 {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) %}
 
                 {% if group_column %}
@@ -98,8 +98,8 @@
 
     </thead>
     <tbody>
-      {% for data in dimension_dict.table.data %}
-        {% set next_row = dimension_dict.table.data[loop.index0 + 1] %}
+      {% for data in dimension.dimension_table.table_object.data %}
+        {% set next_row = dimension.dimension_table.table_object.data[loop.index0 + 1] %}
         <tr class="govuk-table__row">
           {% set row_loop = loop %}
           {% for value in data['values'] %}
@@ -122,7 +122,7 @@
             {% endif %}
 
             {# We only want the 'eff-table-__header-border-right' class on the last column within each group #}
-            {% set td_class = "eff-table__header--border-right" if ((loop.index != loop.length) and (loop.index % (dimension_dict.table.columns|length) == 0)) %}
+            {% set td_class = "eff-table__header--border-right" if ((loop.index != loop.length) and (loop.index % (dimension.dimension_table.table_object.columns|length) == 0)) %}
 
             <td data-sort-value="{{sort_value}}" class="govuk-table__cell eff-table__cell--padding-left {{ td_class }}">{{ value|value_filter|safe }}</td>
           {% endfor %}
@@ -140,7 +140,7 @@
 <div class="table-footer">
 
     <p class="missing-data-explanation govuk-body">
-        {% set table_data = dimension_dict.table.data | flatten %}
+        {% set table_data = dimension.dimension_table.table_object.data | flatten %}
 
         {% if "N/A" in table_data or "n/a" in table_data %}
             <span class="explanation"><sup>*</sup> Not applicable</span>
@@ -160,8 +160,8 @@
 
     </p>
 
-    {% if dimension_dict.table.footer %}
-      <p>{{ dimension_dict.table.footer }}</p>
+    {% if dimension.dimension_table.table_object.footer %}
+      <p>{{ dimension.dimension_table.table_object.footer }}</p>
     {% endif %}
 
 </div>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -131,9 +131,9 @@
             </dd>
           {% endif %}
 
-          {%  if first_published_date %}
+          {%  if measure_version.first_published_date %}
             <dt>Published:</dt>
-            <dd><time itemprop="datePublished" datetime="{{ first_published_date | format_iso8601_date }}">{{ first_published_date | format_friendly_date }}</time>
+            <dd><time itemprop="datePublished" datetime="{{ measure_version.first_published_date | format_iso8601_date }}">{{ measure_version.first_published_date | format_friendly_date }}</time>
             </dd>
           {%  endif %}
 
@@ -413,7 +413,7 @@
             <meta itemprop="name" content="{{ measure_version.format_area_covered() }}">
           </div>
           {% if measure_version.published_at %}<meta itemprop="dateModified" content="{{ measure_version.published_at | format_iso8601_date }}">{% endif %}
-          {% if first_published_date %}<meta itemprop="datePublished" content="{{ first_published_date | format_iso8601_date }}">{% endif %}
+          {% if measure_version.first_published_date %}<meta itemprop="datePublished" content="{{ measure_version.first_published_date | format_iso8601_date }}">{% endif %}
           <div itemprop="creator" itemscope itemtype="http://schema.org/Organization">
             <meta itemprop="name" content="Race Disparity Unit">
             <meta itemprop="url" content="https://www.gov.uk/government/organisations/race-disparity-unit">
@@ -602,15 +602,15 @@
             <p>
                 Publication release date:
                 <span class="published definition">
-                    {% if first_published_date %}
-                        {{ first_published_date|format_friendly_date }}
+                    {% if measure_version.first_published_date %}
+                        {{ measure_version.first_published_date|format_friendly_date }}
                     {% else %}
                         TBC
                     {% endif %}
                 </span>
             </p>
 
-            {% if edit_history %}
+            {% if measure_version.previous_minor_versions %}
                 <p>Updated:
                     <span class="updated definition"> {{ measure_version.published_at|format_friendly_date }}</span>
                 </p>
@@ -643,7 +643,7 @@
                         {{ current_edit_summary }}
                     {% endif %}
                 </li>
-                {% for old_page_version in edit_history %}
+                {% for old_page_version in measure_version.previous_minor_versions %}
                   <li>
                     <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
 
@@ -670,8 +670,8 @@
           </p>
           {%  endif %}
 
-          {% if versions %}
-            {% set version_count = versions|length %}
+          {% if measure_version.previous_major_versions %}
+            {% set version_count = measure_version.previous_major_versions|length %}
 
             <div class="previous-editions">
               Previous {{ "editions" if version_count > 1 else "edition" }}:

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -227,12 +227,12 @@
 
   <div class="govuk-grid-row">
       {% if measure_version.dimensions %}
-          {% for dimension_dict in dimensions %}
+          {% for dimension in measure_version.dimensions %}
 
-            {% set chart_and_downloadable = True if dimension_dict.chart and dimension_dict.chart['type'] not in ['panel_bar_chart', 'panel_line_chart'] else False %}
+            {% set chart_and_downloadable = True if dimension.dimension_chart.chart_object and dimension.dimension_chart.chart_object.type not in ['panel_bar_chart', 'panel_line_chart'] else False %}
 
               <div class="govuk-grid-column-two-thirds">
-                  <h2 class="govuk-heading-m" id="{{ dimension_dict.title|slugify_value }}">{{ dimension_dict.title }}</h2>
+                  <h2 class="govuk-heading-m" id="{{ dimension.title | slugify_value }}">{{ dimension.title }}</h2>
                   <div class="metadata">
                       <dl>
                           {% if measure_version.area_covered %}
@@ -241,10 +241,10 @@
                                   {{ measure_version.format_area_covered()  }}
                               </dd>
                           {% endif %}
-                          {% if dimension_dict.time_period %}
+                          {% if dimension.time_period %}
                               <dt>Time period:</dt>
                               <dd>
-                                  {{ dimension_dict.time_period }}
+                                  {{ dimension.time_period }}
                               </dd>
                           {% endif %}
                           {% if measure_version.primary_data_source %}
@@ -262,12 +262,12 @@
 
               <div class="chart-and-footer">
                 <div class="govuk-grid-row">
-                  <div class="rd_chart" id="chart_{{ dimension_dict.guid }}" style="clear: both; overflow: hidden"></div>
+                  <div class="rd_chart" id="chart_{{ dimension.guid }}" style="clear: both; overflow: hidden"></div>
                 </div>
 
                 <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full chart-footer">
-                  {% set chart_text_data = dimension_dict.chart | flatten_chart %}
+                  {% set chart_text_data = dimension.dimension_chart.chart_object | flatten_chart %}
 
                   {% if "N/A" in chart_text_data or "-" in chart_text_data or "!" in chart_text_data or "?" in chart_text_data %}
                     <p class="missing-data-explanation">
@@ -292,8 +292,8 @@
 
                     {% if chart_and_downloadable %}
                         <p class="chart-download">
-                            <a class="govuk-link download-png" href="#" data-on="click" data-event-category="Image downloaded" data-event-action="Image of the chart" data-event-label="{{ dimension_dict.chart.title.text }}" class="download-png"
-                               id="download-{{ dimension_dict.guid }}" data-title="{{ dimension_dict.chart.title.text }}">
+                            <a class="govuk-link download-png" href="#" data-on="click" data-event-category="Image downloaded" data-event-action="Image of the chart" data-event-label="{{ dimension.dimension_chart.chart_object.title.text }}" class="download-png"
+                               id="download-{{ dimension.guid }}" data-title="{{ dimension.dimension_chart.chart_object.title.text }}">
                                 Download chart (PNG)
                             </a>
                         </p>
@@ -303,36 +303,44 @@
             </div>
 
             <div class="govuk-grid-row">
-              {% set tabular_download_viable = True if dimension_dict.table else False %}
+              {% set tabular_download_viable = True if dimension.dimension_table.table_object else False %}
               <div class="govuk-grid-column-full"
-                   style="{% if not dimension_dict.table and not dimension_dict.chart %}display: none;{% endif %}">
-                  {% if dimension_dict.table %}
+                   style="{% if not dimension.dimension_table and not dimension.dimension_chart.chart_object %}display: none;{% endif %}">
+                  {% if dimension.dimension_table.table_object %}
                       {% include "static_site/_table.html" %}
 
                       {% if tabular_download_viable %}
                       <p class="chart-download">
                           {% if static_mode %}
-                              <a class="govuk-link" href="/{{ topic_slug }}/{{ subtopic_slug }}/{{ measure_version.measure.slug }}/{{ version }}/downloads/{{ dimension_dict.static_table_file_name }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension_dict.table.header}}"
-                                 download="{{ dimension_dict.static_table_file_name }}">Download table data (CSV)</a>
+                              <a class="govuk-link" href="{{ url_for('static_site.measure_version_file_download', topic_slug=topic_slug,
+                                   subtopic_slug=subtopic_slug,
+                                   measure_slug=measure_version.measure.slug,
+                                   version=version,
+                                   filename=dimension.static_table_file_name) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}"
+                                 download="{{ dimension.dimension_table.static_table_file_name }}">Download table data (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_table_download',
                                    topic_slug=topic_slug,
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension_dict.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension_dict.table.header}}">Download table data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}">Download table data (CSV)</a>
                           {% endif %}
 
                           {% if static_mode %}
-                              <a class="govuk-link" href="/{{ topic_slug }}/{{ subtopic_slug }}/{{ measure_version.measure.slug }}/{{ version }}/downloads/{{ dimension_dict.static_file_name }}" data-on="click"
-                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension_dict.table.header}}">Source data (CSV)</a>
+                              <a class="govuk-link" href="{{ url_for('static_site.measure_version_file_download', topic_slug=topic_slug,
+                                   subtopic_slug=subtopic_slug,
+                                   measure_slug=measure_version.measure.slug,
+                                   version=version,
+                                   filename=dimension.static_file_name) }}" data-on="click"
+                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_download',
                                    topic_slug=topic_slug,
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension_dict.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension_dict.table.header}}">Source data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data (CSV)</a>
                           {% endif %}
                       </p>
                     {% endif %}
@@ -343,7 +351,7 @@
               <div class="govuk-grid-column-two-thirds">
                   <h3 class="govuk-heading-s">Summary</h3>
                   <div class="govuk-!-margin-bottom-8 eff-summary--with-bullets-spaced-out">
-                    {{ dimension_dict.summary | render_markdown }}
+                    {{ dimension.summary | render_markdown }}
                   </div>
               </div>
           {% endfor %}
@@ -539,7 +547,11 @@
             {% for file in measure_version.uploads  %}
               {% if file.file_name %}
                 {% set measure_version_data_url =
-                  ("/" + topic_slug + "/"+  subtopic_slug + "/"+  measure_version.measure.slug + "/"+  version + "/downloads/" + file.file_name)
+                  url_for('static_site.measure_version_file_download', topic_slug=topic_slug,
+                          subtopic_slug=subtopic_slug,
+                          measure_slug=measure_version.measure.slug,
+                          version=version,
+                          filename=file.file_name)
                   if static_mode else
                   url_for('static_site.measure_version_file_download',
                           topic_slug=topic_slug,
@@ -692,23 +704,25 @@
 
 <script type="text/javascript">
 
-  var dimensions = {{ dimensions|tojson }};
+  var dimensions = {{ measure_version.dimensions | models_to_dicts | tojson }};
 
   $(document).ready(function () {
     for (d in dimensions) {
-      var chartObject = dimensions[d].chart;
-      if(chartObject) {
-          // code writes title as html and creates sub-container
-          var chartContainer = 'chart_' + dimensions[d].guid;
-          var chartHtml = '<div class="govuk-grid-column-full">';
-          chartHtml = chartObject.title.text ? chartHtml + '<h3 class="govuk-heading-s">' + chartObject.title.text + '</h3>': chartHtml;
-          chartHtml = chartHtml + '<div id="' + chartContainer + '_image"></div>';
-          chartHtml = chartHtml + '</div>';
-          $('#' + chartContainer).html(chartHtml);
+      if (dimensions[d].dimension_chart != null) {
+        var chartObject = dimensions[d].dimension_chart.chart_object;
+        if (chartObject) {
+            // code writes title as html and creates sub-container
+            var chartContainer = 'chart_' + dimensions[d].guid;
+            var chartHtml = '<div class="govuk-grid-column-full">';
+            chartHtml = chartObject.title.text ? chartHtml + '<h3 class="govuk-heading-s">' + chartObject.title.text + '</h3>' : chartHtml;
+            chartHtml = chartHtml + '<div id="' + chartContainer + '_image"></div>';
+            chartHtml = chartHtml + '</div>';
+            $('#' + chartContainer).html(chartHtml);
 
-          // draws chart in sub-container
-          chartObject.title = '';
-          drawChart(chartContainer + '_image', chartObject);
+            // draws chart in sub-container
+            chartObject.title = '';
+            drawChart(chartContainer + '_image', chartObject);
+        }
       }
     };
 

--- a/application/utils.py
+++ b/application/utils.py
@@ -241,3 +241,7 @@ class TimedExecution:
             self.log(f"EXIT: {self.description} ({execution_time}s elapsed)")
 
         return execution_time
+
+
+def cleanup_filename(filename):
+    return slugify(filename)

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -763,7 +763,7 @@ class TestMeasurePage:
     @pytest.mark.parametrize(
         "static_mode, expected_url",
         (
-            # ("yes", "<some_url>"),
+            ("yes", "/topic/subtopic/measure/latest/downloads/dimension-title-table.csv"),
             ("no", "/topic/subtopic/measure/1.0/dimension/dimension-guid/tabular-download"),
         ),
     )
@@ -779,6 +779,7 @@ class TestMeasurePage:
             measure__subtopics__slug="subtopic",
             measure__slug="measure",
             dimensions__guid="dimension-guid",
+            dimensions__title="dimension-title",
             dimensions__dimension_chart__chart_object=chart,
             dimensions__dimension_table__table_object=simple_table(),
             uploads__guid="test-download",
@@ -794,7 +795,7 @@ class TestMeasurePage:
     @pytest.mark.parametrize(
         "static_mode, expected_url",
         (
-            # ("yes", "<some_url>"),
+            ("yes", "/topic/subtopic/measure/latest/downloads/dimension-title.csv"),
             ("no", "/topic/subtopic/measure/1.0/dimension/dimension-guid/download"),
         ),
     )
@@ -810,6 +811,7 @@ class TestMeasurePage:
             measure__subtopics__slug="subtopic",
             measure__slug="measure",
             dimensions__guid="dimension-guid",
+            dimensions__title="dimension-title",
             dimensions__dimension_chart__chart_object=chart,
             dimensions__dimension_table__table_object=simple_table(),
             uploads__guid="test-download",
@@ -824,7 +826,7 @@ class TestMeasurePage:
     @pytest.mark.parametrize(
         "static_mode, expected_url",
         (
-            # ("yes", "<some_url>"),
+            ("yes", "/topic/subtopic/measure/1.0/downloads/test-measure-page-data.csv"),
             ("no", "/topic/subtopic/measure/1.0/downloads/test-measure-page-data.csv"),
         ),
     )


### PR DESCRIPTION
We often pass dimensions into our templates in order to render them on
the page. Instead of using the objects directly, though, we would
convert them to dictionaries with keys which sometimes aligned to the
model attributes and sometimes didn't. This makes it harder for
developers to intuitively know the interface to expect, increasing
cognitive load.

We now pass dimension objects directly into templates where necessary,
and then call `to_dict` on each instance (via the `convert_to_dicts`
filter) when we need to make the data available to JavaScript. The
`to_dict` method has been re-written to more accurately reflect the
model and its relationships, i.e. instead of having keys from the
related chart/table objects as top-level items in the dimension object,
they now are nested inside `dimension_chart/table` keys.

In doing this, I've also added some derived properties to the Dimension
class: static_file_name and static_table_file_name. These were
previously injected into the `to_dict`ed dimensions by the static site
builder. Now they are always available by default, which further
decreases the differences between how our live site works and how the
static site build process works.

 ## Ticket
https://trello.com/c/3DpamNBz