### PR TITLE
Bugfix: set publication dates on published measures

### DIFF
--- a/scripts/oneoff/set_publication_dates_on_approved_measure_versions.py
+++ b/scripts/oneoff/set_publication_dates_on_approved_measure_versions.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-
-import csv
 import sys
 
 sys.path.insert(0, ".")  # noqa

--- a/scripts/oneoff/set_publication_dates_on_approved_measure_versions.py
+++ b/scripts/oneoff/set_publication_dates_on_approved_measure_versions.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+
+import csv
+import sys
+
+sys.path.insert(0, ".")  # noqa
+
+from application import db
+from application.cms.models import MeasureVersion
+from application.cms.page_service import page_service
+from application.config import DevConfig
+from application.factory import create_app
+
+app = create_app(DevConfig)
+with app.app_context():
+
+    sql = """
+SELECT measure_version.id
+FROM   measure_version
+WHERE status = 'APPROVED' AND published_at IS NULL
+AND external_edit_summary = 'Some headings have been changed. No data or commentary has been updated.'
+"""
+
+    result = db.session.execute(sql)
+
+    for row in result:
+
+        measure_version = MeasureVersion.query.get(row[0])
+        page_service.mark_measure_version_published(measure_version)


### PR DESCRIPTION
This fixes a bug in a previous script to update measures with new dimension titles (from a CSV file).

That script assumed that the build process would set a publication date, whereas this actually seems to require `mark_measure_version_published` to be called (which is normally done at time of pressing 'Approve').