### PR TITLE
buttons on the invisble table header should be disabled

### DIFF
--- a/application/src/js/all/_sortable_table.js
+++ b/application/src/js/all/_sortable_table.js
@@ -28,6 +28,8 @@ SortableTable.prototype.createHeadingButtons = function() {
 
   var header_rows = this.table.querySelectorAll('thead tr')
 
+  var disabled_buttons = this.header_table ? true : false
+
   for (var j = 0; j < header_rows.length; j++) {
 
     var headings = header_rows[j].querySelectorAll('th')
@@ -36,7 +38,7 @@ SortableTable.prototype.createHeadingButtons = function() {
     for(var i = 0; i < headings.length; i++) {
         heading = headings[i];
         if(heading.getAttribute('aria-sort')) {
-            this.createHeadingButton(heading, i);
+            this.createHeadingButton(heading, i, disabled_buttons);
         }
     }
 
@@ -55,7 +57,7 @@ SortableTable.prototype.createHeadingButtons = function() {
       for(var i = 0; i < headings.length; i++) {
           heading = headings[i];
           if(heading.getAttribute('aria-sort')) {
-              this.createHeadingButton(heading, i);
+              this.createHeadingButton(heading, i, false);
           }
       }
 
@@ -66,7 +68,7 @@ SortableTable.prototype.createHeadingButtons = function() {
   }
 };
 
-SortableTable.prototype.createHeadingButton = function(heading, i) {
+SortableTable.prototype.createHeadingButton = function(heading, i, disabled) {
     var text = heading.textContent;
     var button = document.createElement('button')
     button.setAttribute('type', 'button')
@@ -82,6 +84,9 @@ SortableTable.prototype.createHeadingButton = function(heading, i) {
       button.setAttribute('data-event-label', text.trim())
     }
 
+    if (disabled) {
+      button.setAttribute('disabled', 'disabled')
+    }
 
     heading.appendChild(button);
 };


### PR DESCRIPTION
This removes them from the tabbing order. Currently both the visible and the invisible buttons are tabbable to.

Resolved https://trello.com/c/EIvPBmku/1500-tables-with-fixed-headers-have-duplicate-sortable-table-headers-which-can-be-focused-by-keyboard-users-but-are-invisible-and-don