### PR TITLE
Capitalise T in Traveller

### DIFF
--- a/application/data/static/standardisers/classification_definitions.csv
+++ b/application/data/static/standardisers/classification_definitions.csv
@@ -68,7 +68,7 @@ Code,Classification short name,Classification long name,Standard,Display,Parent,
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Arab,Arab,Arab,1001,TRUE
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",White Gypsy/Traveller,White Gypsy/Traveller,White Gypsy/Traveller,4100,TRUE
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Gypsy/Roma,White Gypsy/Traveller,White Gypsy/Traveller,4100,
-12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Irish traveller,White Gypsy/Traveller,White Gypsy/Traveller,4100,
+12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Irish Traveller,White Gypsy/Traveller,White Gypsy/Traveller,4100,
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Any other,Other,Other,9000,
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Unknown,Unknown,Unknown,9980,
 12A,Well-being survey - 12,"Bangladeshi, Chinese, Indian, Pakistani, Asian other, Black, Mixed, White British, White other, Other, Arab, Gypsy/Traveller/Irish Traveller",Unclassified,Unclassified,Unclassified,9990,
@@ -189,7 +189,7 @@ Code,Classification short name,Classification long name,Standard,Display,Parent,
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,White British,White British,White,4100,TRUE
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,White Irish,White Irish,White,4200,TRUE
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,Gypsy/Roma,Gypsy/Roma,White,4310,TRUE
-18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,Irish traveller,Irish traveller,White,4330,TRUE
+18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,Irish Traveller,Irish Traveller,White,4330,TRUE
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,White other,White other,White,4900,TRUE
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,Any other,Other,Other,9900,TRUE
 18B,DfE - 18+1,ONS detailed census categories 2001 plus Gypsy/Roma and Irish Traveller,All,All,All,0,

--- a/application/data/static/standardisers/classification_lookup.csv
+++ b/application/data/static/standardisers/classification_lookup.csv
@@ -209,11 +209,11 @@ irish,White Irish
 white - irish,White Irish
 white irish,White Irish
 white: irish,White Irish
-ethnicity_minor_traveller_of_irish_heritage,Irish traveller
-traveller of irish heritage,Irish traveller
-white - irish traveller,Irish traveller
-white - traveller of irish heritage,Irish traveller
-white irish traveller,Irish traveller
+ethnicity_minor_traveller_of_irish_heritage,Irish Traveller
+traveller of irish heritage,Irish Traveller
+white - irish traveller,Irish Traveller
+white - traveller of irish heritage,Irish Traveller
+white irish traveller,Irish Traveller
 white non-british,White other
 white non-british total,White other
 any other white,White other

--- a/scripts/data_migrations/2019_03_29_update-traveller-capitalisation.sql
+++ b/scripts/data_migrations/2019_03_29_update-traveller-capitalisation.sql
@@ -1,0 +1,3 @@
+UPDATE ethnicity SET value = 'Gypsy/Traveller/Irish Traveller' WHERE value = 'Gypsy/Traveller/Irish traveller';
+
+UPDATE ethnicity SET value = 'Irish Traveller' WHERE value = 'Irish traveller';


### PR DESCRIPTION
Traveller is a proper noun, so should be capitalised properly. We do
this in some places, but not everywhere. This should make it consistent.