### PR TITLE
Case insensitive ethnicity matching

### DIFF
--- a/application/data/standardisers/ethnicity_classification_finder.py
+++ b/application/data/standardisers/ethnicity_classification_finder.py
@@ -80,10 +80,11 @@ class EthnicityClassificationCollection:
         return self.classifications
 
     def get_valid_classifications(self, raw_ethnicity_list, ethnicity_standardiser):
+        standardised_ethnicities = ethnicity_standardiser.standardise_all(raw_ethnicity_list)
         valid_classifications = [
             classification
             for classification in self.classifications
-            if classification.is_valid_for_raw_ethnicities(raw_ethnicity_list, ethnicity_standardiser)
+            if classification.is_valid_for_standard_ethnicities(standardised_ethnicities)
         ]
         valid_classifications.sort(
             key=lambda classification: -classification.get_data_fit_level(raw_ethnicity_list, ethnicity_standardiser)
@@ -181,11 +182,6 @@ class EthnicityClassification:
             if item.get_parent() != item.get_display_ethnicity():
                 return True
         return False
-
-    def is_valid_for_raw_ethnicities(self, raw_ethnicities, ethnicity_standardiser):
-        standard_ethnicities_in_data = ethnicity_standardiser.standardise_all(raw_ethnicities)
-
-        return self.is_valid_for_standard_ethnicities(standard_ethnicities_in_data)
 
     def is_valid_for_standard_ethnicities(self, standard_ethnicities):
         unique_ethnicities = EthnicityClassification.__remove_duplicates(standard_ethnicities)

--- a/application/data/static/standardisers/classification_lookup.csv
+++ b/application/data/static/standardisers/classification_lookup.csv
@@ -166,6 +166,7 @@ asian/asian british: pakistani,Pakistani
 ethnicity_minor_pakistani,Pakistani
 pakistani,Pakistani
 pakistani total,Pakistani
+pakistani and bangladeshi,Pakistani and Bangladeshi
 asian - pakistani/bangladeshi,Pakistani and Bangladeshi
 pakistani/bangladeshi,Pakistani and Bangladeshi
 ethnicity_major_unclassified,Unclassified
@@ -181,6 +182,7 @@ not stated/invalid,Unknown
 unclassified,Unknown
 unknown,Unknown
 unknown ethnicity,Unknown
+unmatched,Unmatched
 unreported,Unknown
 ethnicity_major_white_total,White
 white,White
@@ -209,6 +211,7 @@ irish,White Irish
 white - irish,White Irish
 white irish,White Irish
 white: irish,White Irish
+irish traveller,Irish Traveller
 ethnicity_minor_traveller_of_irish_heritage,Irish Traveller
 traveller of irish heritage,Irish Traveller
 white - irish traveller,Irish Traveller
@@ -253,6 +256,8 @@ asian bangladeshi,Bangladeshi
 asian chinese,Chinese
 asian indian,Indian
 asian pakistani,Pakistani
+asian other inc chinese,Asian other inc Chinese
+asian excluding chinese,Asian excluding Chinese
 mixed and other,Other
 other mixed,Mixed other
 other black,Black other
@@ -271,3 +276,10 @@ mixed - white/asian,Mixed White/Asian
 mixed - white/black african,Mixed White/Black African
 mixed - white/black caribbean,Mixed White/Black Caribbean
 other - chinese,Chinese
+other inc asian,Other inc Asian
+other inc chinese,Other inc Chinese
+other inc mixed and chinese,Other inc Mixed and Chinese
+other (inc gypsy/traveller/irish traveller),Other (inc Gypsy/Traveller/Irish Traveller)
+other than white,Other than White
+other than white british,Other than White British
+not applicable,Not applicable

--- a/tests/application/data/standardisers/test_standardisers_classification_finder.py
+++ b/tests/application/data/standardisers/test_standardisers_classification_finder.py
@@ -252,7 +252,8 @@ def test_classification_functions_correctly_with_raw_data_instead_of_standards()
     # WHEN
     # we validate against data that should map to 'Mammal', 'Cat', 'Dog', 'Fish'
     raw_values = ["Mammal", "FELINE", "Canine  ", "fish  "]
-    classification_is_valid = classification.is_valid_for_raw_ethnicities(raw_values, standardiser)
+    standard_values = standardiser.standardise_all(raw_values)
+    classification_is_valid = classification.is_valid_for_standard_ethnicities(standard_values)
 
     # THEN
     # the classification is valid
@@ -285,7 +286,8 @@ def test_classification_functions_correctly_with_multiple_rows_of_raw_data():
         "Canine  ",
         "fish  ",
     ]
-    classification_is_valid = classification.is_valid_for_raw_ethnicities(many_rows_of_raw_data, standardiser)
+    standard_values = standardiser.standardise_all(many_rows_of_raw_data)
+    classification_is_valid = classification.is_valid_for_standard_ethnicities(standard_values)
 
     # THEN
     # the classification is valid
@@ -376,11 +378,14 @@ def test_classification_may_use_several_raw_values_to_map_to_a_required_display_
     standardiser = pet_standardiser()
     raw_values_1 = ["Mammal", "Fish", "Other"]
     raw_values_2 = ["Mammal", "Fish", "Reptile"]
+    standard_values_1 = standardiser.standardise_all(raw_values_1)
+    standard_values_2 = standardiser.standardise_all(raw_values_2)
 
     # WHEN
     # we test both for validity using our single classification
-    valid_with_other = classification.is_valid_for_raw_ethnicities(raw_values_1, standardiser)
-    valid_with_reptile = classification.is_valid_for_raw_ethnicities(raw_values_2, standardiser)
+
+    valid_with_other = classification.is_valid_for_standard_ethnicities(standard_values_1)
+    valid_with_reptile = classification.is_valid_for_standard_ethnicities(standard_values_2)
 
     # THEN
     # we expect both to be valid


### PR DESCRIPTION
For this ticket: https://trello.com/c/7Q6nf0rg/1448-chart-and-table-ethnicity-lookups-shouldnt-be-case-sensitive

The first commit here is a refactor to avoid "standardising" the exact same set of "raw values" multiple times for no good reason.

The second commit here addresses the issue itself, which is that the csv file used to generate the lookup dictionary for reducing input ethnicities to our small "standard" set was missing rows for a few of the ethnicities in themselves.  The lookup dictionary maps lowercase strings to "standard" ethnicities if input strings don't match a standard ethnicity exactly.  So we need entries to map e.g. "Irish traveller" to "Irish Traveller" if we want case-insensitive matching.