### PR TITLE
Display table headings using `caption` elements

### DIFF
--- a/application/src/js/all/_table_with_fixed_header.js
+++ b/application/src/js/all/_table_with_fixed_header.js
@@ -18,18 +18,25 @@ function TableWithFixedHeader(outerTableElement) {
         tableHeader = tableElement.querySelector('thead')
 
         var fixedTableHeader = tableHeader.cloneNode(true)
-        var fixedTableCaption = tableCaption.cloneNode(true)
+        var fixedTableCaption;
+
+        if (tableCaption != null) {
+          fixedTableCaption = tableCaption.cloneNode(true)
+          tableCaption.classList.add('eff-table__caption--transparent')
+        }
 
         fixedTableHeader.classList.add('fixed')
         tableHeader.classList.add('eff-table__head--transparent')
-        tableCaption.classList.add('eff-table__caption--transparent')
 
         fixedTable = document.createElement('table')
 
         fixedTable.setAttribute('class', tableElement.getAttribute('class') + ' fixed')
         fixedTable.classList.remove('fixed-headers')
 
-        fixedTable.appendChild(fixedTableCaption)
+        if (fixedTableCaption != null) {
+          fixedTable.appendChild(fixedTableCaption)
+        }
+
         fixedTable.appendChild(fixedTableHeader)
 
         fixedTableContainer = document.createElement('div')
@@ -41,18 +48,27 @@ function TableWithFixedHeader(outerTableElement) {
         /* Update again after 200ms. Solves a few weird issues. */
         setTimeout(updatePositioning, 200)
 
+        /* Update again after 400ms. Solves a few weird issues. */
+        setTimeout(updatePositioning, 1000)
+
       }
     }
   }
 
   function updatePositioning() {
 
+    var captionHeight, height;
     var headerHeight = heightForElement(tableHeader);
-    var captionHeight = heightForElement(fixedTable.querySelector('caption'), true)
-    var combinedHeight = (parseFloat(headerHeight) + parseFloat(captionHeight)) + 'px'
 
-    tableElement.style.marginTop = '-' + combinedHeight;
-    innerTableElement.style.paddingTop = combinedHeight;
+    if (fixedTable.querySelector('caption') != undefined) {
+      captionHeight = heightForElement(fixedTable.querySelector('caption'))
+      height = (parseFloat(headerHeight) + parseFloat(captionHeight)) + 'px'
+    } else {
+      height = headerHeight
+    }
+
+    tableElement.style.marginTop = '-' + height;
+    innerTableElement.style.paddingTop = height;
 
     var mainTableHeaderCells = tableElement.querySelectorAll('thead th, thead td')
     var headerCells = fixedTable.querySelectorAll('thead th, thead td')
@@ -77,17 +93,12 @@ function TableWithFixedHeader(outerTableElement) {
 
   }
 
-  function heightForElement(element, includeMargin) {
+  function heightForElement(element) {
 
     var height;
 
     if (typeof window.getComputedStyle === "function") {
-      var styles = getComputedStyle(element);
-      height = styles.height
-
-      if (includeMargin === true) {
-        height = (parseFloat(height) + parseFloat(styles.marginTop) + parseFloat(styles.marginBottom)) + 'px';
-      }
+      height = getComputedStyle(element).height
     }
 
     if (!height || height == 'auto') {

--- a/application/src/js/all/_table_with_fixed_header.js
+++ b/application/src/js/all/_table_with_fixed_header.js
@@ -2,7 +2,7 @@ function TableWithFixedHeader(outerTableElement) {
 
   var outerTableElement = outerTableElement
   var middleTableElement, innerTableElement, tableContainer,
-    tableElement, fixedTable, tableHeader, fixedTableContainer
+    tableElement, fixedTable, tableHeader, fixedTableContainer, tableCaption
 
   function setup() {
 
@@ -11,27 +11,31 @@ function TableWithFixedHeader(outerTableElement) {
       innerTableElement = outerTableElement.querySelector('.table-container-inner')
       tableContainer = outerTableElement.querySelector('.table-container')
       tableElement = outerTableElement.querySelector('table')
+      tableCaption = outerTableElement.querySelector('caption')
 
       if (tableContainer) {
 
         tableHeader = tableElement.querySelector('thead')
 
         var fixedTableHeader = tableHeader.cloneNode(true)
-        fixedTableHeader.classList.add('fixed')
+        var fixedTableCaption = tableCaption.cloneNode(true)
 
+        fixedTableHeader.classList.add('fixed')
         tableHeader.classList.add('eff-table__head--transparent')
+        tableCaption.classList.add('eff-table__caption--transparent')
 
         fixedTable = document.createElement('table')
+
         fixedTable.setAttribute('class', tableElement.getAttribute('class') + ' fixed')
         fixedTable.classList.remove('fixed-headers')
 
+        fixedTable.appendChild(fixedTableCaption)
         fixedTable.appendChild(fixedTableHeader)
 
         fixedTableContainer = document.createElement('div')
         fixedTableContainer.classList.add('fixed-header-container')
 
         fixedTableContainer.appendChild(fixedTable)
-
         innerTableElement.appendChild(fixedTableContainer)
 
         /* Update again after 200ms. Solves a few weird issues. */
@@ -43,10 +47,12 @@ function TableWithFixedHeader(outerTableElement) {
 
   function updatePositioning() {
 
-    var height = heightForElement(tableHeader);
+    var headerHeight = heightForElement(tableHeader);
+    var captionHeight = heightForElement(fixedTable.querySelector('caption'), true)
+    var combinedHeight = (parseFloat(headerHeight) + parseFloat(captionHeight)) + 'px'
 
-    tableElement.style.marginTop = '-' + height;
-    innerTableElement.style.paddingTop = height;
+    tableElement.style.marginTop = '-' + combinedHeight;
+    innerTableElement.style.paddingTop = combinedHeight;
 
     var mainTableHeaderCells = tableElement.querySelectorAll('thead th, thead td')
     var headerCells = fixedTable.querySelectorAll('thead th, thead td')
@@ -71,12 +77,17 @@ function TableWithFixedHeader(outerTableElement) {
 
   }
 
-  function heightForElement(element) {
+  function heightForElement(element, includeMargin) {
 
     var height;
 
     if (typeof window.getComputedStyle === "function") {
-      height = getComputedStyle(element).height
+      var styles = getComputedStyle(element);
+      height = styles.height
+
+      if (includeMargin === true) {
+        height = (parseFloat(height) + parseFloat(styles.marginTop) + parseFloat(styles.marginBottom)) + 'px';
+      }
     }
 
     if (!height || height == 'auto') {

--- a/application/src/js/all/_table_with_fixed_header.js
+++ b/application/src/js/all/_table_with_fixed_header.js
@@ -19,6 +19,8 @@ function TableWithFixedHeader(outerTableElement) {
         var fixedTableHeader = tableHeader.cloneNode(true)
         fixedTableHeader.classList.add('fixed')
 
+        tableHeader.classList.add('eff-table__head--transparent')
+
         fixedTable = document.createElement('table')
         fixedTable.setAttribute('class', tableElement.getAttribute('class') + ' fixed')
         fixedTable.classList.remove('fixed-headers')

--- a/application/src/sass/components/_table.scss
+++ b/application/src/sass/components/_table.scss
@@ -98,6 +98,10 @@
   border-color: transparent;
 }
 
+.eff-table__caption {
+  display: table-caption;
+}
+
 /* Outer container is max-width */
 .table-container-outer {
   width: 100%;

--- a/application/src/sass/components/_table.scss
+++ b/application/src/sass/components/_table.scss
@@ -98,10 +98,6 @@
   border-color: transparent;
 }
 
-.eff-table__caption {
-  display: table-caption;
-}
-
 /* Outer container is max-width */
 .table-container-outer {
   width: 100%;

--- a/application/src/sass/components/_table.scss
+++ b/application/src/sass/components/_table.scss
@@ -93,7 +93,7 @@
 
 /* Hide the main table header content (in case it peeks through
    when bouncing back from momentum scroll) */
-.eff-table__head--transparent {
+.eff-table__head--transparent, .eff-table__caption--transparent {
   opacity: 0;
   border-color: transparent;
 }

--- a/application/src/sass/components/_table.scss
+++ b/application/src/sass/components/_table.scss
@@ -93,7 +93,7 @@
 
 /* Hide the main table header content (in case it peeks through
    when bouncing back from momentum scroll) */
-.table-container thead th, .table-container thead td {
+.eff-table__head--transparent {
   opacity: 0;
   border-color: transparent;
 }

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -14,9 +14,7 @@
 
       <div class="table-container">
     <table class="govuk-table govuk-!-margin-bottom-0">
-    {% if dimension.dimension_table.table_object.header %}
       <caption class="govuk-table__caption govuk-!-padding-bottom-3">{{ dimension.dimension_table.table_object.header }}</caption>
-    {% endif %}
     <thead class="govuk-table__head">
 
       {% if (dimension.dimension_table.table_object.type == "grouped") and (dimension.dimension_table.table_object.columns|length > 1) %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -15,7 +15,7 @@
       <div class="table-container">
     <table class="govuk-table govuk-!-margin-bottom-0">
     {% if dimension.dimension_table.table_object.header %}
-      <caption class="govuk-table__caption">{{ dimension.dimension_table.table_object.header }}</caption>
+      <caption class="govuk-table__caption govuk-!-padding-bottom-3">{{ dimension.dimension_table.table_object.header }}</caption>
     {% endif %}
     <thead class="govuk-table__head">
 

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -1,8 +1,5 @@
 
 {{ dimension.header if dimension.header is defined and dimension.header else '' }}
-{% if dimension.dimension_table.table_object.header %}
-  <h3 class="govuk-heading-s">{{ dimension.dimension_table.table_object.header }}</h3>
-{% endif %}
 
 {% set missing_data_sort_order_values = {
   "N/A": -9999999,
@@ -17,6 +14,9 @@
 
       <div class="table-container">
     <table class="govuk-table govuk-!-margin-bottom-0">
+    {% if dimension.dimension_table.table_object.header %}
+      <caption class="govuk-heading-s eff-table__caption">{{ dimension.dimension_table.table_object.header }}</caption>
+    {% endif %}
     <thead class="govuk-table__head">
 
       {% if (dimension.dimension_table.table_object.type == "grouped") and (dimension.dimension_table.table_object.columns|length > 1) %}

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -15,7 +15,7 @@
       <div class="table-container">
     <table class="govuk-table govuk-!-margin-bottom-0">
     {% if dimension.dimension_table.table_object.header %}
-      <caption class="govuk-heading-s eff-table__caption">{{ dimension.dimension_table.table_object.header }}</caption>
+      <caption class="govuk-table__caption">{{ dimension.dimension_table.table_object.header }}</caption>
     {% endif %}
     <thead class="govuk-table__head">
 


### PR DESCRIPTION
Adds behaviour to the fixed table header functionality that allows it to
also display the table title within the fixed area. It does this by
duplicating the table caption into the fixed header `table` element and
setting the original caption to be transparent. The fixed caption then
sits over the top of the original one.

 ## Ticket
https://trello.com/c/gxKxOj16