### PR TITLE
Add script to export dimension titles

### DIFF
--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+
+import logging
+import pprint
+import sys
+
+import csv
+
+sys.path.insert(0, ".")
+
+from flask import Flask
+
+from application import db
+from application.factory import create_app
+from application.config import DevConfig
+
+
+def _calculate_short_title(page_title, dimension_title):
+    # Case 1 - try stripping the dimension title
+    low_title = dimension_title.lower()
+    if low_title.find(page_title.lower()) == 0:
+        return dimension_title[len(page_title) + 1 :]
+
+    # Case 2 - try cutting using the last by
+    by_pos = dimension_title.rfind("by")
+    if by_pos >= 0:
+        return dimension_title[by_pos:]
+
+    # Case else - just return the original
+    return dimension_title
+
+
+app = create_app(DevConfig)
+with app.app_context():
+
+    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position"
+
+    result = db.session.execute(sql)
+    db.session.commit()
+
+    with open("dimension_titles.csv", mode="w") as csv_file:
+        writer = csv.writer(csv_file, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+
+        writer.writerow(("dimension_id", "measure_title", "current_dimension_title", "new_dimension_title"))
+
+        for row in result:
+            writer.writerow(
+                (
+                    row["dimension_id"],
+                    row["measure_title"],
+                    row["dimension_title"],
+                    _calculate_short_title(row["measure_title"], row["dimension_title"]),
+                )
+            )

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -4,7 +4,7 @@
 import sys
 import csv
 
-sys.path.insert(0, ".") # noqa
+sys.path.insert(0, ".")  # noqa
 
 from application.config import DevConfig
 from application import db
@@ -15,7 +15,18 @@ from application.dashboard.data_helpers import _calculate_short_title
 app = create_app(DevConfig)
 with app.app_context():
 
-    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position"  # noqa
+    sql = """
+SELECT dimension.guid        AS dimension_id,
+       measure_version.title AS measure_title,
+       dimension.title       AS dimension_title
+FROM   dimension
+       LEFT JOIN measure_version
+              ON dimension.measure_version_id = measure_version.id
+       INNER JOIN latest_published_measure_versions
+               ON measure_version.id = latest_published_measure_versions.id
+ORDER  BY measure_version.title,
+          dimension.position
+"""
 
     result = db.session.execute(sql)
 

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -10,21 +10,7 @@ from application import db
 from application.factory import create_app
 from application.config import DevConfig
 
-
-
-def _calculate_short_title(page_title, dimension_title):
-    # Case 1 - try stripping the dimension title
-    low_title = dimension_title.lower()
-    if low_title.find(page_title.lower()) == 0:
-        return dimension_title[len(page_title) + 1 :]
-
-    # Case 2 - try cutting using the last by
-    by_pos = dimension_title.rfind("by")
-    if by_pos >= 0:
-        return dimension_title[by_pos:]
-
-    # Case else - just return the original
-    return dimension_title
+from application.dashboard.data_helpers import _calculate_short_title
 
 
 app = create_app(DevConfig)

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python
 
 
-import logging
-import pprint
 import sys
-
 import csv
-
-sys.path.insert(0, ".")
-
-from flask import Flask
 
 from application import db
 from application.factory import create_app
 from application.config import DevConfig
+
+sys.path.insert(0, ".")
 
 
 def _calculate_short_title(page_title, dimension_title):
@@ -34,7 +29,7 @@ def _calculate_short_title(page_title, dimension_title):
 app = create_app(DevConfig)
 with app.app_context():
 
-    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position"
+    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position" # noqa
 
     result = db.session.execute(sql)
     db.session.commit()

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -6,11 +6,10 @@ import csv
 
 sys.path.insert(0, ".")
 
-from application import db
-from application.factory import create_app
-from application.config import DevConfig
-
-from application.dashboard.data_helpers import _calculate_short_title
+from application.config import DevConfig# noqa: E402
+from application import db  # noqa: E402
+from application.factory import create_app  # noqa: E402
+from application.dashboard.data_helpers import _calculate_short_title  # noqa: E402
 
 
 app = create_app(DevConfig)

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -4,11 +4,12 @@
 import sys
 import csv
 
+sys.path.insert(0, ".")
+
 from application import db
 from application.factory import create_app
 from application.config import DevConfig
 
-sys.path.insert(0, ".")
 
 
 def _calculate_short_title(page_title, dimension_title):

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -29,7 +29,7 @@ def _calculate_short_title(page_title, dimension_title):
 app = create_app(DevConfig)
 with app.app_context():
 
-    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position" # noqa
+    sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position"  # noqa
 
     result = db.session.execute(sql)
     db.session.commit()

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -32,7 +32,6 @@ with app.app_context():
     sql = "select dimension.guid as dimension_id, measure_version.title as measure_title, dimension.title as dimension_title from dimension left join measure_version on dimension.measure_version_id = measure_version.id inner join latest_published_measure_versions on measure_version.id = latest_published_measure_versions.id order by measure_version.title, dimension.position"  # noqa
 
     result = db.session.execute(sql)
-    db.session.commit()
 
     with open("dimension_titles.csv", mode="w") as csv_file:
         writer = csv.writer(csv_file, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)

--- a/scripts/oneoff/export-dimension-titles-as-csv.py
+++ b/scripts/oneoff/export-dimension-titles-as-csv.py
@@ -4,12 +4,12 @@
 import sys
 import csv
 
-sys.path.insert(0, ".")
+sys.path.insert(0, ".") # noqa
 
-from application.config import DevConfig# noqa: E402
-from application import db  # noqa: E402
-from application.factory import create_app  # noqa: E402
-from application.dashboard.data_helpers import _calculate_short_title  # noqa: E402
+from application.config import DevConfig
+from application import db
+from application.factory import create_app
+from application.dashboard.data_helpers import _calculate_short_title
 
 
 app = create_app(DevConfig)


### PR DESCRIPTION
This is just a temporary script to output dimension titles alongside suggested shorter versions, for use in a batch-update job.

(It can be deleted at some point in the future)