### PR TITLE
Fix `db_version_id` tracking on measure versions

### DIFF
--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -1,9 +1,11 @@
 from flask_wtf import FlaskForm
 from flask import abort
 from markupsafe import Markup
-from wtforms import StringField, TextAreaField, FileField, HiddenField
+from wtforms import StringField, TextAreaField, FileField, IntegerField
 from wtforms.fields.html5 import DateField
 from wtforms.validators import DataRequired, Optional, ValidationError, Length, StopValidation, InputRequired
+
+from wtforms.widgets import HiddenInput
 
 from application.form_fields import RDUCheckboxField, RDURadioField, RDUStringField, RDUURLField, RDUTextAreaField
 from application.cms.models import (
@@ -159,7 +161,7 @@ class MeasureVersionForm(FlaskForm):
                 field.errors[:] = []
                 raise StopValidation()
 
-    db_version_id = HiddenField()
+    db_version_id = IntegerField(widget=HiddenInput())
     title = RDUStringField(
         label="Title",
         validators=[DataRequired(message="Enter a page title"), Length(max=255)],

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -359,15 +359,11 @@ class PageService(Service):
         if status is not None:
             measure_version.status = status
 
-        title = measure_version_form.data.pop("title").strip()
-        measure_version.title = title
         if measure_version.version == "1.0":
-            slug = slugify(title)
+            slug = slugify(measure_version_form.title.data)
 
             if slug != measure_version.measure.slug and self._new_slug_invalid(measure_version, slug):
-                message = (
-                    f"A page '{title}' with slug '{slug}' already exists under {measure_version.measure.subtopic.title}"
-                )
+                message = f"A page with slug '{slug}' already exists under {measure_version.measure.subtopic.title}"
                 raise PageExistsException(message)
             measure_version.measure.slug = slug
 

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -313,8 +313,13 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
             diffs = _diff_updates(measure_version_form, measure_version)
             if diffs:
                 flash("Your update will overwrite the latest content. Resolve the conflicts below", "error")
+
+                # Need to manually update the `db_version_id`, otherwise when the form is re-submitted it will just
+                # throw the same error.
+                measure_version_form.db_version_id.raw_data = [str(measure_version.db_version_id)]
             else:
                 flash("Your update will overwrite the latest content. Reload this page", "error")
+
         except PageUnEditable as e:
             current_app.logger.info(e)
             flash(str(e), "error")

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -482,7 +482,7 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
             )
 
             # If the page was saved before sending to review form's db_version_id will be out of sync, so update it
-            measure_version_form.db_version_id.data = measure_version.db_version_id
+            measure_version_form.db_version_id.raw_data = [str(measure_version.db_version_id)]
 
             data_source_form, data_source_2_form = get_data_source_forms(request, measure_version=measure_version)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -269,7 +269,13 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     published_by = factory.Maybe("published", yes_declaration=factory.SelfAttribute("_publisher.email"))
     unpublished_at = factory.Maybe("_unpublished", yes_declaration=Faker().past_date(start_date="-7d"))
     unpublished_by = factory.Maybe("_unpublished", yes_declaration=factory.SelfAttribute("_unpublisher.email"))
-    db_version_id = factory.Sequence(lambda x: x)
+
+    # We probably don't want to fake this attribute, as it is tied into a system that SQLAlchemy manages for us,
+    # providing automatic version counting when UPDATE statements are issued against the row. If you try to set it
+    # to anything other than `1` when creating an instance through the factory, SQLAlchemy resets it to 1 anyway.
+    # So allowing it to be faked will probably be more confusing than useful.
+    # db_version_id = factory.Sequence(lambda x: x)
+
     title = factory.Faker("sentence", nb_words=6)
     summary = factory.Faker("sentence", nb_words=10)
     need_to_know = factory.Faker("paragraph", nb_sentences=3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 from lxml import html
+from werkzeug.datastructures import ImmutableMultiDict
+
 from application.cms.models import MeasureVersion
 
 
@@ -30,3 +32,26 @@ def page_displays_error_matching_message(response, message: str) -> bool:
     )
 
     return True if error_summary else False
+
+
+def multidict_from_measure_version_and_kwargs(measure_version: MeasureVersion, **kwargs) -> ImmutableMultiDict:
+    return ImmutableMultiDict(
+        {
+            "title": measure_version.title,
+            "measure_summary": measure_version.measure_summary,
+            "summary": measure_version.summary,
+            "lowest_level_of_geography": measure_version.lowest_level_of_geography_id,
+            "area_covered": [area_covered.name for area_covered in measure_version.area_covered],
+            "time_covered": measure_version.time_covered,
+            "need_to_know": measure_version.need_to_know,
+            "ethnicity_definition_summary": measure_version.ethnicity_definition_summary,
+            "related_publications": measure_version.related_publications,
+            "methodology": measure_version.methodology,
+            "suppression_and_disclosure": measure_version.suppression_and_disclosure,
+            "estimation": measure_version.estimation,
+            "qmi_url": measure_version.qmi_url,
+            "further_technical_information": measure_version.further_technical_information,
+            "db_version_id": measure_version.db_version_id,
+            **kwargs,
+        }
+    )


### PR DESCRIPTION
# Summary
At some point in the past - presumably during the data model refactor - `db_version_id` stopped working because of how we populate `measure_version` instances with form data. This PR fixes this bug, adds some tests, and prevents users from submitting resolved conflicts correctly.

## Add a test to detect db_version_id increment (commit 1)
We have a column on our MeasureVersion model that is meant to track the
number of updates applied to each row. This helps us identify when two
users are editing a measure at the same time. If both users load the
same version of the measure, and then they both save some changes
sequentially, the later update risks overwriting the earlier update. By
tracking each saved version, we can detect when a save might overwrite
changes, and play the changes back to the end user, giving them an
opportunity to rationalise their changeset with the other person's.

Unfortunately db_version_id has not been incrementing correctly, and we
had no test coverage to warn us. This test should provide confidence in
the future that this functionality works.

## Fix db_version_id tracking (commit 2)
A combination of factors led to the loss of an auto-incremented
`db_version_id`, mostly centred around the move to manually populating
each field on the model from the form to use
`form.populate_obj(model_instance)`.

The WTForm field for `db_version_id` was a `HiddenField`, which uses
string types. `db_version_id` on the database is an integer field. When
populating a numeric string into the SQLAlchemy model instance, upon
save, the version is not incremented (but the numeric-string is
automatically cast to an int, so no error is thrown). By switching to an
`IntegerField` in WTForms (using a hidden widget, so that it isn't
visible on the page)`, we get the value cast to a Python int
automatically. When this is injected into the model instance, and
flushed to the database, it *does* get incremented properly.

With just that update in place, `db_version_id` started get incremented
again. But on some of the tests, it would be incremented *twice*. It
turns out that this is because we were manually assigning the title to
the measure version, then running some queries to check whether the slug
needed updating, which caused an implicit flush to the database, saving
the new title and incrementing the ID. After this check, we then
populated the rest of the fields to the measure version and updated it
again, which bumped `db_version_id` for a second time. Given that the
title is already injected into the measure version by the second stage,
we can safely remove the initial manual set.

## Test conflicting updates (commit 3)
We were missing a test that validates the user experience when two users
are updating the same measure around the same time. If user one and two
are both working on the same measure, and user one saves it, when user
two comes to save it they should be presented with a validation screen
that displays the diff between user one's changes and their own. They
can then manually perform a merge to bring the measure back to an ideal
state.

When the user is presented with a set of diffs, the new `db_version_id`
needs to be injected into the page so that a subsequent save will not
keep presenting the same errors.

## Don't fake `db_version_id` (commit 4)
This column is hooked into SQLAlchemy, and we rely on it for tracking
changes to our model. If we fake it, we risk not knowing when this
breaks. It also isn't easy to fake, as SQLAlchemy can overwrite what you
specify through FactoryBoy with its own version of the truth (e.g. upon
initial creation, where it's always set to 1).

## Ticket
https://trello.com/c/eXCUGoTs