### PR TITLE
Add error attributes to measure versions

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -514,6 +514,10 @@ class MeasureVersion(db.Model, CopyableModel):
         return [v for v in self.measure.versions if v.major() == self.major() and v.minor() < self.minor()]
 
     @property
+    def later_minor_versions(self):
+        return [v for v in self.measure.versions if v.major() == self.major() and v.minor() > self.minor()]
+
+    @property
     def first_published_date(self):
         return self.previous_minor_versions[-1].published_at if self.previous_minor_versions else self.published_at
 
@@ -574,6 +578,25 @@ class MeasureVersion(db.Model, CopyableModel):
             return days_from_now.days
         except Exception:
             return 0
+
+    @property
+    def has_known_statistical_errors(self) -> bool:
+        """Returns true if any later version is flagged as correcting a data mistake. This will still return true even
+        if *this* version is correcting a mistake - because it might be that not all the mistakes were fixed by this
+        version."""
+        return any(
+            later_minor_version.update_corrects_data_mistake for later_minor_version in self.later_minor_versions
+        )
+
+    @property
+    def has_known_statistical_corrections(self) -> bool:
+        """Returns true if this version, or an earlier version, is flagged as correcting a data mistake. This is not
+        exclusive to the property above - a measure version can both be correcting errors in a previous version while
+        still also having errors itself (presumably discovered at a later date)."""
+        return self.update_corrects_data_mistake or any(
+            previous_minor_version.update_corrects_data_mistake
+            for previous_minor_version in self.previous_minor_versions
+        )
 
 
 class Dimension(db.Model):
@@ -1105,6 +1128,7 @@ class Measure(db.Model):
     @property
     def latest_published_version(self):
         """Return the latest _published_ version of a measure."""
+
         published_versions = [
             version for version in self.versions if (version.status == "APPROVED" and version.published_at is not None)
         ]

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from application.cms.exceptions import RejectionImpossible
-from application.cms.models import Dimension, UKCountry, Table, Chart, DimensionClassification
+from application.cms.models import Dimension, UKCountry, Table, Chart, DimensionClassification, MeasureVersion
 from tests.models import (
     MeasureFactory,
     MeasureVersionFactory,
@@ -891,6 +891,78 @@ class TestMeasureVersionModel:
         measure_version = MeasureVersionFactory(description=None, summary="This is an intro.")
 
         assert measure_version.social_description is None
+
+    def test_later_minor_versions(self):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="2.0", measure=mv_1_0.measure)
+
+        assert mv_1_0.previous_minor_versions == []
+        assert mv_1_0.later_minor_versions == [mv_1_1, mv_1_2, mv_1_3]
+
+        assert mv_1_1.previous_minor_versions == [mv_1_0]
+        assert mv_1_1.later_minor_versions == [mv_1_2, mv_1_3]
+
+        assert mv_1_2.previous_minor_versions == [mv_1_0, mv_1_1]
+        assert mv_1_2.later_minor_versions == [mv_1_3]
+
+        assert mv_1_3.previous_minor_versions == [mv_1_0, mv_1_1, mv_1_2]
+        assert mv_1_3.later_minor_versions == []
+
+        assert mv_2_0.previous_minor_versions == []
+        assert mv_2_0.later_minor_versions == []
+
+    def test_has_known_statistical_errors(self):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(
+            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        )
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+        mv_1_4: MeasureVersion = MeasureVersionFactory.build(
+            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        )
+        mv_1_5: MeasureVersion = MeasureVersionFactory.build(
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+
+        assert mv_1_0.has_known_statistical_errors is True
+        assert mv_1_1.has_known_statistical_errors is True
+        assert mv_1_2.has_known_statistical_errors is True
+        assert mv_1_3.has_known_statistical_errors is True
+        assert mv_1_4.has_known_statistical_errors is False
+        assert mv_1_5.has_known_statistical_errors is False
+
+    def test_has_known_statistical_corrections(self):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(
+            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        )
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+        mv_1_4: MeasureVersion = MeasureVersionFactory.build(
+            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        )
+        mv_1_5: MeasureVersion = MeasureVersionFactory.build(
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+        )
+
+        assert mv_1_0.has_known_statistical_corrections is False
+        assert mv_1_1.has_known_statistical_corrections is False
+        assert mv_1_2.has_known_statistical_corrections is True
+        assert mv_1_3.has_known_statistical_corrections is True
+        assert mv_1_4.has_known_statistical_corrections is True
+        assert mv_1_5.has_known_statistical_corrections is True
 
 
 class TestChartModel:

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,6 +7,7 @@ See `tests/README.md` for further information on our use of Factory Boy.
 """
 
 import itertools
+
 import random
 
 from faker import Faker


### PR DESCRIPTION
In order to display banners at the top of measure version pages that
contain, or correct, factual errors, we will benefit from an easy-access
attribute on the record that lets us know if either of these are true.

 ## Ticket
https://trello.com/c/5DAHhjMM