### PR TITLE
Order redirects by path fragments then lexical

### DIFF
--- a/application/redirects/views.py
+++ b/application/redirects/views.py
@@ -25,7 +25,11 @@ if these steps are carried out of order it is possible for a redirect a user to 
 def _build_routing_rules_xml(redirects):
     root = Element("RoutingRules")
 
-    for r in redirects:
+    # Sort so that more specific redirects (i.e. with the most path fragments) are emitted first. Redirects with the
+    # same number of path fragments are sorted alphabetically.
+    # This prevents a more generic redirect rule, e.g. on `ethnicity-in-the-uk`, breaking the redirect
+    # of a more specific rule, e.g. `ethnicity-in-the-uk/ethnic-groups-and-data-collected`.
+    for r in sorted(redirects, key=lambda x: (-len(x.from_uri.split("/")), x.from_uri)):
         routing_rule = SubElement(root, "RoutingRule")
 
         condition = SubElement(routing_rule, "Condition")


### PR DESCRIPTION
The order of redirects on an S3 buckets can be important. If we have a
more generic rule followed by a more specific rule, the more generic
rule will be applied first, which might override the behaviour we want
from the more specific one.

This patch will cause redirects to be output in groups based on how many
path fragments the redirect has. More specific redirects (i.e. with more
path fragments) will be displayed first; within those groups, they're
listed alphabetically - this doesn't really have an impact, but might
aid readability.

This fix was prompted by a live example of the above-stated problem: we
had a redirect in place for `ethnicity-in-the-uk`, before a more
specific redirect for
`ethnicity-in-the-uk/ethnic-groups-and-data-collected`. The earlier
redirect was leading the latter path to be turned into
`uk-population-by-ethnicity/ethnic-groups-and-data-collected` rather
than just `ethnic-groups`