### PR TITLE
Add prefix and suffix to sortable buttons

### DIFF
--- a/application/src/js/all/_sortable_table.js
+++ b/application/src/js/all/_sortable_table.js
@@ -74,7 +74,21 @@ SortableTable.prototype.createHeadingButton = function(heading, i, disabled) {
     button.setAttribute('type', 'button')
     button.setAttribute('data-index', i)
     button.setAttribute('class', 'govuk-button eff-button--link eff-button--sort')
-    button.textContent = text
+
+    var button_prefix = document.createElement('span')
+    button_prefix.textContent = 'Sort by: '
+    button_prefix.classList.add('govuk-visually-hidden')
+    button.appendChild(button_prefix)
+
+    var button_label = document.createTextNode(text)
+    button.appendChild(button_label)
+
+    var button_suffix = document.createElement('span')
+    button_suffix.setAttribute('data-role', 'button-suffix')
+    button_suffix.textContent = ' (descending)'
+    button_suffix.classList.add('govuk-visually-hidden')
+    button.appendChild(button_suffix)
+
     button.addEventListener('click', this.sortButtonClicked.bind(this))
     heading.textContent = '';
 
@@ -106,8 +120,14 @@ SortableTable.prototype.createStatusBox = function() {
 
 SortableTable.prototype.sortButtonClicked = function(event) {
 
-  var columnNumber = event.target.getAttribute('data-index')
-  var sortDirection = event.target.parentElement.getAttribute('aria-sort')
+  var button = event.target
+
+  if (button.tagName != 'BUTTON') {
+    button = button.parentElement
+  }
+
+  var columnNumber = button.getAttribute('data-index')
+  var sortDirection = button.parentElement.getAttribute('aria-sort')
   var newSortDirection;
     if(sortDirection === 'none' || sortDirection === 'ascending') {
         newSortDirection = 'descending';
@@ -128,7 +148,9 @@ SortableTable.prototype.sortButtonClicked = function(event) {
   };
 
   this.removeButtonStates();
-  this.updateButtonState(event.target, newSortDirection);
+
+
+  this.updateButtonState(button, newSortDirection);
 
 }
 
@@ -202,6 +224,10 @@ SortableTable.prototype.updateButtonState = function(button, direction) {
 
     button.classList.remove('eff-button--sort')
     button.classList.add('eff-button--sort-' + direction)
+
+    var oppositeDirection = (direction == 'ascending' ? 'descending' : 'ascending')
+    var button_suffix = button.querySelector('*[data-role=button-suffix]')
+    button_suffix.textContent = ' (' + oppositeDirection + ')'
 
     if ('ga' in window) {
       var eventAction = (direction == 'ascending' ? 'Descending' : 'Ascending')

--- a/application/src/sass/components/_sort_buttons.scss
+++ b/application/src/sass/components/_sort_buttons.scss
@@ -23,7 +23,7 @@
 
 .eff-button--sort:before,
 .eff-button--sort:active:before {
-  content: " \25bc"; /* ▼ */
+  content: " \25bc" / ""; /* ▼ */
   position: absolute;
   right: -2px;
   top: 9px;
@@ -33,7 +33,7 @@
 
 .eff-button--sort:after,
 .eff-button--sort:active:after {
-  content: " \25b2"; /* ▲ */
+  content: " \25b2" / ""; /* ▲ */
   position: absolute;
   right: -2px;
   top: 0px;
@@ -47,7 +47,7 @@
 }
 
 .eff-button--sort-ascending:after {
-  content: " \25b2"; /* ▲ */
+  content: " \25b2" / ""; /* ▲ */
   font-size: .7em;
   position: absolute;
   right: -2px;
@@ -55,7 +55,7 @@
 }
 
 .eff-button--sort-descending:after {
-  content: " \25bc"; /* ▼ */
+  content: " \25bc" / ""; /* ▼ */
   font-size: .7em;
   position: absolute;
   right: -2px;

--- a/application/src/sass/components/_sort_buttons.scss
+++ b/application/src/sass/components/_sort_buttons.scss
@@ -23,7 +23,7 @@
 
 .eff-button--sort:before,
 .eff-button--sort:active:before {
-  content: " \25bc" / ""; /* ▼ */
+  content: " \25bc"; /* ▼ */
   position: absolute;
   right: -2px;
   top: 9px;
@@ -33,7 +33,7 @@
 
 .eff-button--sort:after,
 .eff-button--sort:active:after {
-  content: " \25b2" / ""; /* ▲ */
+  content: " \25b2"; /* ▲ */
   position: absolute;
   right: -2px;
   top: 0px;
@@ -47,7 +47,7 @@
 }
 
 .eff-button--sort-ascending:after {
-  content: " \25b2" / ""; /* ▲ */
+  content: " \25b2"; /* ▲ */
   font-size: .7em;
   position: absolute;
   right: -2px;
@@ -55,7 +55,7 @@
 }
 
 .eff-button--sort-descending:after {
-  content: " \25bc" / ""; /* ▼ */
+  content: " \25bc"; /* ▼ */
   font-size: .7em;
   position: absolute;
   right: -2px;


### PR DESCRIPTION
This is to enable screen readers to better understand what the sortable buttons do.

See https://trello.com/c/vBkWvYlZ/1498-sortable-table-buttons-should-have-hidden-descriptive-labels-1