### PR TITLE
Fix skip to main content link

### DIFF
--- a/application/templates/static_site/index.html
+++ b/application/templates/static_site/index.html
@@ -21,26 +21,27 @@
 {% endblock %}
 
 {% block main %}
-<div class="hero-container">
-  <div class="hero">
-    <div class="hero-inner">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">
-                Ethnicity facts and figures
-            </h1>
-            <p class="govuk-body">87% of people in the UK are White, and 13% belong to a Black, Asian, Mixed or Other ethnic group, according to the combined 2011 censuses for England and Wales, Scotland, and Northern Ireland.</p>
+<main id="main-content">
 
-            <p class="govuk-body">Use this service to find information about the different experiences of people from a variety of ethnic backgrounds. It gathers data collected by government in one place, making it available to the public, specialists and charities.</p>
+  <div class="hero-container">
+    <div class="hero">
+      <div class="hero-inner">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+              <h1 class="govuk-heading-xl">
+                  Ethnicity facts and figures
+              </h1>
+              <p class="govuk-body">87% of people in the UK are White, and 13% belong to a Black, Asian, Mixed or Other ethnic group, according to the combined 2011 censuses for England and Wales, Scotland, and Northern Ireland.</p>
 
+              <p class="govuk-body">Use this service to find information about the different experiences of people from a variety of ethnic backgrounds. It gathers data collected by government in one place, making it available to the public, specialists and charities.</p>
+
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="govuk-width-container">
-<main id="content">
+  <div class="govuk-width-container">
     <div class="govuk-grid-row" id="topic-section">
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-m">
@@ -80,7 +81,7 @@
 
     {% include 'static_site/_newsletter-sign-up.html' %}
 
-</main>
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This fixes the "skip to main content" link by updating ID from `content` to `main-content`.

It also moves the `<main>` element so that it includes the 'hero' section (ie the blue bit).

See https://trello.com/c/dDXQpInK/1459-skip-to-main-content-link-is-broken-on-site-homepage-1