### PR TITLE
Refresh materialized views as part of pulling prod data

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -167,7 +167,7 @@ def pull_prod_data(default_user_password=None):
     upgrade()
 
     print("Refreshing materialized views...")
-    refresh_materialized_views()
+    drop_and_create_materialized_views()
 
     if os.environ.get("PROD_UPLOAD_BUCKET_NAME"):
         #  Copy upload files from production to the upload bucket for the current environment

--- a/manage.py
+++ b/manage.py
@@ -166,6 +166,9 @@ def pull_prod_data(default_user_password=None):
     print("Upgrading database from local migrations...")
     upgrade()
 
+    print("Refreshing materialized views...")
+    refresh_materialized_views()
+
     if os.environ.get("PROD_UPLOAD_BUCKET_NAME"):
         #  Copy upload files from production to the upload bucket for the current environment
         import boto3


### PR DESCRIPTION
I noticed that our documentation advises developers to run `refresh_materialized_views` after doing a `pull_prod_data`, but it seems like that should be part of the data pull.