### PR TITLE
Change heading level for page sharing

### DIFF
--- a/application/templates/static_site/_share.html
+++ b/application/templates/static_site/_share.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6" />
-    <h4 class="govuk-heading-s">Share this page</h4>
+    <h2 class="govuk-heading-s">Share this page</h2>
     <div class="share">
 
       {% set encoded_url = (config.RDU_SITE.rstrip('/') + url_for('static_site.measure_version', topic_slug=measure_version.measure.subtopic.topic.slug, subtopic_slug=measure_version.measure.subtopic.slug, measure_slug=measure_version.measure.slug, version='latest')) | urlencode %}


### PR DESCRIPTION
The 'Share this page' heading was an h4 which skipped the h3 level
altogether. After looking at the context for this section of the page,
it feels more appropriate to make it an h2.

 ## Ticket
https://trello.com/c/V8GwdHM8