### PR TITLE
Remove "Ethnicity in the UK" from breadcrumb

### DIFF
--- a/application/templates/static_site/static_pages/ethnicity_in_the_uk/ethnic_groups_by_sexual_identity.html
+++ b/application/templates/static_site/static_pages/ethnicity_in_the_uk/ethnic_groups_by_sexual_identity.html
@@ -2,8 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
-    {"url": url_for('static_site.ethnicity_in_the_uk'), "text": "Ethnicity in the UK"},
+    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"}
   ]
 %}
 


### PR DESCRIPTION
This is in preparation for the "Ethnicity in the UK" page being removed

https://trello.com/c/eRhl4gq5/1510-update-breadcrumb-for-ethnic-groups-by-sexual-identity