### PR TITLE
Bump govuk-frontend to 2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,9 +2885,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.7.0.tgz",
-      "integrity": "sha512-IZvho72ExUAOmMOZHbE7s//HdtpSoO1aLn3fcXTnuIUi20UTsz6j+5i1Ztyqr4KUEb8OB/jNMYt4kuYyJnEMRQ=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.11.0.tgz",
+      "integrity": "sha512-kZR0ZrSju+Jqh8o5niKklj8/m5XmsNNUSQLL4M4urnMcrLypwW2dU3RkR8UCnzS2DDy4BTHb7CZw0VjQPoi3jg=="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2919,7 +2919,7 @@
         "gulp-cli": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
-          "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+          "integrity": "sha1-eEfiIMs2YvK+im1XK/FOF75amUs=",
           "requires": {
             "ansi-colors": "^1.0.1",
             "archy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "govuk-frontend": "^2.7.0",
+    "govuk-frontend": "^2.11.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-if": "^2.0.2",


### PR DESCRIPTION
This upgrades govuk-frontend from 2.7.0 to 2.11.0. This is backwards-compatible, and introduces some new features.

**Release notes**

* [2.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v2.8.0)
* [2.9.0](https://github.com/alphagov/govuk-frontend/releases/tag/v2.9.0)
* [2.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v2.10.0)
* [2.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v2.11.0)