### PR TITLE
Prevent 500 on login attempt with bad password

### DIFF
--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -23,7 +23,7 @@ class LoginForm(FlaskSecurityLoginForm):
         # account, which Flask-Security does by default. `user` attribute is only set if the initial validators pass,
         # i.e. both fields have data.
         if result is False and hasattr(self, "user"):
-            if not self.user or not self.user.password or not verify_password(self.password.data, self.user):
+            if not self.user or not self.user.password or not verify_password(self.password.data, self.user.password):
                 self.email.errors = ["Check your email address"]
                 self.password.errors = ["Check your password"]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from lxml import html
 from application.cms.models import MeasureVersion
 
 
@@ -19,3 +20,13 @@ def get_page_with_title(title):
 
 def assert_strings_match_ignoring_whitespace(string_1, string_2):
     assert "".join(string_1.split()) == "".join(string_2.split())
+
+
+def page_displays_error_matching_message(response, message: str) -> bool:
+    doc = html.fromstring(response.get_data(as_text=True))
+
+    error_summary = doc.xpath(
+        "//div[contains(@class, 'govuk-error-summary')]//a[normalize-space(text())=$message]", message=message
+    )
+
+    return True if error_summary else False


### PR DESCRIPTION
Fix a bug that caused 500s when logging in with the wrong password and
add a test that validates the expected behaviour (page returns a 200 and
displays error summary messages asking the user to check their email
address and password).