### PR TITLE
Add meta description for topics

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -1011,6 +1011,7 @@ class Topic(db.Model):
     title = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text, nullable=True)  # a sentence below topic heading on homepage
     additional_description = db.Column(db.TEXT, nullable=True)  # short paragraph displayed on topic page
+    meta_description = db.Column(db.TEXT, nullable=True)  # sentence or two for search engines and social sharing
 
     # relationships
     subtopics = db.relationship("Subtopic", back_populates="topic", order_by="asc(Subtopic.position)")

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -30,6 +30,7 @@
 
 
 
+    <meta property="description" content="{% block metaDescription %}{% endblock %}" />
 
     {% block socialMetadata %}
       <meta property="og:type" content="{% block socialType %}article{% endblock %}" />

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -7,6 +7,7 @@
 %}
 
 {% block pageTitle %}{{ topic.title }} - GOV.UK Ethnicity facts and figures{% endblock %}
+{% block metaDescription %}{{ topic.meta_description | render_markdown | striptags }}{% endblock %}
 {% block socialTitle %}{{ topic.title }}{% endblock %}
 {% block googleAnalytics %}ga('set','contentGroup1','Topic');{% endblock %}
 

--- a/migrations/versions/2019_04_18_meta_desc_add_meta_description_column_to_topics_.py
+++ b/migrations/versions/2019_04_18_meta_desc_add_meta_description_column_to_topics_.py
@@ -1,0 +1,25 @@
+"""Add meta_description column to topics for SEO/open graph desc
+
+
+Revision ID: 2019_04_18_meta_desc
+Revises: 2019_04_16_drop_published_bool
+Create Date: 2019-04-18 13:56:13.692874
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_04_18_meta_desc"
+down_revision = "2019_04_16_drop_published_bool"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("topic", sa.Column("meta_description", sa.TEXT(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("topic", "meta_description")

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -631,6 +631,19 @@ def test_topic_page_only_shows_empty_subtopics_if_user_can_create_a_measure(
     assert bool(page(string=re.compile("Test subtopic page"))) is empty_subtopic_should_be_visible
 
 
+def test_topic_meta_description(test_app_client, logged_in_rdu_user):
+    TopicFactory(slug="test-topic", meta_description="I'm a description sentence for search engines.")
+
+    resp = test_app_client.get(url_for("static_site.topic", topic_slug="test-topic"))
+    page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+
+    assert resp.status_code == 200
+
+    meta_description = page.findAll("meta", property="description")
+    assert len(meta_description) == 1, f"Missing meta description on topic page"
+    assert meta_description[0].get("content") == "I'm a description sentence for search engines."
+
+
 def test_measure_page_share_links_do_not_contain_double_slashes_between_domain_and_path(
     test_app_client, logged_in_rdu_user
 ):


### PR DESCRIPTION
Add a migration that adds a new column to the `Topic` table,
`meta_description`, which stores a sentence or two to describe the topic
that can be shared via open graph descriptions. Useful for SEO/page
sharing.

 ## Summary
https://trello.com/c/Z2rCfkQk