### PR TITLE
Fetch/pull git repo to depth of 1

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -421,11 +421,17 @@ def build_error_pages(build_dir):
 
 
 def pull_current_site(build_dir, remote_repo):
+    current_app.logger.debug("Starting pull_current_site")
     repo = Repo.init(build_dir)
+    current_app.logger.debug("Repo.init complete")
     origin = repo.create_remote("origin", remote_repo)
+    current_app.logger.debug("repo.create_remote complete")
     origin.fetch()
+    current_app.logger.debug("origin.fetch complete")
     repo.create_head("master", origin.refs.master).set_tracking_branch(origin.refs.master).checkout()
+    current_app.logger.debug("repo.create_head complete")
     origin.pull()
+    current_app.logger.debug("origin.pull complete")
 
 
 def delete_files_from_repo(build_dir):

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -426,11 +426,11 @@ def pull_current_site(build_dir, remote_repo):
     current_app.logger.debug("Repo.init complete")
     origin = repo.create_remote("origin", remote_repo)
     current_app.logger.debug("repo.create_remote complete")
-    origin.fetch()
+    origin.fetch("--depth=1")
     current_app.logger.debug("origin.fetch complete")
     repo.create_head("master", origin.refs.master).set_tracking_branch(origin.refs.master).checkout()
     current_app.logger.debug("repo.create_head complete")
-    origin.pull()
+    origin.pull("--depth=1")
     current_app.logger.debug("origin.pull complete")
 
 


### PR DESCRIPTION
The current static site HTML backup is around 1GB. We've had a number of
stalled builds lately where it seems to be getting stuck at this stage,
and it's probably because Heroku doesn't like us using this much space
on their ephemeral filesystem. By only pulling the latest commit, we
reduce our footprint to about 50MB - which should be fine.

## Ticket
https://trello.com/c/9gT9rNOB
