### PR TITLE
Revert "Fix: only add buttons to fixed table header"

### DIFF
--- a/application/src/js/all/_sortable_table.js
+++ b/application/src/js/all/_sortable_table.js
@@ -26,11 +26,7 @@ SortableTable.prototype.setupOptions = function(options) {
 
 SortableTable.prototype.createHeadingButtons = function() {
 
-  if (this.header_table) {
-    var header_rows = this.header_table.querySelectorAll('thead tr')
-  } else {
-    var header_rows = this.table.querySelectorAll('thead tr')
-  }
+  var header_rows = this.table.querySelectorAll('thead tr')
 
   for (var j = 0; j < header_rows.length; j++) {
 
@@ -43,6 +39,28 @@ SortableTable.prototype.createHeadingButtons = function() {
             this.createHeadingButton(heading, i);
         }
     }
+
+  };
+
+  if (this.header_table) {
+
+    var header_rows = this.header_table.querySelectorAll('thead tr')
+
+    for (var j = 0; j < header_rows.length; j++) {
+
+
+      var headings = header_rows[j].querySelectorAll('th')
+      var heading;
+
+      for(var i = 0; i < headings.length; i++) {
+          heading = headings[i];
+          if(heading.getAttribute('aria-sort')) {
+              this.createHeadingButton(heading, i);
+          }
+      }
+
+
+    };
 
 
   }


### PR DESCRIPTION
Reverts racedisparityaudit/ethnicity-facts-and-figures-publisher#1036

This change was sat on staging on Friday when we needed to ship the changes to allow unpublishing a measure.  It has caused the following issue in tables:

![Screenshot from 2019-04-15 13-44-58](https://user-images.githubusercontent.com/6525554/56133619-ba740c00-5f84-11e9-999d-19cb55e618ea.png)

So reverting for now to get them looking good again.