### PR TITLE
Fix error diffs on conflicting measure version updates

### DIFF
--- a/application/cms/utils.py
+++ b/application/cms/utils.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import List
 
 from flask import current_app
+from markupsafe import Markup
 
 from application.cms.forms import DataSourceForm
 
@@ -11,6 +12,12 @@ from application.cms.forms import DataSourceForm
 class ErrorSummaryMessage:
     text: str
     href: str
+
+
+@dataclass
+class TextFieldDiff:
+    diff_markup: Markup
+    updated_by: str
 
 
 def copy_form_errors(from_form, to_form):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -324,13 +324,19 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
             current_app.logger.error(e)
             diffs = _diff_updates(measure_version_form, measure_version)
             if diffs:
-                errors_preamble = "Your update will overwrite the latest content. Resolve the conflicts below:"
+                errors_preamble = (
+                    "Your update will overwrite updates made by other people. "
+                    "Only save the page after reviewing all of the following:"
+                )
 
                 # Need to manually update the `db_version_id`, otherwise when the form is re-submitted it will just
                 # throw the same error.
                 measure_version_form.db_version_id.raw_data = [str(measure_version.db_version_id)]
             else:
-                errors_preamble = "Your update will overwrite the latest content. Reload this page."
+                errors_preamble = (
+                    "Your update will overwrite updates made by other people. "
+                    "Reload this page and re-enter your update."
+                )
 
         except PageUnEditable as e:
             current_app.logger.info(e)

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -286,6 +286,7 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
         measure_version_form = MeasureVersionForm(is_minor_update=measure_version.is_minor_version())
 
     saved = False
+    errors_preamble = None
     if (
         measure_version_form.validate_on_submit()
         and data_source_form.validate_on_submit()
@@ -315,13 +316,13 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
             current_app.logger.error(e)
             diffs = _diff_updates(measure_version_form, measure_version)
             if diffs:
-                flash("Your update will overwrite the latest content. Resolve the conflicts below", "error")
+                errors_preamble = "Your update will overwrite the latest content. Resolve the conflicts below:"
 
                 # Need to manually update the `db_version_id`, otherwise when the form is re-submitted it will just
                 # throw the same error.
                 measure_version_form.db_version_id.raw_data = [str(measure_version.db_version_id)]
             else:
-                flash("Your update will overwrite the latest content. Reload this page", "error")
+                errors_preamble = "Your update will overwrite the latest content. Reload this page."
 
         except PageUnEditable as e:
             current_app.logger.info(e)
@@ -355,6 +356,7 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
         "diffs": diffs,
         "organisations_by_type": Organisation.select_options_by_type(),
         "topics": page_service.get_topics(include_testing_space=True),
+        "errors_preamble": errors_preamble,
         "errors": get_form_errors(forms=[measure_version_form, data_source_form, data_source_2_form]),
         "new": False,
         "data_not_uploaded_error": False,

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -219,7 +219,9 @@ def _diff_updates(form, page):
             if v is not None and page_value is not None:
                 diff = htmldiff(str(page_value).rstrip(), str(v).rstrip())
                 if "<ins>" in diff or "<del>" in diff:
-                    getattr(form, k).errors.append("has been updated by %s" % page.last_updated_by)
+                    getattr(form, k).errors.append(
+                        f"‘{getattr(form, k).label.text}’ has been updated by {page.last_updated_by}"
+                    )
                     diffs[k] = diff
     form.db_version_id.data = page.db_version_id
     return diffs

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -37,7 +37,13 @@ from application.cms.models import NewVersionType, MeasureVersion, Measure
 from application.cms.models import Organisation
 from application.cms.page_service import page_service
 from application.cms.upload_service import upload_service
-from application.cms.utils import copy_form_errors, get_data_source_forms, get_form_errors, ErrorSummaryMessage
+from application.cms.utils import (
+    copy_form_errors,
+    get_data_source_forms,
+    get_form_errors,
+    ErrorSummaryMessage,
+    TextFieldDiff,
+)
 from application.sitebuilder import build_service
 from application.utils import get_bool, user_can, user_has_access
 
@@ -212,15 +218,14 @@ def delete_dimension(topic_slug, subtopic_slug, measure_slug, version, dimension
 def _diff_updates(form, page):
     from lxml.html.diff import htmldiff
     from flask import escape
-    from application.cms.markdown import markdown
-    from flask import Markup
+    from markupsafe import Markup
 
     diffs = {}
     for k, v in form.data.items():
         if hasattr(page, k) and k != "db_version_id":
             page_value = getattr(page, k)
             if v is not None and page_value is not None:
-                diff = htmldiff(markdown(escape(str(page_value).rstrip())), markdown(escape(str(v).rstrip())))
+                diff = htmldiff(escape(str(page_value).rstrip()), escape(str(v).rstrip()))
                 if "<ins>" in diff or "<del>" in diff:
                     getattr(form, k).errors.append(
                         f"‘{getattr(form, k).label.text}’ has been updated by {page.last_updated_by}"
@@ -228,7 +233,8 @@ def _diff_updates(form, page):
 
                     # The resulting diff has had the user-input escaped, but does contain <ins> and <del> tags that
                     # need to be rendered without being escaped. So we should consider the diff as safe Markup.
-                    diffs[k] = Markup(diff)
+                    diffs[k] = TextFieldDiff(diff_markup=Markup(diff), updated_by=page.last_updated_by)
+
     form.db_version_id.data = page.db_version_id
     return diffs
 

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -11,6 +11,7 @@ $govuk-assets-path: '/static/assets/';
 @import 'components/buttons';
 @import 'components/cookie_banner';
 @import 'components/details';
+@import 'components/diffs';
 @import 'components/document_footer';
 @import 'components/flash_message';
 @import 'components/header';

--- a/application/src/sass/components/_diffs.scss
+++ b/application/src/sass/components/_diffs.scss
@@ -1,0 +1,11 @@
+.eff-diffs {
+  & ins {
+    background-color: lighten(govuk-colour('green'), 60%);
+    text-decoration: none;
+  }
+
+  & del {
+    background-color: lighten(govuk-colour('red'), 50%);
+    text-decoration: line-through;
+  }
+}

--- a/application/templates/_shared/_error_summary.html
+++ b/application/templates/_shared/_error_summary.html
@@ -3,12 +3,16 @@
   https://github.com/alphagov/govuk-frontend/blob/master/src/components/error-summary
 #}
 
-{% if errors is defined and errors %}
+{% if (errors is defined and errors) or (errors_preamble is defined and errors_preamble) %}
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem
   </h2>
   <div class="govuk-error-summary__body">
+    {% if errors_preamble is defined and errors_preamble %}
+      <p>{{ errors_preamble }}</p>
+    {% endif %}
+    {% if errors is defined and errors %}
     <ul class="govuk-list govuk-error-summary__list">
       {% for error in errors %}
       <li>
@@ -16,6 +20,7 @@
       </li>
       {% endfor %}
     </ul>
+    {% endif %}
   </div>
 </div>
 {% endif %}

--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -13,7 +13,20 @@
 {% endif %}
 
 {% if field.errors %}
-  <span class="govuk-error-message">{{ field.errors[0] }}</span>
+  {% if diffs is defined and diffs and name in diffs %}
+  <div class="govuk-error-message">
+    Your update will overwrite a change made by {{ diffs[name].updated_by }}.
+    <br>
+    Review the additions and deletions shown below.
+    <br>
+    Only save the page when you have reviewed all conflicts.
+  </div>
+  <div class="govuk-inset-text eff-diffs">
+      {{ diffs[name].diff_markup }}
+  </div>
+  {% else %}
+    <span class="govuk-error-message">{{ field.errors[0] }}</span>
+  {% endif %}
 {% endif %}
 
 {{ field.extended_hint if field.extended_hint is defined and field.extended_hint else '' }}
@@ -22,13 +35,6 @@
   <textarea id="{{ id_ }}" name="{{ name }}" class="govuk-textarea {{ class_ }}{% if field.errors %} govuk-textarea--error{% endif %}{% if field.character_count_limit %} js-character-count{% endif %}" {{ field_params }}>{{ value or "" }}</textarea>
 {% else %}
   <input id="{{ id_ }}" name="{{ name }}" class="govuk-input {{ class_ }}{% if field.errors %} govuk-input--error{% endif %}" value="{{ value }}" {{ field_params }}>
-{% endif %}
-
-{% if diffs is defined and diffs and name in diffs %}
-  <p class="govuk-body govuk-!-margin-top-4">Your update to "{{ field.label.text }}" is shown below, with detected additions and deletions emphasised. If these changes are fine, save the page, otherwise make further edits above and then save.</p>
-  <div class="govuk-body eff-diffs">
-      {{ diffs[name] }}
-  </div>
 {% endif %}
 
 {% if field.character_count_limit %}

--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -24,10 +24,10 @@
   <input id="{{ id_ }}" name="{{ name }}" class="govuk-input {{ class_ }}{% if field.errors %} govuk-input--error{% endif %}" value="{{ value }}" {{ field_params }}>
 {% endif %}
 
-{% if not field.errors and diffs is defined and diffs and name in diffs %}
-  <p class="govuk-body">Your update to "{{ field.label.text }}" is highlighted green and possible deletions are highlighted red. If these changes are fine, save the page, otherwise edit the copy above and then save.</p>
-  <div class="govuk-body differences">
-      {{ diffs[name] | render_markdown }}
+{% if diffs is defined and diffs and name in diffs %}
+  <p class="govuk-body govuk-!-margin-top-4">Your update to "{{ field.label.text }}" is shown below, with detected additions and deletions emphasised. If these changes are fine, save the page, otherwise make further edits above and then save.</p>
+  <div class="govuk-body eff-diffs">
+      {{ diffs[name] }}
   </div>
 {% endif %}
 

--- a/tests/application/cms/test_forms.py
+++ b/tests/application/cms/test_forms.py
@@ -72,7 +72,7 @@ class TestMeasureVersionForm:
 
     @pytest.mark.parametrize("is_minor_update", ((True,), (False,)))
     def test_all_fields_populate_with_data(self, is_minor_update):
-        measure_version = MeasureVersionFactory.create(version="1.0", status="APPROVED")
+        measure_version = MeasureVersionFactory.create(version="1.1", status="APPROVED")
 
         form = MeasureVersionForm(is_minor_update=False, sending_to_review=True, obj=measure_version)
 

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -808,7 +808,7 @@ def test_edit_measure_page_updated_with_latest_db_version_id_when_posting_a_conf
     assert page.find("input", {"id": "db_version_id"}).attrs["value"] == "2"
     assert measure_version.title == "new title"
     assert page_displays_error_matching_message(
-        response, message=f"has been updated by {measure_version.last_updated_by}"
+        response, message=f"‘Title’ has been updated by {measure_version.last_updated_by}"
     )
 
 

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -810,6 +810,11 @@ def test_edit_measure_page_updated_with_latest_db_version_id_when_posting_a_conf
     assert page_displays_error_matching_message(
         response, message=f"‘Title’ has been updated by {measure_version.last_updated_by}"
     )
+    assert len(page.findAll("div", class_="eff-diffs")) == 1
+    assert (
+        str(page.find("div", class_="eff-diffs"))
+        == '<div class="govuk-body eff-diffs">\n<p class="govuk-body"> <ins>try</ins> new title</p>\n</div>'
+    )
 
 
 def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(test_app_client, logged_in_dept_user):

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -813,7 +813,7 @@ def test_edit_measure_page_updated_with_latest_db_version_id_when_posting_a_conf
     assert len(page.findAll("div", class_="eff-diffs")) == 1
     assert (
         str(page.find("div", class_="eff-diffs"))
-        == '<div class="govuk-body eff-diffs">\n<p class="govuk-body"> <ins>try</ins> new title</p>\n</div>'
+        == '<div class="govuk-inset-text eff-diffs">\n<ins>try</ins> new title\n  </div>'
     )
 
 

--- a/tests/application/templates/test_base.py
+++ b/tests/application/templates/test_base.py
@@ -1,0 +1,29 @@
+from flask import render_template
+from lxml import html as lxml_html
+
+from application.cms.utils import ErrorSummaryMessage
+
+
+class TestTemplateBase:
+    def test_base_template_renders_error_summary(self):
+        # With no errors/preamble, no error summary rendered.
+        html = render_template("base.html")
+        doc = lxml_html.fromstring(html)
+
+        assert doc.xpath("//*[@class='govuk-error-summary']") == []
+
+        # With a preamble, error summary shown and contains preamble text.
+        html = render_template("base.html", errors_preamble="A sentence about the errors.")
+        doc = lxml_html.fromstring(html)
+
+        assert len(doc.xpath("//*[@class='govuk-error-summary']")) == 1
+        assert "A sentence about the errors" in doc.xpath("//*[@class='govuk-error-summary']")[0].text_content()
+
+        # With some error messages, error summary shown and contains link to the erroring field.
+        html = render_template("base.html", errors=[ErrorSummaryMessage(text="An error link", href="/error-link")])
+        doc = lxml_html.fromstring(html)
+
+        assert len(doc.xpath("//*[@class='govuk-error-summary']//a")) == 1
+        link = doc.xpath("//*[@class='govuk-error-summary']//a")[0]
+        assert link.text == "An error link"
+        assert link.get("href") == "/error-link"

--- a/tests/functional/test_cms_measure_lifecycle.py
+++ b/tests/functional/test_cms_measure_lifecycle.py
@@ -27,7 +27,7 @@ def test_create_a_measure_as_editor(driver, live_server, government_departments,
         data_sources__publisher=random.choice(government_departments),
         data_sources__frequency_of_release=random.choice(frequencies_of_release),
     )
-    sample_measure_version = MeasureVersionFactory.build(data_sources=[])
+    sample_measure_version = MeasureVersionFactory.build(version="1.1", data_sources=[])
     sample_data_source = DataSourceFactory.build(
         publisher__name=random.choice(government_departments).name,
         frequency_of_release__description=random.choice(frequencies_of_release).description,

--- a/tests/models.py
+++ b/tests/models.py
@@ -284,10 +284,14 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     ethnicity_definition_summary = factory.Faker("paragraph", nb_sentences=3)
     area_covered = factory.LazyFunction(lambda: _random_combination(UKCountry))
     time_covered = factory.Faker("paragraph", nb_sentences=3)
-    external_edit_summary = factory.Faker("sentence", nb_words=10)
-    internal_edit_summary = factory.Faker("sentence", nb_words=10)
-    update_corrects_data_mistake = factory.LazyAttribute(
-        lambda o: False if o._is_major_version else random.choice((True, False))
+    external_edit_summary = factory.Maybe(
+        "_is_major_version", yes_declaration="", no_declaration=factory.Faker("sentence", nb_words=10)
+    )
+    internal_edit_summary = factory.Maybe(
+        "_is_major_version", yes_declaration="", no_declaration=factory.Faker("sentence", nb_words=10)
+    )
+    update_corrects_data_mistake = factory.Maybe(
+        "_is_major_version", yes_declaration=False, no_declaration=random.choice((True, False))
     )
     lowest_level_of_geography_id = factory.SelfAttribute("lowest_level_of_geography.name")
     methodology = factory.Faker("paragraph", nb_sentences=3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,6 +38,7 @@ def multidict_from_measure_version_and_kwargs(measure_version: MeasureVersion, *
     return ImmutableMultiDict(
         {
             "title": measure_version.title,
+            "description": measure_version.description,
             "measure_summary": measure_version.measure_summary,
             "summary": measure_version.summary,
             "lowest_level_of_geography": measure_version.lowest_level_of_geography_id,


### PR DESCRIPTION
This PR is an attempt to clean up the 'conflicting updates' functionality that at some point in time has gotten broken. Diffs were no longer rendering beneath each text box, and the warning message about conflicting updates was in a green box rather than our unified error message container.

These patches:
* Remove the separate green flash message box, unifying the text into our errors container.
* Include field names in the conflict error message text.
* Fix diff rendering so that it appears again.
* Add a test that asserts diffs are visible.

# Before
![Screen Shot 2019-05-10 at 10 58 08](https://user-images.githubusercontent.com/2920760/57519109-833e1400-7312-11e9-83fa-f7f6a38b6cee.png)

# After
![Screen Shot 2019-05-10 at 10 57 27](https://user-images.githubusercontent.com/2920760/57519091-74eff800-7312-11e9-8292-c229f7bcd8d6.png)

# Ticket
https://trello.com/c/8a8rfdu6