### PR TITLE
No longer retain request context on exceptions

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -125,3 +125,8 @@ class TestConfig(DevConfig):
     ATTACHMENT_SCANNER_ENABLED = False
     ATTACHMENT_SCANNER_API_TOKEN = "fakeToken"
     ATTACHMENT_SCANNER_URL = "http://scanner-service"
+
+    # Prevent exception reporting under test as `AssertionError: Popped wrong request context.`
+    # While some report this don't work, it does seem to work for us.
+    # https://github.com/jarus/flask-testing/issues/21
+    PRESERVE_CONTEXT_ON_EXCEPTION = False


### PR DESCRIPTION
Sometimes, when a test fails and py.test starts to tear it down, it pops
the wrong request context off the stack because Flask (in debug mode)
retains the existing context when exceptions are thrown so that they can
be inspected. However, in combination with py.test, this leads to weird
error reporting and confusing stack traces. By turning off the
preservation of the request context, py.test reports just the error that
we want to bubble up and get reported, which should lead to it being
quicker to see why a test has failed.

An example of the error is: AssertionError: Popped wrong request context.
(<RequestContext 'http://localhost:5000/admin' [GET] of
application.factory> instead of <RequestContext 'http://localhost:5000/'
[GET] of application.factory>)