### PR TITLE
Fix styling of password form fields

### DIFF
--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -1,15 +1,21 @@
 from flask_security.forms import LoginForm as FlaskSecurityLoginForm, Required
 from flask_security.utils import verify_password
 from flask_wtf import FlaskForm
-from wtforms.fields.html5 import EmailField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Email
 
-from application.form_fields import RDUStringField, RDUPasswordField
+from application.form_fields import RDUStringField, RDUPasswordField, RDUEmailField, ValidPublisherEmailAddress
 
 
 class ForgotPasswordForm(FlaskForm):
-    email = EmailField("Email address", validators=[DataRequired()])
-    # TODO ? validation error if not gov.uk email?
+    email = RDUEmailField(
+        "Email address",
+        hint="Enter the email address you login with",
+        validators=[
+            DataRequired(message="Enter an email address"),
+            Email(message="Enter a valid email address"),
+            ValidPublisherEmailAddress(),
+        ],
+    )
 
 
 class LoginForm(FlaskSecurityLoginForm):

--- a/application/register/forms.py
+++ b/application/register/forms.py
@@ -1,11 +1,11 @@
 from flask_wtf import FlaskForm
-from wtforms import PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo
+
+from application.form_fields import RDUPasswordField
 
 
 class SetPasswordForm(FlaskForm):
-
-    password = PasswordField(
+    password = RDUPasswordField(
         "Password",
         validators=[
             DataRequired(message="Please enter a password"),
@@ -13,7 +13,7 @@ class SetPasswordForm(FlaskForm):
         ],
     )
 
-    confirm_password = PasswordField(
+    confirm_password = RDUPasswordField(
         "Confirm password",
         validators=[
             DataRequired(message="Please confirm your new password"),

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
-{% from "cms/forms.html" import render_field %}
 
 {% set breadcrumbs =
   [

--- a/application/templates/auth/forgot_password.html
+++ b/application/templates/auth/forgot_password.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "cms/forms.html" import render_field %}
 
 {% set breadcrumbs = none %}
 

--- a/application/templates/auth/forgot_password.html
+++ b/application/templates/auth/forgot_password.html
@@ -17,9 +17,7 @@
             </p>
             <form action="{{ url_for('auth.forgot_password') }}" method="POST">
                 {{ form.csrf_token }}
-                {{ render_field(form.email,
-                                label_class='govuk-label--s',
-                                hint='Enter the email address you login with') }}
+                {{ form.email }}
 
                 <button type="submit" class="govuk-button" name="send-reset-email">Send reset email</button>
             </form>

--- a/application/templates/auth/reset_password.html
+++ b/application/templates/auth/reset_password.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "cms/forms.html" import render_field %}
 
 {% set breadcrumbs = none %}
 

--- a/application/templates/auth/reset_password.html
+++ b/application/templates/auth/reset_password.html
@@ -13,8 +13,9 @@
 
             <form action="{{ url_for('auth.reset_password', token=token) }}" method="POST">
                 {{ form.csrf_token }}
-                {{ render_field(form.password) }}
-                {{ render_field(form.confirm_password) }}
+                {{ form.password }}
+                {{ form.confirm_password }}
+
                 <button type="submit" class="govuk-button" name="update-password">Update password</button>
             </form>
         </div>

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "cms/forms.html" import render_field %}
 
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 

--- a/application/templates/cms/forms.html
+++ b/application/templates/cms/forms.html
@@ -1,31 +1,3 @@
-{% macro render_field(field, disabled=False, label_class=None, class="", hint=None, diffs={}) -%}
-  {# Deprecated - use a custom RDU form field (e.g. RDUTextField) and render directly with `{{ form.field }}` in a jinja template #}
-
-    {% if label_class %}
-        {{ field.label(class=label_class) }}
-    {% else %}
-        {{ field.label }}
-    {% endif %}
-
-    {% if field.errors %}
-        <span class="error-message">{{ field.errors[0] }}</span>
-        {{ field(class="error " + class) }}
-        {% if diffs %}
-            <p>Your update to "{{ field.label.text }}" is highlighted green
-                and possible deletions are highlighted red. If these changes are fine,
-                save the page, otherwise edit the copy above and then save.</p>
-            <div class="differences">
-                {{ diffs[field.name] | render_markdown }}
-            </div>
-        {% endif %}
-    {% else %}
-        {% if hint %}
-            <span class="govuk-hint">{{ hint }}</span>
-        {% endif %}
-        {{ field(disabled=disabled, class=class) }}
-    {% endif %}
-{%- endmacro %}
-
 {% macro render_department_select(label,
                                   form_field,
                                   current_selected_id,

--- a/application/templates/register/set_account_password.html
+++ b/application/templates/register/set_account_password.html
@@ -12,8 +12,8 @@
                 <p class="govuk-body">Your user name: {{ user.email }}</p>
                 <form class="form"  action="{{url_for('register.confirm_account', token=token)}}" method="POST">
                     {{ form.csrf_token }}
-                    <div>{{ render_field(form.password) }}</div>
-                    <div>{{ render_field(form.confirm_password) }}</div>
+                    {{ form.password }}
+                    {{ form.confirm_password }}
                     <button type="submit" class="govuk-button" name="set">Set password</button>
                 </form>
             </div>

--- a/application/templates/register/set_account_password.html
+++ b/application/templates/register/set_account_password.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "cms/forms.html" import render_field %}
 
 {% set breadcrumbs = none %}
 


### PR DESCRIPTION
## Update forgot password to RDU form
When we transitioned to the GOV.UK Design System it looks like we forgot
to update the styles for the 'Forgot password' page. This patch converts
the form to use our internal RDU form fields, which are set up to render
GOV.UK Design System elements.

## Update other password forms to RDU fields
While doing the 'Forgot password' page I also noticed that the other
password-related forms were not using the RDU fields, so I've converted
those as well. The `SetPasswordForm` form covers both resetting a
password if the user has forgotten it, as well as setting the password
upon initial account creation.

## Remove unused macro
Now that we are almost exclusively using RDU form fields, we don't need
the custom Jinja macro that renders generic WTForm fields according to
our (old) styles, so we can get rid of this bit of templating code.

 ## Ticket
https://trello.com/c/iN2DBDbH