### PR TITLE
Use <td> not <th> for empty grouped table header cell

### DIFF
--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -22,7 +22,7 @@
       {% if (dimension.dimension_table.table_object.type == "grouped") and (dimension.dimension_table.table_object.columns|length > 1) %}
 
         <tr class="govuk-table__row">
-          <th class="govuk-table__header first eff-table__header--border-right"> </th>
+          <td class="govuk-table__header first eff-table__header--border-right"> </td>
           {% for group_column in dimension.dimension_table.table_object.group_columns %}
               {% if group_column %}
                   <th colspan="{{ dimension.dimension_table.table_object.columns|length }}" class="govuk-table__header eff-table__cell--padding-left {{ '' if loop.last else 'eff-table__header--border-right' }}">{{ group_column|safe }}</th>


### PR DESCRIPTION
For this ticket: https://trello.com/c/6qqsfZMO/1463-grouped-tables-have-th-elements-with-no-text-3

WAVE (the Web Accessibility VEaluation tool?) tells us that empty table
header cells are a bad thing.

This changes the empty top-left cell of our grouped tables to be a `<td>`
instead of a `<th>`, which should improve the accessibility of our tables
for screen readers.