### PR TITLE
Refactor page history to use macro

### DIFF
--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -10,6 +10,7 @@ $govuk-assets-path: '/static/assets/';
 @import 'components/badge';
 @import 'components/buttons';
 @import 'components/cookie_banner';
+@import 'components/details';
 @import 'components/document_footer';
 @import 'components/flash_message';
 @import 'components/header';

--- a/application/src/sass/components/_details.scss
+++ b/application/src/sass/components/_details.scss
@@ -1,0 +1,32 @@
+
+/* Page history modifier for Details component
+ *
+ * This adapts the Details component for use in showing
+ * the detailed edit history of a page, in a similar way
+ * to specialist pages on GOV.UK
+ *
+ * The main changes are a smaller font, and not having the
+ * grey border and margin on the left of the revealed
+ * content.
+ */
+.eff-details--page-history .govuk-details__summary-text {
+  @include govuk-font(16);
+}
+
+.eff-details--page-history .govuk-list {
+  @include govuk-font(16);
+}
+
+.eff-details--page-history .govuk-details__text {
+  padding: 0;
+  border-left-width: 0;
+}
+
+.eff-details--page-history li {
+  margin-bottom: 10px
+}
+
+.eff-details--page-history .timestamp {
+  display: block;
+  font-weight: bold;
+}

--- a/application/src/sass/components/_document_footer.scss
+++ b/application/src/sass/components/_document_footer.scss
@@ -73,20 +73,3 @@
 .previous-editions a:hover {
   color: #2b8cc4;
 }
-
-.eff-document-footer .change-notes li {
-  margin-bottom: 10px
-}
-
-.eff-document-footer .change-notes .timestamp {
-  display: block;
-  font-weight: bold;
-}
-
-.eff-document-footer__full_history_summary_text {
-  @include govuk-font(16);
-}
-
-.eff-document-footer__full_history_body .govuk-list {
-  @include govuk-font(16);
-}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -621,36 +621,30 @@
 
             {% set fullPageHistoryHtml %}
               <ol class="govuk-list">
-              {% set current_edit_summary = measure_version.external_edit_summary %}
-              {% if measure_version.published_at %}
-                  {% set publish_date = measure_version.published_at|format_friendly_date %}
-              {% else %}
-                  {% set publish_date = 'TBC' %}
-              {% endif %}
-              <li>
-                  {% if measure_version.published_at %}
-                      <time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time>
-                  {% else %}
-                      <span class="timestamp">TBC</span>
-                  {% endif %}
-                  {% if current_edit_summary %}
-                      {{ current_edit_summary }}
-                  {% endif %}
-              </li>
-              {% for old_page_version in measure_version.previous_minor_versions %}
                 <li>
-                  <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
-
-                  {% if (loop.index == loop|length) %}
-                    {% set edit_summary = old_page_version.external_edit_summary or "First published" %}
+                  {% if measure_version.published_at %}
+                    <time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time>
                   {% else %}
-                    {% set edit_summary = old_page_version.external_edit_summary or "Minor edit" %}
+                    <span class="timestamp">TBC</span>
                   {% endif %}
-                  {% if edit_summary %}
-                      {{ edit_summary }}
+                  {% if measure_version.external_edit_summary %}
+                    {{ measure_version.external_edit_summary }}
                   {% endif %}
                 </li>
-              {% endfor %}
+                {% for old_page_version in measure_version.previous_minor_versions %}
+                  <li>
+                    <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
+
+                    {% if (loop.index == loop|length) %}
+                      {% set edit_summary = old_page_version.external_edit_summary or "First published" %}
+                    {% else %}
+                      {% set edit_summary = old_page_version.external_edit_summary or "Minor edit" %}
+                    {% endif %}
+                    {% if edit_summary %}
+                      {{ edit_summary }}
+                    {% endif %}
+                  </li>
+                {% endfor %}
               </ol>
             {% endset %}
 

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -619,48 +619,54 @@
 
           <div class="change-notes">
 
-            <details data-on="click" data-event-category="Disclosure" data-event-action="Opened" data-event-label="Full page history" class="govuk-details" class="">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text eff-document-footer__full_history_summary_text">
-                  full page history
-                </span>
-              </summary>
-
-              <div class="eff-document-footer__full_history_body" id="full-history" aria-live="polite" role="region">
-                <ol class="govuk-list">
-                {% set current_edit_summary = measure_version.external_edit_summary %}
-                {% if measure_version.published_at %}
-                    {% set publish_date = measure_version.published_at|format_friendly_date %}
-                {% else %}
-                    {% set publish_date = 'TBC' %}
-                {% endif %}
+            {% set fullPageHistoryHtml %}
+              <ol class="govuk-list">
+              {% set current_edit_summary = measure_version.external_edit_summary %}
+              {% if measure_version.published_at %}
+                  {% set publish_date = measure_version.published_at|format_friendly_date %}
+              {% else %}
+                  {% set publish_date = 'TBC' %}
+              {% endif %}
+              <li>
+                  {% if measure_version.published_at %}
+                      <time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time>
+                  {% else %}
+                      <span class="timestamp">TBC</span>
+                  {% endif %}
+                  {% if current_edit_summary %}
+                      {{ current_edit_summary }}
+                  {% endif %}
+              </li>
+              {% for old_page_version in measure_version.previous_minor_versions %}
                 <li>
-                    {% if measure_version.published_at %}
-                        <time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time>
-                    {% else %}
-                        <span class="timestamp">TBC</span>
-                    {% endif %}
-                    {% if current_edit_summary %}
-                        {{ current_edit_summary }}
-                    {% endif %}
-                </li>
-                {% for old_page_version in measure_version.previous_minor_versions %}
-                  <li>
-                    <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
+                  <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
 
-                    {% if (loop.index == loop|length) %}
-                      {% set edit_summary = old_page_version.external_edit_summary or "First published" %}
-                    {% else %}
-                      {% set edit_summary = old_page_version.external_edit_summary or "Minor edit" %}
-                    {% endif %}
-                    {% if edit_summary %}
-                        {{ edit_summary }}
-                    {% endif %}
-                  </li>
-                {% endfor %}
-                </ol>
-              </div>
-            </details>
+                  {% if (loop.index == loop|length) %}
+                    {% set edit_summary = old_page_version.external_edit_summary or "First published" %}
+                  {% else %}
+                    {% set edit_summary = old_page_version.external_edit_summary or "Minor edit" %}
+                  {% endif %}
+                  {% if edit_summary %}
+                      {{ edit_summary }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+              </ol>
+            {% endset %}
+
+            {{ govukDetails(
+              summaryText="full page history",
+              html=fullPageHistoryHtml,
+              id="full-page-history",
+              classes="eff-details--page-history",
+              attributes={
+                "data-on":"click",
+                "data-event-category":"Disclosure",
+                "data-event-action":"Opened",
+                "data-event-label":"Full page history"
+              }
+            ) }}
+
           </div>
         </div>
         <div class="related-information">


### PR DESCRIPTION
I spotted that the current page history details component has a duplicate `class` attribute:

```html
<details data-on="click" data-event-category="Disclosure" 
data-event-action="Opened" data-event-label="Full page history" 
class="govuk-details" class="">
```

This fixes that by switching to using the `govukDetails` macro, which makes similar errors less likely in future.

I also refactored the CSS slightly to use a modifier for the `govuk-details` class instead of depending upon the `eff-document-footer` class.