### PR TITLE
Reduce radius of circles on publications line chart

### DIFF
--- a/application/templates/dashboards/graphs.html
+++ b/application/templates/dashboards/graphs.html
@@ -12,7 +12,7 @@
 {% macro render_value_circles(values, x_scale, y_scale, graph_height, colour="#2B8CC4", start_index=0) %}
   {% set start_index_scaled = (start_index * x_scale) %}
   {% for value in values[start_index:] %}
-    <circle cx="{{ (loop.index0 * x_scale) + start_index_scaled + 0.5 }}" cy="{{ graph_height - (value * y_scale) }}" r="4" fill="{{ colour }}" />
+    <circle cx="{{ (loop.index0 * x_scale) + start_index_scaled + 0.5 }}" cy="{{ graph_height - (value * y_scale) }}" r="3" fill="{{ colour }}" />
   {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
Now that there are so many points on this charts, it's become impossible to see the actual lines.

This reduces the radius of the circles so that the line (and trend) is easier to see again.

Before:

<img width="976" alt="Screenshot 2019-04-12 at 09 40 24" src="https://user-images.githubusercontent.com/30665/56024102-3eb95b80-5d07-11e9-885c-36a129251f16.png">

After:

<img width="971" alt="Screenshot 2019-04-12 at 09 40 35" src="https://user-images.githubusercontent.com/30665/56024109-437e0f80-5d07-11e9-89c6-66038faed80e.png">
