### PR TITLE
Add migration for UK pop short title

### DIFF
--- a/scripts/data_migrations/2019-04-23_uk-short-title.sql
+++ b/scripts/data_migrations/2019-04-23_uk-short-title.sql
@@ -1,0 +1,3 @@
+UPDATE topic
+SET short_title = 'UK population'
+WHERE slug = 'uk-population-by-ethnicity';


### PR DESCRIPTION
Adds a data migration that sets the short title on the newly-renamed 'UK
population by ethnicity' to 'UK population'. Short titles are what will
be shown on the homepage, with the regular title shown on the topic
page.

 ## Ticket
https://trello.com/c/4mLG6bCv