### PR TITLE
Delete "None" values from measure reference field

### DIFF
--- a/scripts/data_migrations/2019-04-04_purge-None-strings-from-reference.sql
+++ b/scripts/data_migrations/2019-04-04_purge-None-strings-from-reference.sql
@@ -1,0 +1,3 @@
+UPDATE measure
+SET reference = NULL
+WHERE reference = 'None';


### PR DESCRIPTION
14 of these crept in as the result of a recent bug. This will tidy them
up now the bug is fixed. (Needs to be run after #1029 has shipped).