### PR TITLE
Fix migration ordering

### DIFF
--- a/migrations/versions/2019_04_18_add_topic_short_title.py
+++ b/migrations/versions/2019_04_18_add_topic_short_title.py
@@ -1,7 +1,7 @@
 """Add short title for topics
 
 Revision ID: 2019_04_18_add_topic_short_title
-Revises: 2019_04_16_drop_published_bool
+Revises: 2019_04_18_meta_desc
 Create Date: 2019-04-18 15:23:51.211497
 
 """
@@ -10,15 +10,15 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '2019_04_18_add_topic_short_title'
-down_revision = '2019_04_16_drop_published_bool'
+revision = "2019_04_18_add_topic_short_title"
+down_revision = "2019_04_18_meta_desc"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('topic', sa.Column('short_title', sa.String(length=255), nullable=True))
+    op.add_column("topic", sa.Column("short_title", sa.String(length=255), nullable=True))
 
 
 def downgrade():
-    op.drop_column('topic', 'short_title')
+    op.drop_column("topic", "short_title")

--- a/migrations/versions/2019_04_18_meta_desc_add_meta_description_column_to_topics_.py
+++ b/migrations/versions/2019_04_18_meta_desc_add_meta_description_column_to_topics_.py
@@ -2,7 +2,7 @@
 
 
 Revision ID: 2019_04_18_meta_desc
-Revises: 2019_04_18_add_topic_short_title
+Revises: 2019_04_16_drop_published_bool
 Create Date: 2019-04-18 13:56:13.692874
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "2019_04_18_meta_desc"
-down_revision = "2019_04_18_add_topic_short_title"
+down_revision = "2019_04_16_drop_published_bool"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The `add_meta_description` migration has already run on staging, but the
topic `short_title` hasn't. So we need to re-order these migrations so
that the short title gets added to the database.