### PR TITLE
Fix for "publication frequency" styling

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -510,10 +510,10 @@
                 {% if measure_version.secondary_data_source.frequency_of_release %}
                   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Publication frequency</h3>
                   {% if measure_version.secondary_data_source.frequency_of_release.description == 'Other' %}
-                        {{ measure_version.secondary_data_source.frequency_of_release_other }}
+                    <p class="govuk-body">{{ measure_version.secondary_data_source.frequency_of_release_other }}</p>
                   {% else %}
-                      {{ measure_version.secondary_data_source.frequency_of_release.description }}
-                  {% endif %}
+                    <p class="govuk-body">{{ measure_version.secondary_data_source.frequency_of_release.description }}
+                  {% endif %}</p>
                 {% endif %}
 
                 {% if measure_version.secondary_data_source.purpose %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -512,8 +512,8 @@
                   {% if measure_version.secondary_data_source.frequency_of_release.description == 'Other' %}
                     <p class="govuk-body">{{ measure_version.secondary_data_source.frequency_of_release_other }}</p>
                   {% else %}
-                    <p class="govuk-body">{{ measure_version.secondary_data_source.frequency_of_release.description }}
-                  {% endif %}</p>
+                    <p class="govuk-body">{{ measure_version.secondary_data_source.frequency_of_release.description }}</p>
+                  {% endif %}
                 {% endif %}
 
                 {% if measure_version.secondary_data_source.purpose %}


### PR DESCRIPTION
This fixes this styling bug, caused by some missing HTML:

<img width="252" alt="Screenshot 2019-05-01 at 10 12 42" src="https://user-images.githubusercontent.com/30665/57011484-c5bc6e00-6bf9-11e9-8084-a4d8ed6fe172.png">
