### PR TITLE
 Add migration for UK population meta desc

### DIFF
--- a/scripts/data_migrations/2019-04-23_uk-population-meta-description.sql
+++ b/scripts/data_migrations/2019-04-23_uk-population-meta-description.sql
@@ -1,0 +1,3 @@
+UPDATE topic
+SET meta_description = 'UK population statistics, broken down by ethnicity, age, location and other factors.'
+WHERE slug = 'uk-population-by-ethnicity';


### PR DESCRIPTION
Adds a data migration that can be used to set the meta description for
the newly-renamed UK population by ethnicity topic.

Also tweaks the names of a few older data migrations to return to a consistent naming scheme.

 ## Ticket
https://trello.com/c/XPRd5C06