### PR TITLE
Convert div to h1

### DIFF
--- a/application/templates/dashboards/planned_pages.html
+++ b/application/templates/dashboards/planned_pages.html
@@ -11,9 +11,9 @@
 
 {% block content %}
     <div class="progress">
-        <div class="progress__title govuk-heading-xl">
+        <h1 class="progress__title govuk-heading-xl">
             Planned pages
-        </div>
+        </h1>
         <div class="govuk-body">
             The dashboard shows what we are planning to publish and which new pages or updated versions we are working on now. You can also find out what we have <a class="govuk-link" href="{{ url_for('dashboards.whats_new') }}">recently published</a>.
         </div>


### PR DESCRIPTION
As part of the accessibility audit, we noticed that the planned pages
dashboard had no `h1` element (instead using a div with the heading
styles attached). People using screen readers often navigate by
headings, which would be more difficult if they stumbled across this
page.

 ## Ticket
https://trello.com/c/8ytTkZqN