### PR TITLE
Enable `StrictUndefined` template rendering

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -401,7 +401,7 @@ class MeasureVersion(db.Model, CopyableModel):
 
     @property
     def available_actions(self):
-        if self.measure.subtopic.topic.slug == TESTING_SPACE_SLUG:
+        if self.measure and self.measure.subtopic.topic.slug == TESTING_SPACE_SLUG:
             return ["UPDATE"]
 
         if self.status == "DRAFT":

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -33,7 +33,7 @@ from application.cms.forms import (
     NewVersionForm,
     UploadForm,
 )
-from application.cms.models import NewVersionType
+from application.cms.models import NewVersionType, MeasureVersion, Measure
 from application.cms.models import Organisation
 from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
@@ -99,12 +99,14 @@ def create_measure(topic_slug, subtopic_slug):
         data_source_2_form=data_source_2_form,
         topic=topic,
         subtopic=subtopic,
-        measure={},
-        measure_version={},
+        measure=Measure(),
+        measure_version=MeasureVersion(),
         new=True,
         organisations_by_type=Organisation.select_options_by_type(),
         topics=page_service.get_topics(include_testing_space=True),
         errors=get_form_errors(forms=(form, data_source_form, data_source_2_form)),
+        data_not_uploaded_error=False,
+        dimensions_not_complete_error=False,
     )
 
 
@@ -354,6 +356,9 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
         "organisations_by_type": Organisation.select_options_by_type(),
         "topics": page_service.get_topics(include_testing_space=True),
         "errors": get_form_errors(forms=[measure_version_form, data_source_form, data_source_2_form]),
+        "new": False,
+        "data_not_uploaded_error": False,
+        "dimensions_not_complete_error": False,
     }
 
     return render_template("cms/edit_measure_version.html", **context)
@@ -519,6 +524,7 @@ def _send_to_review(topic_slug, subtopic_slug, measure_slug, version):  # noqa: 
                 ),
                 "data_not_uploaded_error": data_not_uploaded_error,
                 "dimensions_not_complete_error": dimensions_not_complete_error,
+                "new": False,
             }
 
             return render_template("cms/edit_measure_version.html", **context), 400

--- a/application/config.py
+++ b/application/config.py
@@ -26,6 +26,7 @@ class Config:
     BASE_DIRECTORY = dirname(dirname(os.path.abspath(__file__)))
     WTF_CSRF_ENABLED = True
     SESSION_COOKIE_SECURE = True
+    STATIC_MODE = False
 
     GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
     HTML_CONTENT_REPO = os.environ.get("HTML_CONTENT_REPO", "rd_html_dev")

--- a/application/factory.py
+++ b/application/factory.py
@@ -51,6 +51,7 @@ from application.static_site.filters import (
     format_iso8601_date,
     html_params,
 )
+from application.utils import get_bool
 
 
 def create_app(config_object):
@@ -203,6 +204,7 @@ def create_app(config_object):
             get_content_security_policy=get_content_security_policy,
             current_timestamp=datetime.datetime.now().isoformat(),
             get_form_errors=get_form_errors,
+            static_mode=get_bool(request.args.get("static_mode", app.config["STATIC_MODE"])),
         )
 
     return app

--- a/application/factory.py
+++ b/application/factory.py
@@ -4,6 +4,7 @@ import re
 import sys
 import logging
 
+from jinja2 import StrictUndefined
 from jinja2.ext import do as jinja_do
 
 from flask import Flask, render_template, request, send_from_directory
@@ -122,6 +123,9 @@ def create_app(config_object):
 
     register_errorhandlers(app)
     app.after_request(harden_app)
+
+    # Make sure all variables referenced in templates are explicitly defined
+    app.jinja_env.undefined = StrictUndefined
 
     # Render jinja templates with less whitespace; applies to both CMS and static build
     app.jinja_env.trim_blocks = True

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -34,6 +34,9 @@ def make_new_build_dir(application, build=None):
 
 def do_it(application, build):
     with application.app_context():
+        # Build the pages in static mode
+        application.config["STATIC_MODE"] = True
+
         print("DEBUG: do_it()")
         build_dir = make_new_build_dir(application, build=build)
 
@@ -44,12 +47,6 @@ def do_it(application, build):
         delete_files_from_repo(build_dir)
         print("DEBUG do_it(): Creating versioned assets...")
         create_versioned_assets(build_dir)
-
-        # Inject static_mode=True into all Jinja render_template calls so that pages are automatically rendered in the
-        # correct mode.
-        @application.context_processor
-        def enforce_static_mode():
-            return dict(static_mode=True)
 
         local_build = application.config["LOCAL_BUILD"]
 
@@ -88,13 +85,10 @@ def build_and_upload_error_pages(application):
     convoluted and confusing to integrate into the main site build.
     """
     with application.app_context():
-        build_dir = make_new_build_dir(application)
+        # Build the pages in static mode
+        application.config["STATIC_MODE"] = True
 
-        # Inject static_mode=True into all Jinja render_template calls so that pages are automatically rendered in the
-        # correct mode.
-        @application.context_processor
-        def enforce_static_mode():
-            return dict(static_mode=True)
+        build_dir = make_new_build_dir(application)
 
         local_build = application.config["LOCAL_BUILD"]
 
@@ -121,7 +115,7 @@ def build_homepage_and_topic_hierarchy(build_dir, config):
     from application.cms.page_service import page_service
 
     topics = page_service.get_topics(include_testing_space=False)
-    content = render_template("static_site/index.html", topics=topics, static_mode=True)
+    content = render_template("static_site/index.html", topics=topics)
 
     file_path = os.path.join(build_dir, "index.html")
     write_html(file_path, content)
@@ -149,11 +143,7 @@ def write_topic_html(topic, build_dir, config):
             subtopics.append(subtopic)
 
     content = render_template(
-        "static_site/topic.html",
-        topic=topic,
-        subtopics=subtopics,
-        measures_by_subtopic=measures_by_subtopic,
-        static_mode=True,
+        "static_site/topic.html", topic=topic, subtopics=subtopics, measures_by_subtopic=measures_by_subtopic
     )
 
     file_path = os.path.join(slug, "index.html")

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -1,4 +1,5 @@
 import os
+
 from tempfile import NamedTemporaryFile
 
 from botocore.exceptions import ClientError
@@ -13,7 +14,6 @@ from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
 from application.static_site import static_site_blueprint
 from application.utils import (
-    get_bool,
     get_csv_data_for_download,
     write_dimension_csv,
     write_dimension_tabular_csv,
@@ -25,11 +25,7 @@ from application.utils import cleanup_filename
 @static_site_blueprint.route("")
 @login_required
 def index():
-    return render_template(
-        "static_site/index.html",
-        topics=page_service.get_topics(include_testing_space=False),
-        static_mode=get_bool(request.args.get("static_mode", False)),
-    )
+    return render_template("static_site/index.html", topics=page_service.get_topics(include_testing_space=False))
 
 
 @static_site_blueprint.route("/ethnicity-in-the-uk/<page_name>")
@@ -92,11 +88,7 @@ def topic(topic_slug):
     }
 
     return render_template(
-        "static_site/topic.html",
-        topic=topic,
-        subtopics=subtopics,
-        measures_by_subtopic=measures_by_subtopic,
-        static_mode=get_bool(request.args.get("static_mode", False)),
+        "static_site/topic.html", topic=topic, subtopics=subtopics, measures_by_subtopic=measures_by_subtopic
     )
 
 
@@ -151,11 +143,7 @@ def measure_version(topic_slug, subtopic_slug, measure_slug, version):
         abort(404)
 
     return render_template(
-        "static_site/measure.html",
-        topic_slug=topic_slug,
-        subtopic_slug=subtopic_slug,
-        measure_version=measure_version,
-        static_mode=get_bool(request.args.get("static_mode", False)),
+        "static_site/measure.html", topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_version=measure_version
     )
 
 

--- a/application/templates/_macros/_accordion.html
+++ b/application/templates/_macros/_accordion.html
@@ -1,27 +1,27 @@
 {# Adapted from https://github.com/alphagov/govuk-frontend/blob/master/src/components/accordion/template.njk #}
 {% macro govukAccordion(id=None, attributes={}, classes=None, items=[]) %}
 
-  {% set headingLevel = headingLevel if headingLevel else 2 %}
+  {% set headingLevel = headingLevel | default(2, true) %}
 
   <div class="govuk-accordion {%- if classes %} {{ classes }}{% endif %}" data-module="accordion" {%- if id %} id="{{id}}"{% endif %} {{ attributes | html_params | safe }}>
 
     {% for item in items %}
 
-      <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">
+      <div class="govuk-accordion__section {% if item.expanded is defined and item.expanded %}govuk-accordion__section--expanded{% endif %}">
         <div class="govuk-accordion__section-header"  {% if item.section_header_attributes%}{{ item.section_header_attributes | html_params | safe }}{% endif %}>
           <h{{ headingLevel }} class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">
-              {{ item.heading.html if item.heading.html else item.heading.text }}
+              {{ item.heading.html | default(item.heading.text, true) }}
             </span>
           </h{{ headingLevel }}>
           {% if item.summary is defined and (item.summary.html or item.summary.text) %}
             <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
-              {{ item.summary.html if item.summary.html else item.summary.text }}
+              {{ item.summary.html | default(item.summary.text, true) }}
             </div>
           {% endif %}
         </div>
         <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="{{ id }}-heading-{{ loop.index }}">
-          {{ item.content.html if item.content.html else item.content.text }}
+          {{ item.content.html | default(item.content.text, true) }}
         </div>
       </div>
 

--- a/application/templates/_macros/_accordion.html
+++ b/application/templates/_macros/_accordion.html
@@ -1,7 +1,7 @@
 {# Adapted from https://github.com/alphagov/govuk-frontend/blob/master/src/components/accordion/template.njk #}
 {% macro govukAccordion(id=None, attributes={}, classes=None, items=[]) %}
 
-  {% set headingLevel = headingLevel | default(2, true) %}
+  {% set headingLevel = headingLevel | default(2) %}
 
   <div class="govuk-accordion {%- if classes %} {{ classes }}{% endif %}" data-module="accordion" {%- if id %} id="{{id}}"{% endif %} {{ attributes | html_params | safe }}>
 
@@ -11,17 +11,17 @@
         <div class="govuk-accordion__section-header"  {% if item.section_header_attributes%}{{ item.section_header_attributes | html_params | safe }}{% endif %}>
           <h{{ headingLevel }} class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">
-              {{ item.heading.html | default(item.heading.text, true) }}
+              {{ item.heading.html if item.heading.html is defined and item.heading.html else item.heading.text }}
             </span>
           </h{{ headingLevel }}>
           {% if item.summary is defined and (item.summary.html or item.summary.text) %}
             <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
-              {{ item.summary.html | default(item.summary.text, true) }}
+              {{ item.summary.html if item.summary.html is defined and item.summary.html else item.summary.text }}
             </div>
           {% endif %}
         </div>
         <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="{{ id }}-heading-{{ loop.index }}">
-          {{ item.content.html | default(item.content.text, true) }}
+          {{ item.content.html if item.content.html is defined and item.content.html else item.content.text }}
         </div>
       </div>
 

--- a/application/templates/_macros/_details.html
+++ b/application/templates/_macros/_details.html
@@ -1,6 +1,6 @@
 {# Adapted from https://github.com/alphagov/govuk-frontend/blob/master/src/components/details/template.njk #}
 {% macro govukDetails(summaryHtml=None,summaryText=None,text=None,html=None,id=None,attributes={},open=False,classes=None) %}
-  <details {%- if id %} id="{{id}}"{% endif %} class="govuk-details {%- if classes %} {{ classes }}{% endif %}" {{ attributes | html_params | safe }} {{- " open" if open }}>
+  <details {%- if id %} id="{{id}}"{% endif %} class="govuk-details {%- if classes %} {{ classes }}{% endif %}" {{ attributes | html_params | safe }} {{- " open" if open else "" }}>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       {{ summaryHtml if summaryHtml else summaryText }}

--- a/application/templates/_shared/_breadcrumb.html
+++ b/application/templates/_shared/_breadcrumb.html
@@ -1,11 +1,11 @@
 {% macro render_breadcrumbs(breadcrumbs) %}
-  {% if breadcrumbs or breadcrumbs is not defined %}
+  {% if breadcrumbs is not defined or breadcrumbs %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
 
         <div class="govuk-breadcrumbs">
           <ol class="govuk-breadcrumbs__list">
-            {% if breadcrumbs %}
+            {% if breadcrumbs is defined %}
               {% for breadcrumb in breadcrumbs %}
               <li class="govuk-breadcrumbs__list-item">
                   <a class="govuk-breadcrumbs__link" href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>

--- a/application/templates/_shared/_error_summary.html
+++ b/application/templates/_shared/_error_summary.html
@@ -3,7 +3,7 @@
   https://github.com/alphagov/govuk-frontend/blob/master/src/components/error-summary
 #}
 
-{% if errors %}
+{% if errors is defined and errors %}
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -24,7 +24,7 @@
       <a href="#search-form" class="eff-search__toggle js-header-toggle" aria-expanded="false">Search</a>
       <form id="search-form" class="eff-search__form" action="{{ config.GOOGLE_CUSTOM_SEARCH_ENDPOINT }}" method="get" role="search">
         <label for="site-search-text" class="eff-search__label" id="site-search-label">Search</label>
-        <input type="search" name="q" id="site-search-text" title="Search facts and figures" class="eff-search__input eff-search__input--text js-search-focus" value="{{ current_search_value | default('', true) }}">
+        <input type="search" name="q" id="site-search-text" title="Search facts and figures" class="eff-search__input eff-search__input--text js-search-focus" value="{{ current_search_value if current_search_value is defined and current_search_value else '' }}">
         <input id="search-form-cx" type="hidden" name="cx" value="{{ config.GOOGLE_CUSTOM_SEARCH_ID }}" class="eff-search__input">
         <input class="eff-search__input eff-search__input--submit" type="submit" value="Search">
       </form>

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -24,7 +24,7 @@
       <a href="#search-form" class="eff-search__toggle js-header-toggle" aria-expanded="false">Search</a>
       <form id="search-form" class="eff-search__form" action="{{ config.GOOGLE_CUSTOM_SEARCH_ENDPOINT }}" method="get" role="search">
         <label for="site-search-text" class="eff-search__label" id="site-search-label">Search</label>
-        <input type="search" name="q" id="site-search-text" title="Search facts and figures" class="eff-search__input eff-search__input--text js-search-focus" value="{{ current_search_value }}">
+        <input type="search" name="q" id="site-search-text" title="Search facts and figures" class="eff-search__input eff-search__input--text js-search-focus" value="{{ current_search_value | default('', true) }}">
         <input id="search-form-cx" type="hidden" name="cx" value="{{ config.GOOGLE_CUSTOM_SEARCH_ID }}" class="eff-search__input">
         <input class="eff-search__input eff-search__input--submit" type="submit" value="Search">
       </form>

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -18,7 +18,7 @@
                     Add user
                 </h1>
                 <form action="{{ url_for('admin.add_user') }}" method="POST">
-                    {{ form.csrf_token }}
+                    {{ form.csrf_token | default('') }}
                     {{ form.email() }}
                     {{ form.user_type() }}
 

--- a/application/templates/auth/forgot_password.html
+++ b/application/templates/auth/forgot_password.html
@@ -15,7 +15,7 @@
                 Password reset links are only valid for 24 hours.
             </p>
             <form action="{{ url_for('auth.forgot_password') }}" method="POST">
-                {{ form.csrf_token }}
+                {{ form.csrf_token | default('') }}
                 {{ form.email }}
 
                 <button type="submit" class="govuk-button" name="send-reset-email">Send reset email</button>

--- a/application/templates/auth/reset_password.html
+++ b/application/templates/auth/reset_password.html
@@ -10,7 +10,7 @@
             <h1 class='govuk-heading-xl'>Set a new password</h1>
 
             <form action="{{ url_for('auth.reset_password', token=token) }}" method="POST">
-                {{ form.csrf_token }}
+                {{ form.csrf_token | default('') }}
                 {{ form.password }}
                 {{ form.confirm_password }}
 

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -8,7 +8,7 @@
   <!-- Page built at {{ current_timestamp }} -->
 
   <meta charset="utf-8" />
-  <title>{% if errors %}Error: {% endif %}{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+  <title>{% if errors is defined and errors %}Error: {% endif %}{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c" />
 

--- a/application/templates/cms/_data_source_form.html
+++ b/application/templates/cms/_data_source_form.html
@@ -1,7 +1,7 @@
 {% from "cms/forms.html" import render_department_select %}
 
 {% macro render_data_source_form(data_source_form, organisations_by_type, form_disabled, diffs) %}
-  {{ data_source_form.csrf_token }}
+  {{ data_source_form.csrf_token | default('') }}
 
   {{ data_source_form.remove_data_source(class_="js-hidden js-remove-data-source", value="false", disabled=form_disabled) }}
 

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -23,7 +23,7 @@
         <div class="govuk-grid-column-two-thirds">
           {% block measure_form %}
             <form method="POST" action="{{ url_for('cms.create_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version )}}">
-                {{ form.csrf_token }}
+                {{ form.csrf_token | default('') }}
                 {% block fields %}
 
                     {{ form.title(disabled=form_disabled) }}

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -27,7 +27,7 @@
             </p>
             <form method="POST"
                   action="{{ url_for('cms.new_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
-                {{ form.csrf_token }}
+                {{ form.csrf_token | default('') }}
                 {{ form.version_type }}
                 <button class="govuk-button">Create new version in draft</button>
             </form>

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -32,10 +32,9 @@
                             {{ form.upload(class="govuk-file-upload") }}
                         {% endif %}
                         </div>
+                        {{ form.title() }}
 
-                        {{ form.title(disabled=form_disabled) }}
-
-                        {{ form.description(disabled=form_disabled, rows='7',cols='100') }}
+                        {{ form.description(rows='7',cols='100') }}
 
                     {% endblock fields %}
                      <button type="submit" class="govuk-button" name="save">Save</button>

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -21,7 +21,7 @@
             {% block measure_form %}
                 <form method="POST" enctype="multipart/form-data"
                       action="{{ url_for('cms.create_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version ) }}">
-                    {{ form.csrf_token }}
+                    {{ form.csrf_token | default('') }}
                     {% block fields %}
                         <div class="govuk-form-group {% if form.upload.errors %}govuk-form-group--error{% endif %}">
                         {{ form.upload.label(class='govuk-label') }}

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -22,7 +22,7 @@
             {% block measure_form %}
                 <form id="dimension_form" method="POST"
                       action="{{ url_for('cms.edit_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}">
-                    {{ form.csrf_token }}
+                    {{ form.csrf_token | default('') }}
                     {% block fields %}
                         {{ super() }}
                     {% endblock fields %}
@@ -49,7 +49,7 @@
                                     <td class="govuk-table__cell">
                                     {% if 'UPDATE' in  measure_version.available_actions %}
                                         <form action="{{ url_for('cms.delete_chart', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure_version.measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}" method="post">
-                                            {{ form.csrf_token }}
+                                            {{ form.csrf_token | default('') }}
                                             <button id="delete_chart" class="eff-button--link">delete</button>
                                         </form>
                                     {% endif %}
@@ -67,7 +67,7 @@
                                     <td class="govuk-table__cell">
                                         {% if 'UPDATE' in  measure_version.available_actions %}
                                         <form action="{{ url_for('cms.delete_table', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure_version.measure.slug, version=measure_version.version, dimension_guid=dimension.guid) }}" method="post">
-                                            {{ form.csrf_token }}
+                                            {{ form.csrf_token | default('') }}
                                             <button id="delete_table" class="eff-button--link">delete</button>
                                         </form>
                                         {% endif %}

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -11,7 +11,7 @@
 {% set form_disabled = false if (new is defined and new) else measure_version.status != 'DRAFT' %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ measure_version.title | default('Create a measure', true) }}{% endblock %}
+{% block pageTitle %}{{ measure_version.title if measure_version.title is defined and measure_version.title else "Create a measure" }}{% endblock %}
 
 {% block content %}
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure', topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}{% else %}{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}{% endif %}">

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -360,64 +360,64 @@
                     }
                 })
             }
+
+            function moveDimensionUp(event) {
+                event.preventDefault();
+                var row = $(event.currentTarget).parents('tr:first');
+                if (row.prev().length > 0) {
+                    row.insertBefore(row.prev());
+                    syncDimensionOrder();
+                }
+            }
+
+            function moveDimensionDown(event) {
+                event.preventDefault();
+                var row = $(event.currentTarget).parents('tr:last');
+                if (row.next().length > 0) {
+                    row.insertAfter(row.next());
+                    syncDimensionOrder();
+                }
+            }
+
+            function syncDimensionOrder() {
+                var rows = $('tr.eff-movable'),
+                    dimensions = [],
+                    guid;
+
+                $(rows).each(function (index, row) {
+                    guid = $(row).data('dimension-guid');
+                    dimensions.push({"index": index, "guid": guid});
+                });
+                $.ajax({
+                    type: 'POST',
+                    url: "{{ url_for('cms.set_dimension_order') }}",
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    data: JSON.stringify({"dimensions": dimensions}),
+                    success: function (data) {
+                        console.log('Set order for dimensions:', dimensions);
+                    },
+                    error: function (data) {
+                        console.log('Error setting order for dimensions:', dimensions);
+                    }
+                });
+            }
+
+            function getPreviewUrl(event) {
+                event.preventDefault();
+                $.ajax({
+                    type: 'GET',
+                    url: "{{ url_for('review.get_new_review_url', id=measure_version.id)}}",
+                    success: function (data) {
+                        $('#review-url').html(data);
+                        initialiseCopy();
+                    },
+                    error: function(data) {
+                        $('#review-url').html('<span class="warning">Error trying to generate new preview url</span>');
+                    }
+                })
+            }
         {%  endif %}
-
-        function moveDimensionUp(event) {
-            event.preventDefault();
-            var row = $(event.currentTarget).parents('tr:first');
-            if (row.prev().length > 0) {
-                row.insertBefore(row.prev());
-                syncDimensionOrder();
-            }
-        }
-
-        function moveDimensionDown(event) {
-            event.preventDefault();
-            var row = $(event.currentTarget).parents('tr:last');
-            if (row.next().length > 0) {
-                row.insertAfter(row.next());
-                syncDimensionOrder();
-            }
-        }
-
-        function syncDimensionOrder() {
-            var rows = $('tr.eff-movable'),
-                dimensions = [],
-                guid;
-
-            $(rows).each(function (index, row) {
-                guid = $(row).data('dimension-guid');
-                dimensions.push({"index": index, "guid": guid});
-            });
-            $.ajax({
-                type: 'POST',
-                url: "{{ url_for('cms.set_dimension_order') }}",
-                dataType: 'json',
-                contentType: 'application/json',
-                data: JSON.stringify({"dimensions": dimensions}),
-                success: function (data) {
-                    console.log('Set order for dimensions:', dimensions);
-                },
-                error: function (data) {
-                    console.log('Error setting order for dimensions:', dimensions);
-                }
-            });
-        }
-
-        function getPreviewUrl(event) {
-            event.preventDefault();
-            $.ajax({
-                type: 'GET',
-                url: "{{ url_for('review.get_new_review_url', id=measure_version.id)}}",
-                success: function (data) {
-                    $('#review-url').html(data);
-                    initialiseCopy();
-                },
-                error: function(data) {
-                    $('#review-url').html('<span class="warning">Error trying to generate new preview url</span>');
-                }
-            })
-        }
 
         function copyToClipboard(event) {
             event.preventDefault();

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -8,16 +8,17 @@
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
   ]
 %}
-{% set form_disabled = not (measure_version.status == "DRAFT" or new) %}
+{% set form_disabled = false if (new is defined and new) else measure_version.status != 'DRAFT' %}
 
-{% block pageTitle %}{{ measure_version.title }}{% endblock %}
+{% block bodyClasses %}rd_cms{% endblock %}
+{% block pageTitle %}{{ measure_version.title | default('Create a measure', true) }}{% endblock %}
 
 {% block content %}
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure', topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}{% else %}{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}{% endif %}">
         {{ form.csrf_token }}
         {% call status_banner() %}
             <div class="left">
-                <span class="info">Version&nbsp;<b>{{ measure_version.version }}</b></span>
+                <span class="info">Version&nbsp;<b>{{ '1.0' if new else measure_version.version }}</b></span>
             </div>
             <div>
                 <span class="info" id="status">
@@ -82,7 +83,7 @@
                 </div>
             {% endif %}
 
-            {%  if measure_version.status == 'DRAFT' or new %}
+            {%  if new or measure_version.status == 'DRAFT' %}
                  <button class="govuk-button" type="submit" name="save">Save</button>
             {% endif %}
 
@@ -128,7 +129,7 @@
                     <div class="govuk-form-group">
                         <label class="govuk-label" for="subtopic">Topic</label>
                         <select id="subtopic" name="subtopic" class="govuk-select sub-topic"
-                                {% if form_disabled or (measure_version and measure_version.version != '1.0') or new %}disabled{% endif %}>
+                                {% if form_disabled or new or (measure_version and measure_version.version != '1.0') %}disabled{% endif %}>
                             {% for topic in topics %}
                                 <optgroup label="{{ topic.title }}">
                                     {% for st in topic.subtopics %}

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -15,7 +15,7 @@
 
 {% block content %}
     <form method="POST" action="{% if new %}{{ url_for('cms.create_measure', topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}{% else %}{{ url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}{% endif %}">
-        {{ form.csrf_token }}
+        {{ form.csrf_token | default('') }}
         {% call status_banner() %}
             <div class="left">
                 <span class="info">Version&nbsp;<b>{{ '1.0' if new else measure_version.version }}</b></span>
@@ -236,7 +236,7 @@
                                         {% if 'UPDATE' in measure_version.available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td class="govuk-table__cell">{% if 'UPDATE' in measure_version.available_actions %}
                                     <form action="{{ url_for('cms.delete_dimension', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, dimension_guid=dimension.guid ) }}" method="post">
-                                        {{ form.csrf_token }}
+                                        {{ form.csrf_token | default('') }}
                                         <button class="eff-button--link">delete</button>
                                     </form>
                                     {% endif %}
@@ -286,7 +286,7 @@
                                     <td class="govuk-table__cell">
                                         {% if 'UPDATE' in measure_version.available_actions %}
                                             <form action="{{ url_for('cms.delete_upload', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version, upload_guid=upload.guid ) }}" method="post">
-                                                {{ form.csrf_token }}
+                                                {{ form.csrf_token | default('') }}
                                                 <button class="eff-button--link">delete</button>
                                             </form>
                                         {% endif %}
@@ -309,7 +309,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form id="measure-action-section__copy_measure_form-{{ measure_version.id }}" method="POST" action="{{ url_for('cms.copy_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version) }}">
-                {{ form.csrf_token }}
+                {{ form.csrf_token | default('') }}
                 <button class="govuk-button copy-button" type="submit">Create a copy of this measure</button>
             </form>
         </div>

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -27,7 +27,7 @@
                 </p>
                 <p class="govuk-body">To replace this file choose another file below</p>
                 <form method="POST" enctype="multipart/form-data" action="{{ url_for('cms.edit_upload',topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, upload_guid=upload.guid, version=measure_version.version)}}">
-                    {{ form.csrf_token }}
+                    {{ form.csrf_token | default('') }}
                     {% block fields %}
                         <div class="govuk-form-group">
                         {{ form.upload.label(class='govuk-label') }}

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -7,7 +7,7 @@
     {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title},
   ]
 %}
-{% set form_disabled = not (measure_version.status == "DRAFT" or new) %}
+{% set form_disabled = measure_version.status != 'DRAFT' %}
 
 {% block pageTitle %}Edit source data{% endblock %}
 

--- a/application/templates/dashboards/ethnicity_classification.html
+++ b/application/templates/dashboards/ethnicity_classification.html
@@ -52,21 +52,6 @@
         {%  endfor %}
       {%  endfor %}
     {%  endfor %}
-
-    {% for page in pages %}
-        <tr class="govuk-table__row">
-        <td class="govuk-table__cell eff-table__cell--align-top">{{ page.topic }}</td>
-        <td class="govuk-table__cell eff-table__cell--align-top">{{ page.subtopic }}</td>
-        <td class="govuk-table__cell eff-table__cell--align-top">
-          <a class="govuk-link" href="{{ page.measure_url }}">{{ page.measure }}</a>
-            {% for dimension in page.dimensions %}
-                <ul class="dimensions">
-                   <li><a class="govuk-link" href="{{ page.measure_url }}#{{ dimension.dimension|slugify_value }}">… {{ dimension.short_title }}</a></li>
-                </ul>
-            {%  endfor %}
-        </td>
-      </tr>
-    {%  endfor %}
     </tbody>
   </table>
 

--- a/application/templates/dashboards/ethnicity_classifications.html
+++ b/application/templates/dashboards/ethnicity_classifications.html
@@ -35,7 +35,6 @@
 
     <tbody class="govuk-table__body">
       {% for ethnicity_classification in ethnicity_classifications %}
-          {% set has_broad_group = ethnicity_classification.parent_values|length > 0 %}
             <tr class="govuk-table__row">
               <th class="govuk-table__cell eff-table__cell--dense govuk-!-font-weight-regular"><a class="govuk-link" href="/dashboards/ethnicity-classifications/{{ ethnicity_classification.id }}">{{ ethnicity_classification.title }}</a></th>
               <td class="govuk-table__cell  eff-table__cell--dense govuk-table__cell--numeric">{{ ethnicity_classification.measure_count }}</td>

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -11,7 +11,7 @@
       {{- field.label.text }} {% if errors is defined and errors %}<span class="govuk-error-message">{{ errors[0] }}</span>{% endif -%}
     </legend>
     {% if field.hint or hint | default(false) %}
-    <span class="govuk-hint">{{ field.hint | default(hint, true) }}</span>
+    <span class="govuk-hint">{{ field.hint or hint }}</span>
     {% endif %}
       <div class="{{ govukBaseClass }}{% if inline %} {{ govukBaseClass }}--inline{% endif %}">
         {% for field in fields %}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -2,16 +2,16 @@
 
 {% set govukBaseClass = 'govuk-' + ('checkboxes' if field_type == 'checkbox' else 'radios') %}
 
-<div id="{{ id_ }}" name="{{ name }}" class="govuk-form-group{% if class_ %} {{ class_ }}{% endif %}{% if errors %} govuk-form-group--error{% endif %}">
+<div id="{{ id_ }}" name="{{ name }}" class="govuk-form-group{% if class_ %} {{ class_ }}{% endif %}{% if errors is defined and errors %} govuk-form-group--error{% endif %}">
   {% if fields|length == 1 %}
     {{ fields[0](disabled=disabled) }}
   {% else %}
   <fieldset class="govuk-fieldset{% if fieldset_class %} {{ fieldset_class }}{% endif %}">
     <legend id="{{ id_ + '-label'}}" class="govuk-fieldset__legend{% if legend_class %} {{ legend_class }}{% endif %}">
-      {{- field.label.text }} {% if errors %}<span class="govuk-error-message">{{ errors[0] }}</span>{% endif -%}
+      {{- field.label.text }} {% if errors is defined and errors %}<span class="govuk-error-message">{{ errors[0] }}</span>{% endif -%}
     </legend>
-    {% if field.hint or hint %}
-    <span class="govuk-hint">{{ field.hint or hint }}</span>
+    {% if field.hint or hint | default(false) %}
+    <span class="govuk-hint">{{ field.hint | default(hint, true) }}</span>
     {% endif %}
       <div class="{{ govukBaseClass }}{% if inline %} {{ govukBaseClass }}--inline{% endif %}">
         {% for field in fields %}

--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -9,14 +9,14 @@
 {{ field.label(id=field.id + '-label', class_='govuk-label') }}
 
 {% if field.hint or hint | default(false) %}
-  <span class="govuk-hint">{{ field.hint | default(hint, true) }}</span>
+  <span class="govuk-hint">{{ field.hint or hint }}</span>
 {% endif %}
 
 {% if field.errors %}
   <span class="govuk-error-message">{{ field.errors[0] }}</span>
 {% endif %}
 
-{{ field.extended_hint | default('', true) }}
+{{ field.extended_hint if field.extended_hint is defined and field.extended_hint else '' }}
 
 {% if textarea %}
   <textarea id="{{ id_ }}" name="{{ name }}" class="govuk-textarea {{ class_ }}{% if field.errors %} govuk-textarea--error{% endif %}{% if field.character_count_limit %} js-character-count{% endif %}" {{ field_params }}>{{ value or "" }}</textarea>

--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -8,14 +8,15 @@
 
 {{ field.label(id=field.id + '-label', class_='govuk-label') }}
 
-{% if field.hint or hint %}
-  <span class="govuk-hint">{{ field.hint or hint }}</span>
+{% if field.hint or hint | default(false) %}
+  <span class="govuk-hint">{{ field.hint | default(hint, true) }}</span>
 {% endif %}
+
 {% if field.errors %}
   <span class="govuk-error-message">{{ field.errors[0] }}</span>
 {% endif %}
 
-{{ field.extended_hint if field.extended_hint }}
+{{ field.extended_hint | default('', true) }}
 
 {% if textarea %}
   <textarea id="{{ id_ }}" name="{{ name }}" class="govuk-textarea {{ class_ }}{% if field.errors %} govuk-textarea--error{% endif %}{% if field.character_count_limit %} js-character-count{% endif %}" {{ field_params }}>{{ value or "" }}</textarea>
@@ -23,7 +24,7 @@
   <input id="{{ id_ }}" name="{{ name }}" class="govuk-input {{ class_ }}{% if field.errors %} govuk-input--error{% endif %}" value="{{ value }}" {{ field_params }}>
 {% endif %}
 
-{% if not field.errors and diffs %}
+{% if not field.errors and diffs is defined and diffs and name in diffs %}
   <p class="govuk-body">Your update to "{{ field.label.text }}" is highlighted green and possible deletions are highlighted red. If these changes are fine, save the page, otherwise edit the copy above and then save.</p>
   <div class="govuk-body differences">
       {{ diffs[name] | render_markdown }}

--- a/application/templates/register/set_account_password.html
+++ b/application/templates/register/set_account_password.html
@@ -10,7 +10,7 @@
                 <h1 class="govuk-heading-xl">Set password</h1>
                 <p class="govuk-body">Your user name: {{ user.email }}</p>
                 <form class="form"  action="{{url_for('register.confirm_account', token=token)}}" method="POST">
-                    {{ form.csrf_token }}
+                    {{ form.csrf_token | default('') }}
                     {{ form.password }}
                     {{ form.confirm_password }}
                     <button type="submit" class="govuk-button" name="set">Set password</button>

--- a/application/templates/security/login_user.html
+++ b/application/templates/security/login_user.html
@@ -17,7 +17,7 @@ prefix does not get added there. #}
                 <h1 class="govuk-heading-xl">Login</h1>
 
                 <form action="{{ url_for('security.login') }}" method="post">
-                    {{ login_user_form.csrf_token }}
+                    {{ login_user_form.csrf_token | default('') }}
 
                     {{ login_user_form.email }}
 

--- a/application/templates/security/login_user.html
+++ b/application/templates/security/login_user.html
@@ -8,7 +8,7 @@ this template receives, so can't make sure it's rendered with the `errors` varia
 is added in the base template, the {% set errors %} above isn't in scope when the base template is rendered, so the
 prefix does not get added there. #}
 
-{% block pageTitle %}{% if errors %}Error: {% endif %}Login{% endblock %}
+{% block pageTitle %}{% if errors is defined and errors %}Error: {% endif %}Login{% endblock %}
 {% block nav_home %}active{% endblock %}
 
 {% block content %}

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -9,7 +9,7 @@
           <div>
             <span><a class="govuk-link" href="https://www.ethnicity-facts-figures.service.gov.uk">Live website</a></span>
 
-            {% if not current_user.is_anonymous and not preview %}
+            {% if not current_user.is_anonymous and (preview is undefined or not preview) %}
               <span><a class="govuk-link" href="{{ url_for('static_site.topic', topic_slug=TESTING_SPACE_SLUG) }}">Testing space</a></span>
 
               {% if current_user.is_authenticated and current_user.can(MANAGE_USERS) %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -1,5 +1,5 @@
 
-{{ dimension.header | default('', true) }}
+{{ dimension.header if dimension.header is defined and dimension.header else '' }}
 {% if dimension.dimension_table.table_object.header %}
   <h3 class="govuk-heading-s">{{ dimension.dimension_table.table_object.header }}</h3>
 {% endif %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -1,5 +1,5 @@
 
-{{ dimension.header }}
+{{ dimension.header | default('', true) }}
 {% if dimension.dimension_table.table_object.header %}
   <h3 class="govuk-heading-s">{{ dimension.dimension_table.table_object.header }}</h3>
 {% endif %}
@@ -39,8 +39,8 @@
 
       <tr>
         <th class="govuk-table__header eff-table__header--border-right eff-table__header--dense eff-table__header--align-top eff-table__header--padding-top-0
-         {{ th_class }}" aria-sort="none">
-            {% if dimension.dimension_table.table_object.category_caption %}
+         {{ th_class | default('') }}" aria-sort="none">
+            {% if dimension.dimension_table.table_object.category_caption is defined and dimension.dimension_table.table_object.category_caption %}
                 {{ dimension.dimension_table.table_object.category_caption }}
             {% else %}
                 {{ dimension.dimension_table.table_object.category }}
@@ -66,7 +66,7 @@
                 {% set group_loop = loop %}
                 {% if group_column %}
                     {% for column in dimension.dimension_table.table_object.columns %}
-                      {% set th_class = "eff-table__header--border-right" if loop.last and (group_loop.index != group_loop.length) %}
+                      {% set th_class = "eff-table__header--border-right" if loop.last and (group_loop.index != group_loop.length) else "" %}
                       <th class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular eff-table__header--dense eff-table__header--align-top eff-table__header--padding-top-0 eff-table__cell--padding-left {{ th_class }}" aria-sort="none">{{ column }}</th>
                     {% endfor %}
                 {% endif %}
@@ -108,7 +108,7 @@
           {% for value in data['values'] %}
             {% set sort_value = value %}
 
-            {% if data.sort_values %}
+            {% if data.sort_values is defined and data.sort_values %}
               {% if data.sort_values[loop.index0] in missing_data_sort_order_values %}
                 {% set sort_value = missing_data_sort_order_values[data.sort_values[loop.index0]] %}
               {% elif data.sort_values[loop.index0] %}
@@ -117,21 +117,21 @@
             {% endif %}
 
             {% if loop.first %}
-              {% set data_order = data.order if data.order else row_loop.index0 %}
-              {% set row_scope = 'rowgroup' if data.relationships and data.relationships.is_parent else 'row' %}
+              {% set data_order = data.order if data.order is defined and data.order else row_loop.index0 %}
+              {% set row_scope = 'rowgroup' if data.relationships is defined and data.relationships.is_parent else 'row' %}
 
-              {% set th_class = 'eff-table__header--child' if dimension.dimension_table.table_object.parent_child and not data.relationships.is_parent else '' %}
+              {% set th_class = 'eff-table__header--child' if dimension.dimension_table.table_object.parent_child is defined and dimension.dimension_table.table_object.parent_child and not data.relationships.is_parent else '' %}
               <th class="govuk-table__header eff-table__header--border-right eff-table__header--dense {{ th_class }}" data-sort-value="{{ data_order }}" scope="{{ row_scope }}">{{ data.category }}</th>
             {% endif %}
 
             {# We only want the 'eff-table-__header-border-right' class on the last column within each group #}
-            {% set td_class = "eff-table__header--border-right" if ((loop.index != loop.length) and (loop.index % (dimension.dimension_table.table_object.columns|length) == 0)) %}
+            {% set td_class = "eff-table__header--border-right" if ((loop.index != loop.length) and (loop.index % (dimension.dimension_table.table_object.columns|length) == 0)) else "" %}
 
             <td data-sort-value="{{sort_value}}" class="govuk-table__cell govuk-table__cell--numeric eff-table__cell--padding-left eff-table__cell--dense {{ td_class }}">{{ value|value_filter|safe }}</td>
           {% endfor %}
         </tr>
 
-        {% if next_row and next_row.relationships and next_row.relationships.is_parent %}
+        {% if next_row is defined and next_row.relationships is defined and next_row.relationships.is_parent %}
           </tbody>
           <tbody>
         {% endif %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -53,7 +53,7 @@
 
             {% for group_column in dimension.dimension_table.table_object.group_columns %}
 
-                {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) %}
+                {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) else "" %}
 
                 {% if group_column %}
                     <th class="govuk-table__header govuk-table__header--numeric eff-table__header--dense eff-table__header--align-top eff-table__header--border-bottom-0  eff-table__header--padding-top-0 {{th_class}}" aria-sort="none"> {{ group}} {{ group_column|safe }}</th>
@@ -88,7 +88,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell eff-table__cell--border-right "></td>
               {% for group_column in dimension.dimension_table.table_object.group_columns %}
-                {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) %}
+                {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) else "" %}
 
                 {% if group_column %}
                   <th class="govuk-table__header govuk-table__header--numeric eff-table__header--dense eff-table__header--align-top eff-table__header--padding-top-0 {{th_class}}"> {{ heading }}</th>

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -56,7 +56,7 @@
                 {% set th_class = "eff-table__header--border-right" if (loop.index != loop.length) else "" %}
 
                 {% if group_column %}
-                    <th class="govuk-table__header govuk-table__header--numeric eff-table__header--dense eff-table__header--align-top eff-table__header--border-bottom-0  eff-table__header--padding-top-0 {{th_class}}" aria-sort="none"> {{ group}} {{ group_column|safe }}</th>
+                    <th class="govuk-table__header govuk-table__header--numeric eff-table__header--dense eff-table__header--align-top eff-table__header--border-bottom-0  eff-table__header--padding-top-0 {{th_class}}" aria-sort="none"> {{ group_column|safe }}</th>
                 {% endif %}
             {% endfor %}
 

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -461,7 +461,7 @@
               {% if measure_version.primary_data_source.frequency_of_release %}
                 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Publication frequency</h3>
                 {% if measure_version.primary_data_source.frequency_of_release.description == 'Other' %}
-                  <p class="govuk-body">{{ measure_version.primary_data_source.frequency_other }}</p>
+                  <p class="govuk-body">{{ measure_version.primary_data_source.frequency_of_release_other }}</p>
                 {% else %}
                   <p class="govuk-body">{{ measure_version.primary_data_source.frequency_of_release.description }}</p>
                 {% endif %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -235,8 +235,6 @@
       {% if measure_version.dimensions %}
           {% for dimension in measure_version.dimensions %}
 
-            {% set chart_and_downloadable = True if dimension.dimension_chart.chart_object and dimension.dimension_chart.chart_object.type not in ['panel_bar_chart', 'panel_line_chart'] else False %}
-
               <div class="govuk-grid-column-two-thirds">
                   <h2 class="govuk-heading-m" id="{{ dimension.title | slugify_value }}">{{ dimension.title }}</h2>
                   <div class="metadata">
@@ -266,6 +264,8 @@
               </div>
             </div>
 
+            {% if dimension.dimension_chart %}
+              {% set chart_and_downloadable = (dimension.dimension_chart.chart_object.type not in ['panel_bar_chart', 'panel_line_chart']) %}
               <div class="chart-and-footer hidden">
                 <div class="govuk-grid-row">
                   <div class="rd_chart" id="chart_{{ dimension.guid }}" style="clear: both; overflow: hidden"></div>
@@ -303,15 +303,14 @@
                 </div>
               </div>
             </div>
+            {% endif %}
 
+            {% if dimension.dimension_table %}
             <div class="govuk-grid-row">
-              {% set tabular_download_viable = True if dimension.dimension_table.table_object else False %}
               <div class="govuk-grid-column-full"
                    style="{% if not dimension.dimension_table and not dimension.dimension_chart.chart_object %}display: none;{% endif %}">
-                  {% if dimension.dimension_table.table_object %}
                       {% include "static_site/_table.html" %}
 
-                      {% if tabular_download_viable %}
                       <p class="chart-download">
                           {% if static_mode %}
                               <a class="govuk-link" href="{{ url_for('static_site.measure_version_file_download', topic_slug=topic_slug,
@@ -345,10 +344,10 @@
                                    dimension_guid=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data (CSV)</a>
                           {% endif %}
                       </p>
-                    {% endif %}
-                  {% endif %}
               </div>
             </div>
+            {% endif %}
+
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
                   <h3 class="govuk-heading-s">Summary</h3>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -319,7 +319,7 @@
                                    measure_slug=measure_version.measure.slug,
                                    version=version,
                                    filename=dimension.static_table_file_name) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}"
-                                 download="{{ dimension.dimension_table.static_table_file_name }}">Download table data (CSV)</a>
+                                 download="{{ dimension.static_table_file_name }}">Download table data (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_table_download',
                                    topic_slug=topic_slug,

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -7,7 +7,7 @@
     {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
     {"url": url_for("static_site.topic", topic_slug=topic_slug), "text": measure_version.measure.subtopic.topic.title},
   ]
-  if not preview else
+  if preview | default(true) else
   none
 %}
 
@@ -37,14 +37,14 @@
                           version=version) }}"/>
 
 
-  {% if not static_mode and not preview %}
+  {% if not static_mode and (preview is undefined or not preview) %}
     {% call status_banner(sticky=False) %}
       <div class="left">
-          <span class="info">Version&nbsp;<b>{% if new %}1.0{% else %}{{ measure_version.version }}{% endif %}</b></span>
+          <span class="info">Version&nbsp;<b>{{ measure_version.version }}</b></span>
       </div>
       <div>
           <span class="info" id="status">
-              Status:&nbsp;<b>{{ ("DRAFT" if new else measure_version.status) | format_status | safe }}</b>
+              Status:&nbsp;<b>{{ measure_version.status | format_status | safe }}</b>
           </span>
 
           {% if measure_version.measure.versions|length > 1 %}
@@ -569,9 +569,9 @@
                   <meta itemprop="name" content="{{ file.title | striptags }}">
                   <a class="govuk-link govuk-!-font-size-19" itemprop="contentUrl" href="{{ measure_version_data_url }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Source data" data-event-label="{{ file.title }}">
                         {{ file.title }}
-                        {{ " - Spreadsheet " if file.extension() == "csv" }}
-                        {{ " - Microsoft Excel " if file.extension() == "xls" or file.extension() == "xlsx" }}
-                        {{ " - Open Document Format " if file.extension() == "odf" }}
+                        {{ " - Spreadsheet " if file.extension() == "csv" else "" }}
+                        {{ " - Microsoft Excel " if file.extension() == "xls" or file.extension() == "xlsx" else "" }}
+                        {{ " - Open Document Format " if file.extension() == "odf" else "" }}
                         ({{ file.extension() }})
                         {{ file.size|filesize }}
                   </a>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -432,12 +432,12 @@
 
           <div class="govuk-accordion__section-content" id="data-sources-content" aria-labelledby="data-sources-heading">
             <div itemprop="isBasedOn" itemscope itemtype="http://schema.org/Dataset">
+            {% if measure_version.primary_data_source %}
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Source</h3>
             <p class="govuk-body" itemprop="name"><a class="govuk-link" href="{{ measure_version.primary_data_source.source_url }}" data-on="click" data-event-category="External link clicked" data-event-action="Data Source (Source Details section)" data-event-label="{{ measure_version.title }}" itemprop="url">
                 {{ measure_version.primary_data_source.title }}</a>
             </p>
 
-            {% if measure_version.primary_data_source %}
               {% if measure_version.primary_data_source.type_of_data %}
               <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Type of data</h3>
               <p class="govuk-body">{{ measure_version.primary_data_source.type_of_data| join_enum_display_names(' and ') }} data</p>

--- a/tests/application/sitebuilder/test_build_service.py
+++ b/tests/application/sitebuilder/test_build_service.py
@@ -56,6 +56,8 @@ def test_static_site_build(db_session, single_use_app):
                                 s3_fs_patch.side_effect = UnexpectedMockInvocationException
                                 trello_service_patch.get_measure_cards.return_value = []
 
+                                from tests.test_data.chart_and_table import chart, simple_table
+
                                 # Including these three versioned pages ensures the build test exercises the logic to
                                 # build multiple page versions
                                 measure = MeasureFactory()
@@ -66,6 +68,8 @@ def test_static_site_build(db_session, single_use_app):
                                     latest=False,
                                     published_at=datetime.now().date(),
                                     version="1.0",
+                                    dimensions__dimension_chart=None,
+                                    dimensions__dimension_table__table_object=simple_table(),
                                 )
                                 # Latest published version
                                 MeasureVersionWithDimensionFactory(
@@ -74,16 +78,22 @@ def test_static_site_build(db_session, single_use_app):
                                     latest=False,
                                     published_at=datetime.now().date(),
                                     version="2.0",
+                                    dimensions__dimension_chart=None,
+                                    dimensions__dimension_table__table_object=simple_table(),
                                 )
                                 # Newer draft version
                                 MeasureVersionWithDimensionFactory(
-                                    measure=measure, status="DRAFT", published_at=None, latest=True, version="2.1"
+                                    measure=measure,
+                                    status="DRAFT",
+                                    published_at=None,
+                                    latest=True,
+                                    version="2.1",
+                                    dimensions__dimension_chart=None,
+                                    dimensions__dimension_table=None,
                                 )
 
                                 # Publish another page with dimension, chart and table to ensure there's an item for
                                 # each of the dashboard views
-                                from tests.test_data.chart_and_table import chart, simple_table
-
                                 MeasureVersionWithDimensionFactory(
                                     status="APPROVED",
                                     latest=True,

--- a/tests/application/test_factory.py
+++ b/tests/application/test_factory.py
@@ -1,0 +1,19 @@
+from flask import render_template_string
+
+
+class TestTemplateGlobals:
+    def test_static_mode(self, single_use_app):
+        @single_use_app.route("/test-globals")
+        def test_globals():
+            return render_template_string("""{{ static_mode }}""")
+
+        client = single_use_app.test_client()
+
+        single_use_app.config["STATIC_MODE"] = False
+        assert client.get("/test-globals").get_data(as_text=True) == "False"
+
+        single_use_app.config["STATIC_MODE"] = True
+        assert client.get("/test-globals").get_data(as_text=True) == "True"
+
+        assert client.get("/test-globals?static_mode=no").get_data(as_text=True) == "False"
+        assert client.get("/test-globals?static_mode=yes").get_data(as_text=True) == "True"


### PR DESCRIPTION
## Summary
Tighten up the variable namespace when rendering templates, so that references to undefined variables cause errors.

## Reasoning
We've seen a few bugs get out to production over the last few months that would have been prevented if Jinja2 failed fast when rendering templates with undefined variables. Enabling this option will mean it's far easier to detect templates with wonky logic.

## Details
By default, when rendering templates, you don't need to explicitly provide, at runtime, values for every variable referenced within that template. Any undefined variables automatically coalesce to `None`-ish values. This can make it easier to quickly write templates, but we've experienced bugs from this behaviour and so are making the template rendering engine more strict - it raises an error when it encounters an undefined variable. There's one main exception to this: explicitly checking that the variable is defined (with the `is defined` or `is undefined` Jinja2 test).

We should aim to always provide a value for every variable in the template at runtime, but if this is unreasonable (e.g. we are referencing a variable in the base template and don't want to specify it for every single template render), we can use the un/defined checks.

Side effect: all views now have access to a `static_mode` variable, and will understand the `static_mode` URL query parameter.

**NOTE**: I recommend reviewing this commit-by-commit.

## Ticket
https://trello.com/c/gZlHQpZB