### PR TITLE
Fix chart downloads on IE11

### DIFF
--- a/application/src/js/all/vendor/polyfills/find.js
+++ b/application/src/js/all/vendor/polyfills/find.js
@@ -1,0 +1,46 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    },
+    configurable: true,
+    writable: true
+  });
+}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -307,11 +307,7 @@
                   {% endif %}
 
                     {% if chart_and_downloadable %}
-                        <p class="chart-download">
-                            <a class="govuk-link download-png" href="#" data-on="click" data-event-category="Image downloaded" data-event-action="Image of the chart" data-event-label="{{ dimension.dimension_chart.chart_object.title.text }}" class="download-png"
-                               id="download-{{ dimension.guid }}" data-title="{{ dimension.dimension_chart.chart_object.title.text }}">
-                                Download chart (PNG)
-                            </a>
+                        <p class="chart-download chart-download-link-container" data-chart-guid="{{ dimension.guid }}" data-chart-title="{{ dimension.dimension_chart.chart_object.title.text }}">
                         </p>
                     {% endif %}
                 </div>
@@ -746,6 +742,24 @@
     for (var i=0, chart_div; chart_div = chart_divs[i]; i++) {
         chart_div.classList.remove('hidden');
     };
+
+    if ($() && typeof($().highcharts) === 'function') {
+        var chartDownloadLinkContainers = document.getElementsByClassName('chart-download-link-container');
+        for (var i = 0, chartDownloadLinkContainer; chartDownloadLinkContainer = chartDownloadLinkContainers[i]; i++) {
+            var link = document.createElement('a');
+            link.id = 'download-' + chartDownloadLinkContainer.getAttribute('data-chart-guid');
+            link.href = '#';
+            link.className = 'govuk-link download-png';
+            link.setAttribute('data-on', 'click');
+            link.setAttribute('data-event-category', 'Image downloaded');
+            link.setAttribute('data-event-action', "Image of the chart");
+            link.setAttribute('data-event-label', chartDownloadLinkContainer.getAttribute('data-chart-title'));
+            link.setAttribute('data-title', chartDownloadLinkContainer.getAttribute('data-chart-title'));
+            link.text = 'Download chart (PNG)';
+            chartDownloadLinkContainer.appendChild(link);
+        }
+        ;
+    }
 
     $('.download-png').click(function(evt){
         var dimensionGuid = $(evt.currentTarget).attr('id').replace('download-', ''),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,5 +145,5 @@ gulp.task('make', gulp.parallel('copy-govuk-frontend-assets', 'copy-static', 'ma
 gulp.task('default', gulp.series('make'));
 
 gulp.task('watch', function () {
-  gulp.watch(['./application/src/js/**/*.js', './application/src/sass/*.scss', './application/src/sass/**/*.scss'], gulp.series('make'));
+  gulp.watch(['./application/src/js/**/*.js', './application/src/sass/*.scss', './application/src/sass/**/*.scss', './gulpfile.js'], gulp.series('make'));
 });


### PR DESCRIPTION
Chart download links currently do not work on IE11 due to the absence of
the `Array.find` prototype method. Adding this polyfill brings support
back for chart downloads on IE11.

Two additional changes:
* updates the gulpfile's `watch` task so that it re-builds assets when the gulpfile itself changes.
* start with 'Download chart' link hidden, which is then revealed by JavaScript.

 ## Ticket
https://trello.com/c/kfP1uD2E/1477-chart-download-link-broken-on-ie11-1