### PR TITLE
Smaller review app databases

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -147,11 +147,19 @@ class DataSource(db.Model, CopyableModel):
     __tablename__ = "data_source"
     __table_args__ = (
         ForeignKeyConstraint(
-            ["type_of_statistic_id"], ["type_of_statistic.id"], name="data_source_type_of_statistic_id_fkey"
+            ["type_of_statistic_id"],
+            ["type_of_statistic.id"],
+            name="data_source_type_of_statistic_id_fkey",
+            ondelete="restrict",
         ),
-        ForeignKeyConstraint(["publisher_id"], ["organisation.id"], name="data_source_publisher_id_fkey"),
         ForeignKeyConstraint(
-            ["frequency_of_release_id"], ["frequency_of_release.id"], name="data_source_frequency_of_release_id_fkey"
+            ["publisher_id"], ["organisation.id"], name="data_source_publisher_id_fkey", ondelete="restrict"
+        ),
+        ForeignKeyConstraint(
+            ["frequency_of_release_id"],
+            ["frequency_of_release.id"],
+            name="data_source_frequency_of_release_id_fkey",
+            ondelete="restrict",
         ),
     )
 
@@ -189,8 +197,10 @@ class DataSourceInMeasureVersion(db.Model):
     # metadata
     __tablename__ = "data_source_in_measure_version"
     __table_args__ = (
-        ForeignKeyConstraint(["data_source_id"], ["data_source.id"], name="data_source_in_page_data_source_id_fkey"),
-        ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"]),
+        ForeignKeyConstraint(
+            ["data_source_id"], ["data_source.id"], name="data_source_in_page_data_source_id_fkey", ondelete="restrict"
+        ),
+        ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"], ondelete="cascade"),
     )
 
     data_source_id = db.Column(db.Integer, primary_key=True)
@@ -199,8 +209,8 @@ class DataSourceInMeasureVersion(db.Model):
 
 user_measure = db.Table(
     "user_measure",
-    db.Column("user_id", db.Integer, db.ForeignKey("users.id"), primary_key=True),
-    db.Column("measure_id", db.Integer, db.ForeignKey("measure.id"), primary_key=True),
+    db.Column("user_id", db.Integer, db.ForeignKey("users.id", ondelete="cascade"), primary_key=True),
+    db.Column("measure_id", db.Integer, db.ForeignKey("measure.id", ondelete="cascade"), primary_key=True),
 )
 
 
@@ -216,7 +226,10 @@ class MeasureVersion(db.Model, CopyableModel):
 
     # metadata
     __tablename__ = "measure_version"
-    __table_args__ = (ForeignKeyConstraint(["measure_id"], ["measure.id"]), UniqueConstraint("measure_id", "version"))
+    __table_args__ = (
+        ForeignKeyConstraint(["measure_id"], ["measure.id"], ondelete="cascade"),
+        UniqueConstraint("measure_id", "version"),
+    )
 
     def __eq__(self, other):
         return self.id == other.id
@@ -278,7 +291,7 @@ class MeasureVersion(db.Model, CopyableModel):
 
     # lowest_level_of_geography is not displayed on the public site but is used for geographic dashboard
     lowest_level_of_geography_id = db.Column(
-        db.String(255), ForeignKey("lowest_level_of_geography.name"), nullable=True
+        db.String(255), ForeignKey("lowest_level_of_geography.name", ondelete="restrict"), nullable=True
     )
 
     # Methodology section
@@ -555,7 +568,7 @@ class MeasureVersion(db.Model, CopyableModel):
 class Dimension(db.Model):
     # metadata
     __tablename__ = "dimension"
-    __table_args__ = (ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"]), {})
+    __table_args__ = (ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"], ondelete="cascade"), {})
 
     # This is a database expression to get the current timestamp in UTC.
     # Possibly specific to PostgreSQL:
@@ -753,7 +766,7 @@ class Dimension(db.Model):
 class Upload(db.Model, CopyableModel):
     # metadata
     __tablename__ = "upload"
-    __table_args__ = (ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"]), {})
+    __table_args__ = (ForeignKeyConstraint(["measure_version_id"], ["measure_version.id"], ondelete="cascade"), {})
 
     # columns
     guid = db.Column(db.String(255), primary_key=True)
@@ -849,8 +862,8 @@ class DimensionClassification(db.Model):
     # metadata
     __tablename__ = "dimension_categorisation"
     __table_args__ = (
-        ForeignKeyConstraint(["dimension_guid"], ["dimension.guid"]),
-        ForeignKeyConstraint(["classification_id"], ["classification.id"]),
+        ForeignKeyConstraint(["dimension_guid"], ["dimension.guid"], ondelete="cascade"),
+        ForeignKeyConstraint(["classification_id"], ["classification.id"], ondelete="restrict"),
         {},
     )
 
@@ -1032,8 +1045,8 @@ class Subtopic(db.Model):
 
 subtopic_measure = db.Table(
     "subtopic_measure",
-    db.Column("subtopic_id", db.Integer, db.ForeignKey("subtopic.id"), primary_key=True),
-    db.Column("measure_id", db.Integer, db.ForeignKey("measure.id"), primary_key=True),
+    db.Column("subtopic_id", db.Integer, db.ForeignKey("subtopic.id", ondelete="restrict"), primary_key=True),
+    db.Column("measure_id", db.Integer, db.ForeignKey("measure.id", ondelete="cascade"), primary_key=True),
 )
 
 

--- a/manage.py
+++ b/manage.py
@@ -478,6 +478,12 @@ def delete_all_measures_except_two_per_subtopic():
         Table,
     )
 
+    environment = os.environ.get("ENVIRONMENT", "PRODUCTION")
+    if environment.upper().startswith("PROD"):
+        print("It looks like you are running this in production or some unknown environment.")
+        print("Do not run this command in this environment as it deletes data")
+        sys.exit(-1)
+
     with TimedExecution("Delete 3rd measure and onward in each subtopic"):
         try:
             measure_ids_to_save = []

--- a/manage.py
+++ b/manage.py
@@ -537,8 +537,5 @@ def delete_all_measures_except_two_per_subtopic():
     db.session.commit()
 
 
-# TODO: END
-
-
 if __name__ == "__main__":
     manager.run()

--- a/migrations/versions/2019_04_01_fkey_cascades_cascade_foreign_key_relationships_for_.py
+++ b/migrations/versions/2019_04_01_fkey_cascades_cascade_foreign_key_relationships_for_.py
@@ -1,0 +1,217 @@
+"""Cascade foreign key relationships for deleting measure versions
+
+Revision ID: 2019_04_01_fkey_cascades
+Revises: 2019_03_25_remove_title
+Create Date: 2019-04-01 15:43:15.024950
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_04_01_fkey_cascades"
+down_revision = "2019_03_25_remove_title"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("data_source_frequency_of_release_id_fkey", "data_source", type_="foreignkey")
+    op.drop_constraint("data_source_type_of_statistic_id_fkey", "data_source", type_="foreignkey")
+    op.drop_constraint("data_source_publisher_id_fkey", "data_source", type_="foreignkey")
+    op.create_foreign_key(
+        "data_source_type_of_statistic_id_fkey",
+        "data_source",
+        "type_of_statistic",
+        ["type_of_statistic_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    op.create_foreign_key(
+        "data_source_publisher_id_fkey", "data_source", "organisation", ["publisher_id"], ["id"], ondelete="restrict"
+    )
+    op.create_foreign_key(
+        "data_source_frequency_of_release_id_fkey",
+        "data_source",
+        "frequency_of_release",
+        ["frequency_of_release_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    op.drop_constraint("data_source_in_page_data_source_id_fkey", "data_source_in_measure_version", type_="foreignkey")
+    op.drop_constraint(
+        "data_source_in_measure_version_measure_version_id_fkey", "data_source_in_measure_version", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "data_source_in_page_data_source_id_fkey",
+        "data_source_in_measure_version",
+        "data_source",
+        ["data_source_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    op.create_foreign_key(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        "measure_version",
+        ["measure_version_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.drop_constraint("dimension_measure_version_id_fkey", "dimension", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("dimension_measure_version_id_fkey"),
+        "dimension",
+        "measure_version",
+        ["measure_version_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.drop_constraint("dimension_categorisation_classification_fkey", "dimension_categorisation", type_="foreignkey")
+    op.drop_constraint("dimension_dimension_categorisation_fkey", "dimension_categorisation", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("dimension_categorisation_classification_id_fkey"),
+        "dimension_categorisation",
+        "classification",
+        ["classification_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    op.create_foreign_key(
+        op.f("dimension_categorisation_dimension_guid_fkey"),
+        "dimension_categorisation",
+        "dimension",
+        ["dimension_guid"],
+        ["guid"],
+        ondelete="cascade",
+    )
+    op.drop_constraint("measure_version_measure_id_fkey", "measure_version", type_="foreignkey")
+    op.drop_constraint("page_lowest_level_of_geography_fkey", "measure_version", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("measure_version_measure_id_fkey"),
+        "measure_version",
+        "measure",
+        ["measure_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        op.f("measure_version_lowest_level_of_geography_id_fkey"),
+        "measure_version",
+        "lowest_level_of_geography",
+        ["lowest_level_of_geography_id"],
+        ["name"],
+        ondelete="restrict",
+    )
+    op.drop_constraint("subtopic_measure_subtopic_id_fkey", "subtopic_measure", type_="foreignkey")
+    op.drop_constraint("subtopic_measure_measure_id_fkey", "subtopic_measure", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("subtopic_measure_subtopic_id_fkey"),
+        "subtopic_measure",
+        "subtopic",
+        ["subtopic_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    op.create_foreign_key(
+        op.f("subtopic_measure_measure_id_fkey"),
+        "subtopic_measure",
+        "measure",
+        ["measure_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.drop_constraint("upload_measure_version_id_fkey", "upload", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("upload_measure_version_id_fkey"),
+        "upload",
+        "measure_version",
+        ["measure_version_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.drop_constraint("user_page_user_id_fkey", "user_measure", type_="foreignkey")
+    op.drop_constraint("user_page_measure_id_fkey", "user_measure", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("user_measure_user_id_fkey"), "user_measure", "users", ["user_id"], ["id"], ondelete="cascade"
+    )
+    op.create_foreign_key(
+        op.f("user_measure_measure_id_fkey"), "user_measure", "measure", ["measure_id"], ["id"], ondelete="cascade"
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("user_measure_measure_id_fkey"), "user_measure", type_="foreignkey")
+    op.drop_constraint(op.f("user_measure_user_id_fkey"), "user_measure", type_="foreignkey")
+    op.create_foreign_key("user_page_measure_id_fkey", "user_measure", "measure", ["measure_id"], ["id"])
+    op.create_foreign_key("user_page_user_id_fkey", "user_measure", "users", ["user_id"], ["id"])
+    op.drop_constraint(op.f("upload_measure_version_id_fkey"), "upload", type_="foreignkey")
+    op.create_foreign_key("upload_measure_version_id_fkey", "upload", "measure_version", ["measure_version_id"], ["id"])
+    op.drop_constraint(op.f("subtopic_measure_measure_id_fkey"), "subtopic_measure", type_="foreignkey")
+    op.drop_constraint(op.f("subtopic_measure_subtopic_id_fkey"), "subtopic_measure", type_="foreignkey")
+    op.create_foreign_key("subtopic_measure_measure_id_fkey", "subtopic_measure", "measure", ["measure_id"], ["id"])
+    op.create_foreign_key("subtopic_measure_subtopic_id_fkey", "subtopic_measure", "subtopic", ["subtopic_id"], ["id"])
+    op.drop_constraint(op.f("measure_version_lowest_level_of_geography_id_fkey"), "measure_version", type_="foreignkey")
+    op.drop_constraint(op.f("measure_version_measure_id_fkey"), "measure_version", type_="foreignkey")
+    op.create_foreign_key(
+        "page_lowest_level_of_geography_fkey",
+        "measure_version",
+        "lowest_level_of_geography",
+        ["lowest_level_of_geography_id"],
+        ["name"],
+    )
+    op.create_foreign_key("measure_version_measure_id_fkey", "measure_version", "measure", ["measure_id"], ["id"])
+    op.drop_constraint(
+        op.f("dimension_categorisation_dimension_guid_fkey"), "dimension_categorisation", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("dimension_categorisation_classification_id_fkey"), "dimension_categorisation", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "dimension_dimension_categorisation_fkey", "dimension_categorisation", "dimension", ["dimension_guid"], ["guid"]
+    )
+    op.create_foreign_key(
+        "dimension_categorisation_classification_fkey",
+        "dimension_categorisation",
+        "classification",
+        ["classification_id"],
+        ["id"],
+    )
+    op.drop_constraint(op.f("dimension_measure_version_id_fkey"), "dimension", type_="foreignkey")
+    op.create_foreign_key(
+        "dimension_measure_version_id_fkey", "dimension", "measure_version", ["measure_version_id"], ["id"]
+    )
+    op.drop_constraint(
+        op.f("data_source_in_measure_version_measure_version_id_fkey"),
+        "data_source_in_measure_version",
+        type_="foreignkey",
+    )
+    op.drop_constraint("data_source_in_page_data_source_id_fkey", "data_source_in_measure_version", type_="foreignkey")
+    op.create_foreign_key(
+        "data_source_in_measure_version_measure_version_id_fkey",
+        "data_source_in_measure_version",
+        "measure_version",
+        ["measure_version_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "data_source_in_page_data_source_id_fkey",
+        "data_source_in_measure_version",
+        "data_source",
+        ["data_source_id"],
+        ["id"],
+    )
+    op.drop_constraint("data_source_frequency_of_release_id_fkey", "data_source", type_="foreignkey")
+    op.drop_constraint("data_source_publisher_id_fkey", "data_source", type_="foreignkey")
+    op.drop_constraint("data_source_type_of_statistic_id_fkey", "data_source", type_="foreignkey")
+    op.create_foreign_key("data_source_publisher_id_fkey", "data_source", "organisation", ["publisher_id"], ["id"])
+    op.create_foreign_key(
+        "data_source_type_of_statistic_id_fkey", "data_source", "type_of_statistic", ["type_of_statistic_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "data_source_frequency_of_release_id_fkey",
+        "data_source",
+        "frequency_of_release",
+        ["frequency_of_release_id"],
+        ["id"],
+    )

--- a/scripts/setup_review_app.sh
+++ b/scripts/setup_review_app.sh
@@ -26,3 +26,6 @@ display_result $? 1 "Apply migrations including any in review app PR"
 
 ./manage.py delete_all_measures_except_two_per_subtopic
 display_result $? 1 "Drop all but first two measures in each subtopic from database so rowcount < heroku limit of 10k"
+
+./manage.py refresh_materialized_views
+display_result $? 1 "Refresh materialized views"

--- a/scripts/setup_review_app.sh
+++ b/scripts/setup_review_app.sh
@@ -23,3 +23,6 @@ display_result $? 1 "Copy over db from dev/master"
 
 ./manage.py db upgrade
 display_result $? 1 "Apply migrations including any in review app PR"
+
+./manage.py delete_all_measures_except_two_per_subtopic
+display_result $? 1 "Drop all but first two measures in each subtopic from database so rowcount < heroku limit of 10k"


### PR DESCRIPTION
Databases attached to Heroku review apps can only support the default plan, which for Postgres has a 10k row limit before it starts complaining loudly and/or blocking further writes.

In order to come under this limit, we've decided to drop all except the first two measures in each subtopic, and all of those dropped measures' associated records.

This PR includes a set of updates to our models' foreign keys so that they cascade deletes to child records. Where we have join tables or foreign key constraints that don't support cascading, the related records are dropped explicitly in the management command.

The script that sets up review apps has been modified to call the new management command which handles, reasonably efficiently, dropping the records we want to get rid of.