### PR TITLE
Include social description as meta description

### DIFF
--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -35,7 +35,11 @@
       <meta property="og:type" content="{% block socialType %}article{% endblock %}" />
       <meta property="og:title" content="{% block socialTitle %}{% endblock %}" />
       <meta property="og:image" content="{% block socialImage %}{{ config.RDU_SITE | strip_trailing_slash }}/static/assets/images/govuk-opengraph-image.png{% endblock %}" />
-      <meta property="og:description" content="{% block socialDescription %}{% endblock %}" />
+
+      {% if socialDescription %}
+        <meta property="og:description" content="{% block socialDescription %}{% endblock %}" />
+        <meta name="description" content="{% block socialDescription %}{% endblock %}" />
+      {% endif %}
 
       {% block twitterMetadata %}
         <meta name="twitter:card" content="summary" />

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -30,16 +30,13 @@
 
 
 
+    <meta name="description" content="{% block metaDescription %}{% endblock %}" />
 
     {% block socialMetadata %}
       <meta property="og:type" content="{% block socialType %}article{% endblock %}" />
       <meta property="og:title" content="{% block socialTitle %}{% endblock %}" />
       <meta property="og:image" content="{% block socialImage %}{{ config.RDU_SITE | strip_trailing_slash }}/static/assets/images/govuk-opengraph-image.png{% endblock %}" />
-
-      {% if socialDescription %}
-        <meta property="og:description" content="{% block socialDescription %}{% endblock %}" />
-        <meta name="description" content="{% block socialDescription %}{% endblock %}" />
-      {% endif %}
+      <meta property="og:description" content="{% block socialDescription %}{% endblock %}" />
 
       {% block twitterMetadata %}
         <meta name="twitter:card" content="summary" />

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -14,6 +14,8 @@
 {% block pageTitle %}{{ measure_version.title }} - GOV.UK Ethnicity facts and figures{% endblock %}
 {% block socialTitle %}{{ measure_version.title }}{% endblock %}
 {% block socialDescription %}{{ measure_version.social_description | render_markdown | striptags }}{% endblock %}
+{% block metaDescription %}{{ measure_version.social_description | render_markdown | striptags }}{% endblock %}
+
 {% block googleAnalytics %}ga('set','contentGroup1','Measure');{% endblock %}
 
 {% set version = 'latest' if measure_version.has_no_later_published_versions() else measure_version.version %}


### PR DESCRIPTION
Currently we only expose page summaries (descriptions) using the Open Graph metadata tagging, which is used by Facebook, Twitter and other social media platforms.

However we should also include it as a regular meta description for use by search engines and other indexes.

See https://support.google.com/webmasters/answer/79812