### PR TITLE
Fix classification options in custom

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -774,6 +774,7 @@ def create_chart(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         measure=measure,
         measure_version=measure_version,
         dimension=dimension,
+        classification_options=__get_classification_finder_classifications(),
     )
 
 
@@ -799,6 +800,7 @@ def create_table(topic_slug, subtopic_slug, measure_slug, version, dimension_gui
         measure=measure,
         measure_version=measure_version,
         dimension=dimension,
+        classification_options=__get_classification_finder_classifications(),
     )
 
 


### PR DESCRIPTION
Fixes a bug that led to empty dropdowns where a full list of our known
classifications should be provided to the user. The classifications were
not being passed into the template and no tests were in place to detect
this - we now have one.

I've created a tech improvement ticket from this
(https://trello.com/c/fwYpIWkD) that records the fact our tests are
currently using 'real' data rather than the test data for classification
finders/classications. Our tests break if we switch the config for this,
so leaving it to a later ticket to deal with separately.

 ## Ticket
https://trello.com/c/gRGCp1yr