### PR TITLE
Remove ability to unpublish

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -413,9 +413,6 @@ class MeasureVersion(db.Model, CopyableModel):
         if self.status == "DEPARTMENT_REVIEW":
             return ["APPROVE", "REJECT"]
 
-        if self.status == "APPROVED":
-            return ["UNPUBLISH"]
-
         if self.status in ["REJECTED", "UNPUBLISHED"]:
             return ["RETURN_TO_DRAFT"]
         else:
@@ -443,12 +440,6 @@ class MeasureVersion(db.Model, CopyableModel):
         rejected_state = "REJECTED"
         message = 'Sent page "{}" to {}'.format(self.title, rejected_state)
         self.status = rejected_state
-        return message
-
-    def unpublish(self):
-        unpublish_state = publish_status.inv[5]
-        message = 'Request to unpublish page "{}" - page will be removed from site'.format(self.title)
-        self.status = unpublish_state
         return message
 
     def not_editable(self):

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -406,13 +406,6 @@ class PageService(Service):
         self.logger.info(message)
         return message
 
-    def unpublish_measure_version(self, measure_version: MeasureVersion, unpublished_by: str):
-        message = measure_version.unpublish()
-        measure_version.unpublished_by = unpublished_by
-        db.session.commit()
-        self.logger.info(message)
-        return message
-
     def send_measure_version_to_draft(self, measure_version: MeasureVersion):
         if "RETURN_TO_DRAFT" in measure_version.available_actions:
             numerical_status = measure_version.publish_status(numerical=True)

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -268,12 +268,6 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
             _publish(topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_slug, version=version)
             return redirect_following_change_of_status
 
-        elif measure_action == "unpublish-measure":
-            _unpublish_page(
-                topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_slug, version=version
-            )
-            return redirect_following_change_of_status
-
     diffs = {}
 
     data_source_form, data_source_2_form = get_data_source_forms(request, measure_version=measure_version)
@@ -568,21 +562,6 @@ def _reject_page(topic_slug, subtopic_slug, measure_slug, version):
         abort(400, "This page can not be rejected because it is not currently under review.")
 
     message = page_service.reject_measure_version(measure_version)
-    flash(message, "info")
-    current_app.logger.info(message)
-
-
-def _unpublish_page(topic_slug, subtopic_slug, measure_slug, version):
-    if not current_user.can(PUBLISH):
-        abort(403)
-    *_, measure_version = page_service.get_measure_version_hierarchy(topic_slug, subtopic_slug, measure_slug, version)
-
-    # Can only unpublish if currently published
-    if measure_version.status != "APPROVED":
-        abort(400, "This page is not published, so it can’t be unpublished.")
-
-    message = page_service.unpublish_measure_version(measure_version, unpublished_by=current_user.email)
-    _build_if_necessary(measure_version)
     flash(message, "info")
     current_app.logger.info(message)
 

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -63,10 +63,6 @@
                 </a>
             {% endif %}
 
-            {% if measure_version.status == 'APPROVED' and current_user.can(PUBLISH) %}
-                <button id="unpublish-measure" name="measure-action" value="unpublish-measure" class="govuk-button eff-button--destructive">Unpublish</button>
-            {% endif %}
-
             {% if measure_version.status == 'APPROVED' and not measure_version.latest %}
 
                 {%  set latest = measure.latest_version %}

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -663,11 +663,6 @@ class TestMeasureVersionModel:
         with pytest.raises(RejectionImpossible):
             measure_version.reject()
 
-    def test_unpublish_page(self):
-        measure_version = MeasureVersionFactory(status="APPROVED")
-        measure_version.unpublish()
-        assert measure_version.status == "UNPUBLISH"
-
     @pytest.mark.parametrize(
         "status, should_be_eligible",
         [
@@ -711,7 +706,7 @@ class TestMeasureVersionModel:
 
     def test_available_actions_for_approved_page(self):
         measure_version = MeasureVersionFactory(status="APPROVED")
-        expected_available_actions = ["UNPUBLISH"]
+        expected_available_actions = []
 
         assert expected_available_actions == measure_version.available_actions
 

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -220,48 +220,8 @@ def test_non_admin_user_can_not_publish_page_in_dept_review(test_app_client, log
     mock_request_build.assert_not_called()
 
 
-def test_admin_user_can_unpublish_page(test_app_client, logged_in_admin_user, mock_request_build):
-    measure_version = MeasureVersionFactory(status="APPROVED")
 
-    response = test_app_client.post(
-        url_for(
-            "cms.edit_measure_version",
-            topic_slug=measure_version.measure.subtopic.topic.slug,
-            subtopic_slug=measure_version.measure.subtopic.slug,
-            measure_slug=measure_version.measure.slug,
-            version=measure_version.version,
-        ),
-        data=ImmutableMultiDict({"measure-action": "unpublish-measure"}),
-        follow_redirects=True,
-    )
-
-    assert response.status_code == 200
-    assert measure_version.status == "UNPUBLISH"
-    assert measure_version.unpublished_by == logged_in_admin_user.email
-    mock_request_build.assert_called_once()
-
-
-def test_non_admin_user_can_not_unpublish_page(test_app_client, logged_in_rdu_user, mock_request_build):
-    measure_version = MeasureVersionFactory(status="APPROVED")
-
-    response = test_app_client.post(
-        url_for(
-            "cms.edit_measure_version",
-            topic_slug=measure_version.measure.subtopic.topic.slug,
-            subtopic_slug=measure_version.measure.subtopic.slug,
-            measure_slug=measure_version.measure.slug,
-            version=measure_version.version,
-        ),
-        data=ImmutableMultiDict({"measure-action": "unpublish-measure"}),
-        follow_redirects=True,
-    )
-
-    assert response.status_code == 403
-    assert measure_version.status == "APPROVED"
-    mock_request_build.assert_not_called()
-
-
-def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(test_app_client, logged_in_admin_user):
+def test_admin_user_can_see_publish_buttons_on_edit_page(test_app_client, logged_in_admin_user):
     measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
     response = test_app_client.get(
         url_for(
@@ -277,24 +237,8 @@ def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(test_app_clie
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert page.find_all("button")[-1].text.strip().lower() == "approve for publishing"
 
-    measure_version = MeasureVersionFactory(status="APPROVED")
 
-    response = test_app_client.get(
-        url_for(
-            "cms.edit_measure_version",
-            topic_slug=measure_version.measure.subtopic.topic.slug,
-            subtopic_slug=measure_version.measure.subtopic.slug,
-            measure_slug=measure_version.measure.slug,
-            version=measure_version.version,
-        ),
-        follow_redirects=True,
-    )
-
-    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    assert page.find_all("button")[-1].text.strip().lower() == "unpublish"
-
-
-def test_internal_user_can_not_see_publish_unpublish_buttons_on_edit_page(test_app_client, logged_in_rdu_user):
+def test_internal_user_can_not_see_publish_buttons_on_edit_page(test_app_client, logged_in_rdu_user):
     measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
     response = test_app_client.get(
         url_for(

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -220,7 +220,6 @@ def test_non_admin_user_can_not_publish_page_in_dept_review(test_app_client, log
     mock_request_build.assert_not_called()
 
 
-
 def test_admin_user_can_see_publish_buttons_on_edit_page(test_app_client, logged_in_admin_user):
     measure_version = MeasureVersionFactory(status="DEPARTMENT_REVIEW")
     response = test_app_client.get(


### PR DESCRIPTION
This removes the ability to unpublish, as we’ve decided this functionality is no longer necessary.

https://trello.com/c/ZgdSXjPi/1569-1-remove-all-cms-logic-that-enables-unpublishing-measures-ie-from-template-views-pageservice-3