### PR TITLE
Refactor the sortable button styles

### DIFF
--- a/application/src/js/all/_sortable_table.js
+++ b/application/src/js/all/_sortable_table.js
@@ -71,6 +71,7 @@ SortableTable.prototype.createHeadingButton = function(heading, i) {
     var button = document.createElement('button')
     button.setAttribute('type', 'button')
     button.setAttribute('data-index', i)
+    button.setAttribute('class', 'govuk-button eff-button--link eff-button--sort')
     button.textContent = text
     button.addEventListener('click', this.sortButtonClicked.bind(this))
     heading.textContent = '';
@@ -194,6 +195,9 @@ SortableTable.prototype.compareValues = function(valueA, valueB, sortDirection) 
 SortableTable.prototype.updateButtonState = function(button, direction) {
     button.parentElement.setAttribute('aria-sort', direction);
 
+    button.classList.remove('eff-button--sort')
+    button.classList.add('eff-button--sort-' + direction)
+
     if ('ga' in window) {
       var eventAction = (direction == 'ascending' ? 'Descending' : 'Ascending')
       button.setAttribute('data-event-action', eventAction)
@@ -213,12 +217,29 @@ SortableTable.prototype.removeButtonStates = function() {
       tableHeaders[i].setAttribute('aria-sort', 'none')
     };
 
+
+    var buttons = this.table.querySelectorAll('thead button')
+
+    for (var i = buttons.length - 1; i >= 0; i--) {
+      buttons[i].classList.remove('eff-button--sort-ascending')
+      buttons[i].classList.remove('eff-button--sort-descending')
+      buttons[i].classList.add('eff-button--sort')
+    };
+
     if (this.header_table) {
 
       var tableHeaders = this.header_table.querySelectorAll('thead th')
 
       for (var i = tableHeaders.length - 1; i >= 0; i--) {
         tableHeaders[i].setAttribute('aria-sort', 'none')
+      };
+
+      var buttons = this.header_table.querySelectorAll('thead button')
+
+      for (var i = buttons.length - 1; i >= 0; i--) {
+        buttons[i].classList.remove('eff-button--sort-ascending')
+        buttons[i].classList.remove('eff-button--sort-descending')
+        buttons[i].classList.add('eff-button--sort')
       };
 
 

--- a/application/src/sass/components/_buttons.scss
+++ b/application/src/sass/components/_buttons.scss
@@ -98,9 +98,9 @@ $eff-quiet-button-hover-colour: mix($black, $eff-quiet-button-colour, 15%);
 
 /* Link button
 
-   Use on buttons that should look like they're links
+   Use on buttons that should look like they're links,
+   except with no underline.
 */
-
 .eff-button--link {
   color: govuk-colour("blue");
   font-size: inherit;
@@ -111,4 +111,19 @@ $eff-quiet-button-hover-colour: mix($black, $eff-quiet-button-colour, 15%);
   background-color: transparent;
   box-shadow: none;
   cursor: pointer;
+}
+
+.eff-button--link:active {
+  color: govuk-colour("blue");
+}
+
+.eff-button--link:focus,
+.eff-button--link:focus:hover {
+  background-color: $govuk-focus-colour;
+  color: $govuk-focus-text-colour;
+}
+
+.eff-button--link:hover {
+  color: $govuk-link-hover-colour;
+  background-color: transparent;
 }

--- a/application/src/sass/components/_sort_buttons.scss
+++ b/application/src/sass/components/_sort_buttons.scss
@@ -1,63 +1,63 @@
-/* Sort buttons
+/* Sort button modifiers
  *
- * TODO: convert to BEM naming conventions.
-*/
-[aria-sort] button,
-[aria-sort] button:hover,
-[aria-sort] button:focus {
-  background-color: transparent;
-  border-width: 0;
-  -webkit-box-shadow: 0 0 0 0;
-  -moz-box-shadow: 0 0 0 0;
-  box-shadow: 0 0 0 0;
-  color: #005ea5;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  padding: 0 10px 0 0;
+ * These are used for indicating that a button can be used to re-order
+ * a table by a particular column, in either ascending or descending order.
+ *
+ * The modifier classes should be added alongside the base component class
+ * from the GOV.UK Design System of `govuk-button`
+ *
+ * When un-sorted (`eff-button--sort`), the button includes both up and down
+ * arrows on the right, as an affordance to indicate what the button does.
+ *
+ * When sorted in a particular direction (`eff-button--sort-ascending` or `eff-button--sort-descending`(, a single (larger) up or down arrow is shown.
+ *
+ * This modifier can also be used alongside the `eff-button--link` modifier, in
+ * order to style the button to look more like a link than a button.
+ */
+.eff-button--sort,
+.eff-button--sort-ascending,
+.eff-button--sort-descending {
   position: relative;
-  text-align: inherit;
-  font-size: 1em;
+  padding: 0 10px 0 0;
 }
 
-[aria-sort]:first-child button {
-  right: auto;
-}
-
-[aria-sort] button:before {
-  content: " \25bc";
+.eff-button--sort:before,
+.eff-button--sort:active:before {
+  content: " \25bc"; /* ▼ */
   position: absolute;
   right: -2px;
   top: 9px;
   font-size: 0.5em;
+  text-align: right;
 }
 
-[aria-sort] button:after {
-  content: " \25b2";
+.eff-button--sort:after,
+.eff-button--sort:active:after {
+  content: " \25b2"; /* ▲ */
   position: absolute;
   right: -2px;
   top: 0px;
   font-size: 0.5em;
+  text-align: right;
 }
 
-  [aria-sort="ascending"] button:before,
-  [aria-sort="descending"] button:before {
-    content: none;
-  }
+.eff-button--sort-ascending:before,
+.eff-button--sort-descending:before {
+  content: none;
+}
 
-  [aria-sort="ascending"] button:after {
-    content: " \25b2";
-    font-size: .7em;
-    position: absolute;
-    right: -2px;
-    top: 2px;
-  }
+.eff-button--sort-ascending:after {
+  content: " \25b2"; /* ▲ */
+  font-size: .7em;
+  position: absolute;
+  right: -2px;
+  top: 2px;
+}
 
-  [aria-sort="descending"] button:after {
-    content: " \25bc";
-    font-size: .7em;
-    position: absolute;
-    right: -2px;
-    top: 2px;
-  }
+.eff-button--sort-descending:after {
+  content: " \25bc"; /* ▼ */
+  font-size: .7em;
+  position: absolute;
+  right: -2px;
+  top: 2px;
+}


### PR DESCRIPTION
This refactors the "sort buttons" on tables to use the BEM convention from GOV.UK Design System.

In doing so, it also updates the focus style for the buttons to use black text on a solid yellow background.

Current focus style:

<img width="1015" alt="Screenshot 2019-04-29 at 14 55 08" src="https://user-images.githubusercontent.com/30665/56900908-de5c4500-6a8e-11e9-9b0c-dc31d78d0d44.png">

New focus style:

<img width="1002" alt="Screenshot 2019-04-29 at 14 55 26" src="https://user-images.githubusercontent.com/30665/56900926-e3b98f80-6a8e-11e9-819b-a79ead7f5569.png">
