### PR TITLE
BUGFIX: Previous version links not displaying

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -677,7 +677,7 @@
               Previous {{ "editions" if version_count > 1 else "edition" }}:
 
               <ol class="govuk-list">
-                {% for page_version in versions %}
+                {% for page_version in measure_version.previous_major_versions %}
                     <li>
                         <a class="govuk-link" href="{{ url_for('static_site.measure_version',
                             topic_slug=topic_slug,

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -751,15 +751,6 @@ def test_previous_version_adds_noindex_for_robots(test_app_client, logged_in_adm
 
 
 class TestMeasurePage:
-    """
-    This class includes a set of tests that check download links for source data of a measure page.
-    Unfortunately, without a refactor of how dimensions are passed into the measure page template, we aren't
-    able to test how the static site renders these links. The static site builder passes in a specially-formatted
-    set of dimensions that aren't available in 'static-mode style requests' to the CMS.
-
-    Tech improvement ticket: https://trello.com/c/U4rMSk0w/70
-    """
-
     @pytest.mark.parametrize(
         "static_mode, expected_url",
         (

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -845,6 +845,56 @@ class TestMeasurePage:
         assert len(data_links) == 1
         assert data_links[0].attrs["href"] == expected_url
 
+    def test_later_version_shows_links_to_earlier_versions(self, test_app_client, logged_in_admin_user):
+        # GIVEN a page with a later published version
+        measure = MeasureFactory()
+        # Published version 1.0
+        measure_1_0 = MeasureVersionFactory(
+            measure=measure, status="APPROVED", latest=False, version="1.0", published_at=datetime.datetime(2018, 3, 29)
+        )
+        # Published version 1.1
+        measure_1_1 = MeasureVersionFactory(
+            measure=measure, status="APPROVED", latest=False, version="1.1", published_at=datetime.datetime(2019, 3, 29)
+        )
+        # Latest published version 2.0
+        measure_2_0 = MeasureVersionFactory(measure=measure, status="APPROVED", latest=True, version="2.0")
+
+        measure_1_0_url = url_for(
+            "static_site.measure_version",
+            topic_slug=measure_1_0.measure.subtopic.topic.slug,
+            subtopic_slug=measure_1_0.measure.subtopic.slug,
+            measure_slug=measure_1_0.measure.slug,
+            version=measure_1_0.version,
+        )
+        measure_1_1_url = url_for(
+            "static_site.measure_version",
+            topic_slug=measure_1_1.measure.subtopic.topic.slug,
+            subtopic_slug=measure_1_1.measure.subtopic.slug,
+            measure_slug=measure_1_1.measure.slug,
+            version=measure_1_1.version,
+        )
+        measure_2_0_url = url_for(
+            "static_site.measure_version",
+            topic_slug=measure_2_0.measure.subtopic.topic.slug,
+            subtopic_slug=measure_2_0.measure.subtopic.slug,
+            measure_slug=measure_2_0.measure.slug,
+            version=measure_2_0.version,
+        )
+
+        # WHEN we get the latest measure page
+        resp = test_app_client.get(measure_2_0_url)
+
+        # THEN it should contain a link to the latest minor version of the earlier published version
+        assert resp.status_code == 200
+        page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+        measure_1_1_links = page.find_all("a", attrs={"href": measure_1_1_url})
+        assert len(measure_1_1_links) == 1
+        assert measure_1_1_links[0].text == "29 March 2019"
+
+        # AND should not contain a link to the superseded earlier version
+        measure_1_0_links = page.find_all("a", attrs={"href": measure_1_0_url})
+        assert len(measure_1_0_links) == 0
+
 
 class TestCorrections:
     def setup(self):


### PR DESCRIPTION
Fixes this bug:
https://trello.com/c/xvU1rOWt/1457-links-to-previous-editions-are-not-listed-on-measure-page

As part of a recent refactor we stopped passing in `versions` explicitly and instead reference `measure_version.previous_major_versions` directly.

But we missed this one occurrence of `versions` in the template.