### PR TITLE
Fix available edit_measure actions

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -388,6 +388,18 @@ class MeasureVersion(db.Model, CopyableModel):
         else:
             return current_status
 
+    @property
+    def next_approval_state(self) -> Optional[str]:
+        """Returns the next state in the approval process, from ‘draft’ to ‘approved’. Once approved, returns `None`."""
+        approval_state = None
+
+        if "APPROVE" in self.available_actions:
+            numerical_status = self.publish_status(numerical=True)
+            approval_state = publish_status.inv[numerical_status + 1]
+
+        return approval_state
+
+    @property
     def available_actions(self):
         if self.measure.subtopic.topic.slug == TESTING_SPACE_SLUG:
             return ["UPDATE"]

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -414,9 +414,7 @@ class PageService(Service):
         return message
 
     def send_measure_version_to_draft(self, measure_version: MeasureVersion):
-        available_actions = measure_version.available_actions()
-
-        if "RETURN_TO_DRAFT" in available_actions:
+        if "RETURN_TO_DRAFT" in measure_version.available_actions:
             numerical_status = measure_version.publish_status(numerical=True)
             measure_version.status = publish_status.inv[(numerical_status + 1) % 6]
             db.session.commit()

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -407,7 +407,7 @@
                     <h2 class="govuk-heading-m eff-numbered-sections__item">Preview</h2>
                     <div id="container" class="chart-container"></div>
 
-                    {% if 'UPDATE' in measure_version.available_actions() %}
+                    {% if 'UPDATE' in measure_version.available_actions %}
                     <br>
                     <div id="save_section" class="chart-builder-section hidden">
                         <div class="govuk-!-padding-left-8">

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -274,7 +274,7 @@
                     </div>
                     <div id="container"></div>
 
-                    {% if 'UPDATE' in measure_version.available_actions() %}
+                    {% if 'UPDATE' in measure_version.available_actions %}
                     <br>
                     <div id="save_section" class="chart-builder-section" class="hidden">
                         <div>

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -28,7 +28,7 @@
                         {{ super() }}
                     {% endblock fields %}
 
-                    {% if 'UPDATE' in  measure_version.available_actions() %}
+                    {% if 'UPDATE' in  measure_version.available_actions %}
                     <button type="submit" class="govuk-button" name="update">
                         Update
                     </button>
@@ -45,10 +45,10 @@
                                     <td class="govuk-table__cell">{{ dimension.dimension_chart.chart_object.title.text }}</td>
                                     <td class="govuk-table__cell"><a class="govuk-link" id="edit_chart"
                                            href="{{ url_for('cms.create_chart', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}">
-                                        {% if 'UPDATE' in  measure_version.available_actions() %}edit{% else %}
+                                        {% if 'UPDATE' in  measure_version.available_actions %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td class="govuk-table__cell">
-                                    {% if 'UPDATE' in  measure_version.available_actions() %}
+                                    {% if 'UPDATE' in  measure_version.available_actions %}
                                         <form action="{{ url_for('cms.delete_chart', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure_version.measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}" method="post">
                                             {{ form.csrf_token }}
                                             <button id="delete_chart" class="eff-button--link">delete</button>
@@ -63,10 +63,10 @@
                                     <td class="govuk-table__cell">{{ dimension.dimension_table.table_object.header }}</td>
                                     <td class="govuk-table__cell"><a class="govuk-link" id="edit_table"
                                            href="{{ url_for('cms.create_table', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}">
-                                        {% if 'UPDATE' in  measure_version.available_actions() %}edit{% else %}
+                                        {% if 'UPDATE' in  measure_version.available_actions %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td class="govuk-table__cell">
-                                        {% if 'UPDATE' in  measure_version.available_actions() %}
+                                        {% if 'UPDATE' in  measure_version.available_actions %}
                                         <form action="{{ url_for('cms.delete_table', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure_version.measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}" method="post">
                                             {{ form.csrf_token }}
                                             <button id="delete_table" class="eff-button--link">delete</button>
@@ -77,7 +77,7 @@
                             {% endif %}
                           </tbody>
                         </table>
-                        {% if 'UPDATE' in  measure_version.available_actions() %}
+                        {% if 'UPDATE' in  measure_version.available_actions %}
 
                                 {% if not dimension.dimension_chart or (dimension.dimension_chart and (dimension.dimension_chart.chart_object is none or dimension.dimension_chart.chart_object == '""')) %}
                                 <p class="govuk-body">

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -87,26 +87,26 @@
                  <button class="govuk-button" type="submit" name="save">Save</button>
             {% endif %}
 
-            {% if "REJECT" in available_actions %}
+            {% if "REJECT" in measure_version.available_actions %}
                 <button id="reject-measure" name="measure-action" value="reject-measure" class="govuk-button eff-button--destructive">Reject</button>
             {% endif %}
 
-            {% if status == 'REJECTED' or status == 'UNPUBLISHED' %}
+            {% if measure_version.status == 'REJECTED' or measure_version.status == 'UNPUBLISHED' %}
                 <button id="send-back-to-draft" name="measure-action" value="send-back-to-draft" class="govuk-button">Send back to draft</button>
             {%  endif %}
 
-            {% if  "APPROVE" in available_actions %}
-                {% if status == 'DRAFT' %}
-                    <button type="submit" class="govuk-button {% if next_approval_state == 'INTERNAL_REVIEW' %}eff-button--neutral{%endif %}" name="save-and-review" id="save-and-review">
-                        {{ next_approval_state | format_approve_button | safe }}
+            {% if "APPROVE" in measure_version.available_actions %}
+                {% if measure_version.status == 'DRAFT' %}
+                    <button type="submit" class="govuk-button {% if measure_version.next_approval_state == 'INTERNAL_REVIEW' %}eff-button--neutral{%endif %}" name="save-and-review" id="save-and-review">
+                        {{ measure_version.next_approval_state | format_approve_button | safe }}
                     </button>
-                {% elif next_approval_state == 'DEPARTMENT_REVIEW' %}
+                {% elif measure_version.next_approval_state == 'DEPARTMENT_REVIEW' %}
                     <button class="govuk-button" id="send-to-department-review" name="measure-action" value="send-to-department-review">
-                        {{ next_approval_state | format_approve_button | safe }}
+                        {{ measure_version.next_approval_state | format_approve_button | safe }}
                     </button>
-                {% elif next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
+                {% elif measure_version.next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
                     <button class="govuk-button" id="send-to-approved" name="measure-action" value="send-to-approved">
-                        {{ next_approval_state | format_approve_button | safe }}
+                        {{ measure_version.next_approval_state | format_approve_button | safe }}
                     </button>
                 {% endif %}
             {% endif %}
@@ -233,8 +233,8 @@
                                 </td>
                                 <td class="govuk-table__cell">
                                     <a class="govuk-link" href="{{ url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}">
-                                        {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
-                                <td class="govuk-table__cell">{% if 'UPDATE' in available_actions %}
+                                        {% if 'UPDATE' in measure_version.available_actions %}edit{% else %}view{% endif %}</a></td>
+                                <td class="govuk-table__cell">{% if 'UPDATE' in measure_version.available_actions %}
                                     <form action="{{ url_for('cms.delete_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}" method="post">
                                         {{ form.csrf_token }}
                                         <button class="eff-button--link">delete</button>
@@ -242,7 +242,7 @@
                                     {% endif %}
                                 </td>
                                 <td class="govuk-table__cell eff-move-controls">
-                                    {% if 'UPDATE' in available_actions %}
+                                    {% if 'UPDATE' in measure_version.available_actions %}
                                         <span title="move up" class="eff-move-up">&#x25B2</span>
                                         <span title="move down" class="eff-move-down">&#x25BC</span>
                                     {% endif %}
@@ -252,7 +252,7 @@
                     </table>
                 {% endif %}
 
-                {% if 'UPDATE' in available_actions %}
+                {% if 'UPDATE' in measure_version.available_actions %}
                     <p class="govuk-body"><a class="govuk-link" href="{{ url_for('cms.create_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">Add
                         dimension</a></p>
                 {% endif %}
@@ -281,10 +281,10 @@
                                     <td class="govuk-table__cell">{{ upload.title }}</td>
                                     <td class="govuk-table__cell">
                                         <a class="govuk-link" href="{{ url_for('cms.edit_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, upload_guid=upload.guid ) }}">
-                                            {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a>
+                                            {% if 'UPDATE' in measure_version.available_actions %}edit{% else %}view{% endif %}</a>
                                     </td>
                                     <td class="govuk-table__cell">
-                                        {% if 'UPDATE' in available_actions %}
+                                        {% if 'UPDATE' in measure_version.available_actions %}
                                             <form action="{{ url_for('cms.delete_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, upload_guid=upload.guid ) }}" method="post">
                                                 {{ form.csrf_token }}
                                                 <button class="eff-button--link">delete</button>
@@ -295,7 +295,7 @@
                             {% endfor %}
                         </table>
                     {% endif %}
-                    {% if 'UPDATE' in available_actions %}
+                    {% if 'UPDATE' in measure_version.available_actions %}
                         <p class="govuk-body"><a class="govuk-link" href="{{ url_for('cms.create_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">Add source data</a></p>
                     {% endif %}
                     {% if new %}

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -46,7 +46,7 @@
 
                     {% endblock fields %}
 
-                    {% if 'UPDATE' in measure_version.available_actions() %}
+                    {% if 'UPDATE' in measure_version.available_actions %}
                         <button type="submit" class="govuk-button" name="save">
                             Save
                         </button>

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -689,43 +689,43 @@ class TestMeasureVersionModel:
         measure_version = MeasureVersionFactory(status="DRAFT")
         expected_available_actions = ["APPROVE", "UPDATE"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_available_actions_for_page_in_internal_review(self):
         measure_version = MeasureVersionFactory(status="INTERNAL_REVIEW")
         expected_available_actions = ["APPROVE", "REJECT"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_available_actions_for_page_in_department_review(self):
         measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
         expected_available_actions = ["APPROVE", "REJECT"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_available_actions_for_rejected_page(self):
         measure_version = MeasureVersionFactory(status="REJECTED")
         expected_available_actions = ["RETURN_TO_DRAFT"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_available_actions_for_approved_page(self):
         measure_version = MeasureVersionFactory(status="APPROVED")
         expected_available_actions = ["UNPUBLISH"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_no_available_actions_for_page_awaiting_unpublication(self):
         measure_version = MeasureVersionFactory(status="UNPUBLISH")
         expected_available_actions = []
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_available_actions_for_unpublished(self):
         measure_version = MeasureVersionFactory(status="UNPUBLISHED")
         expected_available_actions = ["RETURN_TO_DRAFT"]
 
-        assert expected_available_actions == measure_version.available_actions()
+        assert expected_available_actions == measure_version.available_actions
 
     def test_page_sort_by_version(self):
 


### PR DESCRIPTION
Extract logic to the model; change `available_actions` into a property
so it doesn't need to be called with `()` every time. Consistently
reference `available_actions` on the model instance from templates,
rather than duplicating/complicating things by passing it in directly as
well as on the model.

Partly required for work on the StrictUndefined ticket, but separated for ease-of-review.