### PR TITLE
Adjust styling on search results page

### DIFF
--- a/application/src/sass/_search_results.scss
+++ b/application/src/sass/_search_results.scss
@@ -75,13 +75,17 @@ main#main-content {
     max-width: 590px;
     line-height: 30px;
     text-decoration: none;
-    //font-weight: bold;
     color: govuk-colour("blue");
   }
 
   /* Words highlighted within title */
   .gs-title b {
-    @include govuk-font(19);
+    @include govuk-font(24, $weight: "bold");
+    height: auto;
+    max-width: 590px;
+    line-height: 30px;
+    text-decoration: none;
+    color: govuk-colour("blue");
   }
 
   /* URL at the top of each search result */
@@ -95,7 +99,7 @@ main#main-content {
     max-width: 590px;
 
     & b {
-      @include govuk-font(16);
+      @include govuk-font(16, $weight: "bold");
     }
   }
 
@@ -109,4 +113,7 @@ main#main-content {
     font-size: 16px;
   }
 
+  .gcsc-more-maybe-branding-root {
+    visibility: none;
+  }
 }


### PR DESCRIPTION
The styling on 'b' elements, which are nested within result
titles/snippets, were leaking through with plain settings. This applies
some additional styling to bring them back to a normal GOV.UK Design
System appearance.

 ## Ticket
https://trello.com/c/6MFhY5I6

 ## Before
![Screen Shot 2019-04-02 at 09 19 45](https://user-images.githubusercontent.com/2920760/55386962-7a466f80-5528-11e9-8eaa-f16f0864b8ce.png)


 ## After
![Screen Shot 2019-04-02 at 09 20 06](https://user-images.githubusercontent.com/2920760/55386979-85999b00-5528-11e9-9a42-20aafaa4b250.png)
