### PR TITLE
Publish all unpublished measure versions

### DIFF
--- a/scripts/data_migrations/2019-05-16_republish-all-unpublished-measure-versions.sql
+++ b/scripts/data_migrations/2019-05-16_republish-all-unpublished-measure-versions.sql
@@ -1,0 +1,14 @@
+UPDATE
+    measure_version
+SET
+    status = 'APPROVED'
+WHERE
+    status = 'UNPUBLISH'
+    or status = 'UNPUBLISHED';
+
+INSERT
+INTO
+    build
+    (id, created_at, status)
+VALUES
+    ('6bd13007-9e8e-4f53-bdcc-fdd3f8728611', now(), 'PENDING');

--- a/scripts/data_migrations/2019-05-16_republish-all-unpublished-measure-versions.sql
+++ b/scripts/data_migrations/2019-05-16_republish-all-unpublished-measure-versions.sql
@@ -5,10 +5,3 @@ SET
 WHERE
     status = 'UNPUBLISH'
     or status = 'UNPUBLISHED';
-
-INSERT
-INTO
-    build
-    (id, created_at, status)
-VALUES
-    ('6bd13007-9e8e-4f53-bdcc-fdd3f8728611', now(), 'PENDING');


### PR DESCRIPTION
We want all of our measure versions to be available, even if
historically we published versions with errors. This promotes
transparency and is a good statistical practice. It also means that
users can link explicitly to the version of the data/commentary that
they saw on a specific date via permalinks.

While we probably don't *need* to trigger a re-build, it seems
harmless to do so.

 ## Ticket
https://trello.com/c/Vksqpdrm