### PR TITLE
Consistent error messaging across the site

### DIFF
--- a/application/admin/forms.py
+++ b/application/admin/forms.py
@@ -9,7 +9,7 @@ class AddUserForm(FlaskForm):
         label="Email address",
         validators=[
             Length(min=5, max=255),
-            DataRequired(message="Can’t be empty"),
+            DataRequired(message="Enter an email address"),
             Email(message="Enter a valid email address"),
             ValidPublisherEmailAddress(),
         ],

--- a/application/admin/views.py
+++ b/application/admin/views.py
@@ -10,7 +10,7 @@ from application.auth.models import User, TypeOfUser, CAPABILITIES, MANAGE_SYSTE
 from application.cms.models import user_measure
 from application.cms.page_service import page_service
 from application.utils import create_and_send_activation_email, user_can
-from application.cms.utils import get_error_summary_data
+from application.cms.utils import get_form_errors
 
 
 @admin_blueprint.route("")
@@ -104,9 +104,7 @@ def add_user():
         create_and_send_activation_email(form.email.data, current_app)
         return redirect(url_for("admin.users"))
 
-    return render_template(
-        "admin/add_user.html", form=form, error_summary=get_error_summary_data(title="There is a problem", forms=[form])
-    )
+    return render_template("admin/add_user.html", form=form, errors=get_form_errors(forms=[form]))
 
 
 @admin_blueprint.route("/users/<int:user_id>/resend-account-activation-email")

--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -1,4 +1,5 @@
-from flask_security.forms import LoginForm as FlaskSecurityLoginForm, password_required, Required
+from flask_security.forms import LoginForm as FlaskSecurityLoginForm, Required
+from flask_security.utils import verify_password
 from flask_wtf import FlaskForm
 from wtforms.fields.html5 import EmailField
 from wtforms.validators import DataRequired
@@ -12,5 +13,18 @@ class ForgotPasswordForm(FlaskForm):
 
 
 class LoginForm(FlaskSecurityLoginForm):
-    email = RDUStringField("Email", validators=[Required(message="EMAIL_NOT_PROVIDED")])
-    password = RDUPasswordField("Password", validators=[password_required])
+    email = RDUStringField("Email", validators=[Required(message="Enter your email address")])
+    password = RDUPasswordField("Password", validators=[Required(message="Enter your password")])
+
+    def validate(self):
+        result = super().validate()
+
+        # Check for parent form's processing and override messaging so that we don't leak the existence of a specific
+        # account, which Flask-Security does by default. `user` attribute is only set if the initial validators pass,
+        # i.e. both fields have data.
+        if result is False and hasattr(self, "user"):
+            if not self.user or not self.user.password or not verify_password(self.password.data, self.user):
+                self.email.errors = ["Check your email address"]
+                self.password.errors = ["Check your password"]
+
+        return result

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -82,18 +82,24 @@ class DataSourceForm(FlaskForm):
     title = RDUStringField(
         label="Title of data source",
         hint="For example, Crime and Policing Survey",
-        validators=[RequiredForReviewValidator(), Length(max=255)],
+        validators=[RequiredForReviewValidator(message="Enter a data source title"), Length(max=255)],
     )
 
-    type_of_data = RDUCheckboxField(label="Type of data", enum=TypeOfData, validators=[RequiredForReviewValidator()])
+    type_of_data = RDUCheckboxField(
+        label="Type of data",
+        enum=TypeOfData,
+        validators=[RequiredForReviewValidator(message="Select the type of data")],
+    )
     type_of_statistic_id = RDURadioField(
-        label="Type of statistic", coerce=int, validators=[RequiredForReviewValidator("Select one", else_optional=True)]
+        label="Type of statistic",
+        coerce=int,
+        validators=[RequiredForReviewValidator("Select the type of statistic", else_optional=True)],
     )
 
     publisher_id = RDUStringField(
         label="Source data published by",
         hint="For example, Ministry of Justice",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Select a department or organisation")],
     )
     source_url = RDUURLField(
         label="Link to data source",
@@ -103,7 +109,7 @@ class DataSourceForm(FlaskForm):
             '<a href="https://www.gov.uk/government/statistics/youth-justice-annual-statistics-2016-to-2017" '
             'target="_blank" class="govuk-link">View example</a> (this will open a new page).'
         ),
-        validators=[RequiredForReviewValidator(), Length(max=255)],
+        validators=[RequiredForReviewValidator(message="Enter a link to the data source"), Length(max=255)],
     )
 
     publication_date = RDUStringField(
@@ -121,14 +127,14 @@ class DataSourceForm(FlaskForm):
         coerce=int,
         validators=[
             FrequencyOfReleaseOtherRequiredValidator(),
-            RequiredForReviewValidator("Select one", else_optional=True),
+            RequiredForReviewValidator("Select the source data publication frequency", else_optional=True),
         ],
     )
 
     purpose = RDUTextAreaField(
         label="Purpose of data source",
         hint="Explain why this data’s been collected and how it will be used",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Explain the purpose of the data source")],
     )
 
     def __init__(self, sending_to_review=False, *args, **kwargs):
@@ -156,7 +162,7 @@ class MeasureVersionForm(FlaskForm):
     db_version_id = HiddenField()
     title = RDUStringField(
         label="Title",
-        validators=[DataRequired(), Length(max=255)],
+        validators=[DataRequired(message="Enter a page title"), Length(max=255)],
         hint="For example, ‘Self-harm by young people in custody’",
     )
     internal_reference = RDUStringField(
@@ -165,16 +171,18 @@ class MeasureVersionForm(FlaskForm):
     published_at = DateField(label="Publication date", format="%Y-%m-%d", validators=[Optional()])
     time_covered = RDUStringField(
         label="Time period covered",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Enter the time period covered")],
         hint="For example, ‘2016 to 2017’, or ‘2014/15 to 2016/17’",
     )
 
-    area_covered = RDUCheckboxField(label="Areas covered", enum=UKCountry, validators=[RequiredForReviewValidator()])
+    area_covered = RDUCheckboxField(
+        label="Areas covered", enum=UKCountry, validators=[RequiredForReviewValidator(message="Enter the area covered")]
+    )
 
     lowest_level_of_geography_id = RDURadioField(
         label="Geographic breakdown",
         hint="Select the most detailed type of geographic breakdown available in the data",
-        validators=[RequiredForReviewValidator("Select one", else_optional=True)],
+        validators=[RequiredForReviewValidator(message="Select the geographic breakdown", else_optional=True)],
     )
     suppression_and_disclosure = RDUTextAreaField(
         label="Suppression rules and disclosure control (optional)",
@@ -187,14 +195,14 @@ class MeasureVersionForm(FlaskForm):
 
     summary = RDUTextAreaField(
         label="Main points",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Enter the main points")],
         hint="Summarise the main findings and highlight any serious caveats in the quality of the data",
         extended_hint="_summary.html",
     )
 
     measure_summary = RDUTextAreaField(
         label="What the data measures",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Explain what the data measures")],
         hint=(
             "Explain what the data is analysing, what’s included in categories labelled as ‘Other’ and define any "
             "terms users might not understand"
@@ -203,7 +211,7 @@ class MeasureVersionForm(FlaskForm):
 
     description = RDUTextAreaField(
         label="Description for search engines",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Enter a description for search engines")],
         hint=(
             "Choose an up‐to‐date statistic that shows a key disparity or change over time. The figure should work as "
             "a stand-alone statement and end with a full stop."
@@ -214,14 +222,14 @@ class MeasureVersionForm(FlaskForm):
 
     need_to_know = RDUTextAreaField(
         label="Things you need to know",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Explain what the reader needs to know to understand the data")],
         hint="Outline how the data was collected and explain any limitations",
         extended_hint="_things_you_need_to_know.html",
     )
 
     ethnicity_definition_summary = RDUTextAreaField(
         label="The ethnic categories used in this data",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="List the ethnic categories used in the data")],
         hint=Markup(
             "Say which ethnic groups are included in the data and why. "
             "For the most common ethnic categorisations, see the "
@@ -232,7 +240,7 @@ class MeasureVersionForm(FlaskForm):
 
     methodology = RDUTextAreaField(
         label="Methodology",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Enter the data’s methodology")],
         hint="Explain your methods in clear, simple language",
         extended_hint="_methodology.html",
     )
@@ -250,12 +258,12 @@ class MeasureVersionForm(FlaskForm):
         coerce=lambda value: None if value is None else get_bool(value),
         validators=[
             NotRequiredForMajorVersions(),
-            RequiredForReviewValidator("This field is required", else_optional=True),
+            RequiredForReviewValidator("Confirm whether this is a correction", else_optional=True),
         ],
     )
     external_edit_summary = RDUTextAreaField(
         label="Changes to previous version",
-        validators=[RequiredForReviewValidator()],
+        validators=[RequiredForReviewValidator(message="Summarise changes to the previous version")],
         hint=(
             "If you’ve corrected the data, explain what’s changed and why. Otherwise, summarise what you’ve updated "
             "(for example, ‘Updated with the latest available data’)."
@@ -297,7 +305,9 @@ class MeasureVersionForm(FlaskForm):
 
 class DimensionForm(FlaskForm):
     title = RDUStringField(
-        label="Title", hint="For example, ‘Employment by ethnicity and gender’", validators=[DataRequired()]
+        label="Title",
+        hint="For example, ‘Employment by ethnicity and gender’",
+        validators=[DataRequired(message="Enter the dimension title")],
     )
     time_period = RDUStringField(label="Time period covered", hint="For example, ‘2015/16’")
     summary = RDUTextAreaField(label="Summary", extended_hint="_dimension_summary.html")
@@ -313,7 +323,11 @@ class UploadForm(FlaskForm):
 
     guid = StringField()
     upload = FileField(label="File in CSV format", validators=[])
-    title = RDUStringField(label="Title", hint="For example, ‘Household income data’", validators=[DataRequired()])
+    title = RDUStringField(
+        label="Title",
+        hint="For example, ‘Household income data’",
+        validators=[DataRequired(message="Enter the source data title")],
+    )
     description = RDUTextAreaField(
         hint=(
             Markup(
@@ -340,7 +354,10 @@ class DimensionRequiredForm(DimensionForm):
 
 
 class NewVersionForm(FlaskForm):
-    version_type = RDURadioField(label=Markup("<b>New version type:</b>"), validators=[DataRequired()])
+    version_type = RDURadioField(
+        label=Markup("<b>New version type:</b>"),
+        validators=[DataRequired(message="Select the type of new version you are creating")],
+    )
 
     def __init__(self, measure_version: MeasureVersion, *args, **kwargs):
         super(NewVersionForm, self).__init__(*args, **kwargs)

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -293,7 +293,7 @@ class MeasureVersion(db.Model, CopyableModel):
     # relationships
     measure = db.relationship("Measure", back_populates="versions")
     lowest_level_of_geography = db.relationship("LowestLevelOfGeography", back_populates="measure_versions")
-    uploads = db.relationship("Upload", back_populates="measure_version", lazy="dynamic", cascade="all, delete-orphan")
+    uploads = db.relationship("Upload", back_populates="measure_version", cascade="all, delete-orphan")
     dimensions = db.relationship(
         "Dimension",
         back_populates="measure_version",

--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
-
+from typing import List
 
 from flask import current_app
 
@@ -9,7 +9,6 @@ from application.cms.forms import DataSourceForm
 
 @dataclass
 class ErrorSummaryMessage:
-    field: str
     text: str
     href: str
 
@@ -22,25 +21,24 @@ def copy_form_errors(from_form, to_form):
         setattr(to_form, key, field)
 
 
-def get_error_summary_data(title="Please see below errors:", forms=None, extra_non_form_errors=None):
+def get_form_errors(forms=None, extra_non_form_errors=None):
+    errors: List[ErrorSummaryMessage] = []
+
     if not forms:
         forms = []
 
     if not any(form.errors for form in forms) and not extra_non_form_errors:
-        return {}
+        return errors
 
-    error_summary_data = {"title": title, "errors": []}
     for form in forms:
         for field_name, error_message in form.errors.items():
             form_field = getattr(form, field_name)
-            error_summary_data["errors"].append(
-                ErrorSummaryMessage(field=form_field.label.text, text=error_message[0], href=f"#{form_field.id}-label")
-            )
+            errors.append(ErrorSummaryMessage(text=error_message[0], href=f"#{form_field.id}-label"))
 
     if extra_non_form_errors:
-        error_summary_data["errors"].extend(extra_non_form_errors)
+        errors.extend(extra_non_form_errors)
 
-    return error_summary_data
+    return errors
 
 
 def get_data_source_forms(request, measure_version, sending_to_review=False):

--- a/application/factory.py
+++ b/application/factory.py
@@ -33,6 +33,7 @@ from application.cms.models import TESTING_SPACE_SLUG
 from application.cms.page_service import page_service
 from application.cms.scanner_service import scanner_service
 from application.cms.upload_service import upload_service
+from application.cms.utils import get_form_errors
 from application.dashboard.trello_service import trello_service
 
 from application.static_site.filters import (
@@ -193,6 +194,7 @@ def create_app(config_object):
             TESTING_SPACE_SLUG=TESTING_SPACE_SLUG,
             get_content_security_policy=get_content_security_policy,
             current_timestamp=datetime.datetime.now().isoformat(),
+            get_form_errors=get_form_errors,
         )
 
     return app

--- a/application/templates/README.md
+++ b/application/templates/README.md
@@ -51,7 +51,7 @@ derived from the GOV.UK Design System: https://design-system.service.gov.uk/styl
                 * flashMessages
                     * Renders flash messages for the page, retrieving them from `get_flashed_messages` exposed by Flask.
                 * errorSummary
-                    * Renders an error summary for any forms on the page, populated from the `error_summary` variable.
+                    * Renders an error summary for any forms on the page, populated from the `errors` variable.
         * mainAttributes
             * A hook into additional attributes for the `main` element.
         * content

--- a/application/templates/_shared/_error_summary.html
+++ b/application/templates/_shared/_error_summary.html
@@ -3,16 +3,16 @@
   https://github.com/alphagov/govuk-frontend/blob/master/src/components/error-summary
 #}
 
-{% if error_summary and error_summary.errors %}
+{% if errors %}
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    {{ error_summary.title }}
+    There is a problem
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      {% for error in error_summary.errors %}
+      {% for error in errors %}
       <li>
-        <a href="{{ error.href }}">{{ error.field }}</a>{% if error.text %}<span> {{ error.text }}</span>{% endif %}
+        <a href="{{ error.href }}">{{ error.text }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/application/templates/_shared/_page_title.html
+++ b/application/templates/_shared/_page_title.html
@@ -1,3 +1,0 @@
-{% macro page_title(title, error=False) %}
-{{ "Error: " if error }}{{ title }}
-{%- endmacro %}

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 {% from "cms/forms.html" import render_field %}
 
 {% set breadcrumbs =
@@ -11,7 +10,7 @@
   ]
 %}
 
-{% block pageTitle %}{{ page_title("Add user", error=(form.errors|length) > 0) }}{% endblock %}
+{% block pageTitle %}Add user{% endblock %}
 {% block bodyClasses %}rd_cms{% endblock %}
 
 {% block content %}

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -8,7 +8,7 @@
   <!-- Page built at {{ current_timestamp }} -->
 
   <meta charset="utf-8" />
-  <title>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+  <title>{% if errors %}Error: {% endif %}{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c" />
 

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% from "cms/forms.html" import render_field %}
 
-{% from "_shared/_page_title.html" import page_title %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 
 {% set form_disabled = measure_version.status != 'DRAFT' %}
@@ -15,7 +14,7 @@
 
 {% block bodyClasses %}rd_cms{% endblock %}
 
-{% block pageTitle %}{{ page_title("Create dimension", error=(form.errors|length > 0) )}}{% endblock %}
+{% block pageTitle %}Create dimension{% endblock %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 
 {% set breadcrumbs =
   [
@@ -10,7 +9,7 @@
 %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ page_title("Add the source data", error=(form.errors|length > 0) ) }}{% endblock %}
+{% block pageTitle %}Add the source data{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/application/templates/cms/delete_page.html
+++ b/application/templates/cms/delete_page.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 
 {% set breadcrumbs =
   [
@@ -10,7 +9,7 @@
 %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}Delete pa{% endblock %}ge
+{% block pageTitle %}Delete page{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -1,6 +1,5 @@
 {% extends "cms/create_dimension.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 
 {% set breadcrumbs =
   [
@@ -10,7 +9,7 @@
 %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ page_title("Edit dimension", error=(form.errors|length > 0) )}}{% endblock %}
+{% block pageTitle %}Edit dimension{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 {% from "_shared/_status_banner_macro.html" import status_banner %}
 {% from "cms/_data_source_form.html" import render_data_source_form %}
 
@@ -12,7 +11,7 @@
 {% set form_disabled = not (measure_version.status == "DRAFT" or new) %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ page_title(measure_version.title, error=(form.errors|length > 0)) }}{% endblock %}
+{% block pageTitle %}{{ measure_version.title }}{% endblock %}
 
 {% block content %}
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure', topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}{% else %}{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}{% endif %}">
@@ -272,7 +271,7 @@
                 <div class="govuk-form-group {% if data_not_uploaded_error %}govuk-form-group--error{% endif %}">
                     <h3 class="govuk-heading-m" id="source-data">Data</h3>
                     {% if data_not_uploaded_error %}
-                        <span class="govuk-error-message">Source data must be uploaded.</span>
+                        <span class="govuk-error-message">Upload the source data</span>
                     {% endif %}
                     {% if measure_version.uploads %}
                         <table class="govuk-table govuk-!-font-size-16">

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "_shared/_page_title.html" import page_title %}
 
 {% set breadcrumbs =
   [
@@ -11,7 +10,7 @@
 {% set form_disabled = not (measure_version.status == "DRAFT" or new) %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ page_title("Edit source data", error=(form.errors|length > 0) ) }}{% endblock %}
+{% block pageTitle %}Edit source data{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/application/templates/security/login_user.html
+++ b/application/templates/security/login_user.html
@@ -1,24 +1,16 @@
 {% extends "base.html" %}
 
 {% set breadcrumbs = none %}
+{% set errors = get_form_errors(forms=[login_user_form, ]) %}
 
-{% block pageTitle %}Login{% endblock %}
+{# We have to manually add the `Error: ` prefix to the pageTitle here as we don't have control over the context that
+this template receives, so can't make sure it's rendered with the `errors` variable from the start. Because `Error: `
+is added in the base template, the {% set errors %} above isn't in scope when the base template is rendered, so the
+prefix does not get added there. #}
+
+{% block pageTitle %}{% if errors %}Error: {% endif %}Login{% endblock %}
 {% block nav_home %}active{% endblock %}
 {% block bodyClasses %}rd_cms{% endblock %}
-
-{% block flashMessages %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            {% if login_user_form.errors %}
-                <div class="govuk-error-summary govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
-                    <div class="govuk-error-summary__body">
-                        <p>Make sure you've entered the right email address and password. If you've forgotten your password you can reset it by clicking 'Forgotten password'</p>
-                    </div>
-                </div>
-            {% endif %}
-        </div>
-    </div>
-{% endblock %}
 
 {% block content %}
         <div class="govuk-grid-row">

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -415,12 +415,12 @@ class TestPageService:
     def test_create_new_minor_version_duplicates_uploads(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)
         measure_version = MeasureVersionFactory(latest=True)
-        assert measure_version.uploads.count() == 1
+        assert len(measure_version.uploads) == 1
         original_upload = measure_version.uploads[0]
 
         new_version = page_service.create_measure_version(measure_version, NewVersionType.MINOR_UPDATE, user=user)
 
-        assert new_version.uploads.count() == 1
+        assert len(new_version.uploads) == 1
         new_upload = new_version.uploads[0]
         assert new_upload.guid != original_upload.guid
         assert new_upload.file_name == original_upload.file_name
@@ -433,8 +433,8 @@ class TestPageService:
 
         new_version = page_service.create_measure_version(measure_version, NewVersionType.MAJOR_UPDATE, user=user)
 
-        assert measure_version.uploads.count() == 1
-        assert new_version.uploads.count() == 0
+        assert len(measure_version.uploads) == 1
+        assert len(new_version.uploads) == 0
 
     def test_create_copy_of_page(self):
         user = UserFactory(user_type=TypeOfUser.RDU_USER)

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -108,7 +108,7 @@ def test_can_not_send_to_review_without_a_data_source_uploaded(test_app_client, 
     )
     assert response.status_code == 400
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    assert "Data Source data must be uploaded." in page.find("div", class_="govuk-error-summary").text
+    assert "Upload the source data" in page.find("div", class_="govuk-error-summary").text
 
 
 @pytest.mark.parametrize("cannot_reject_status", ("DRAFT", "APPROVED"))
@@ -639,7 +639,7 @@ def test_dept_user_should_be_able_to_delete_upload_from_shared_page(test_app_cli
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert page.find("div", class_="eff-flash-message__body").get_text(strip=True) == "Deleted upload ‘upload title’"
-    assert len(measure_version.uploads.all()) == 0
+    assert len(measure_version.uploads) == 0
 
 
 def test_dept_user_should_not_be_able_to_edit_upload_if_page_not_shared(

--- a/tests/functional/test_cms_measure_lifecycle.py
+++ b/tests/functional/test_cms_measure_lifecycle.py
@@ -112,7 +112,7 @@ def test_create_a_measure_as_editor(driver, live_server, government_departments,
     measure_edit_page.click_save_and_send_to_review()
 
     # THEN we get validation errors (corrections radio+edit summary)
-    assert "Cannot submit for review" in driver.page_source
+    assert "There is a problem" in driver.page_source
 
     # WHEN we fill in the required data
     measure_edit_page.fill_measure_page_minor_edit_fields(sample_measure_version)
@@ -138,7 +138,7 @@ def test_create_a_measure_as_editor(driver, live_server, government_departments,
     measure_edit_page.click_save_and_send_to_review()
 
     # THEN we get validation errors (edit summary)
-    assert "Cannot submit for review" in driver.page_source
+    assert "There is a problem" in driver.page_source
 
     # WHEN we add an upload file
     measure_edit_page.click_add_source_data()


### PR DESCRIPTION
Add custom error messages for all of our form fields that have required
inputs. This allows us to use the GOV.UK Design System error summary
component in the recommended way, as per the link below.

https://design-system.service.gov.uk/components/error-summary/

Rather than listing the field name as a link, next to a default error
message ("This field is required"), we now tell the user exactly what
action they need to take, and the entire message is a link to the field
that needs correcting.

All pages with form errors should now correctly render the `Error: `
prefix in the page title.

The login page needed extra work to get all of the form errors passed
through correctly for the summary. This is because the authentication
process is mostly handled through Flask-Security, which provides limited
hooks for adding extra context variables. You can provide a context
processor, but it doesn't have access to the other context (the forms),
so extracting the form summaries in Python, rather than Jinja, is
infeasible. This leads to some slightly wonky work inside the
`login_user.html` template, whereby we duplicate the `Error: ` page
title prefix logic.

 ## Ticket
https://trello.com/c/jzyzzyjZ

 ## Extreme example (old)
![Screen Shot 2019-04-02 at 18 51 47](https://user-images.githubusercontent.com/2920760/55424553-6e829980-5578-11e9-9667-7a9bc2596f8d.png)


 ## Extreme example (new)
![Screen Shot 2019-04-02 at 18 54 47](https://user-images.githubusercontent.com/2920760/55424731-d0430380-5578-11e9-8ac6-d65ffbed7450.png)
