### PR TITLE
Remove code for unpublishing

### DIFF
--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -51,7 +51,6 @@ def format_status(state):
         "DEPARTMENT_REVIEW": "Department&nbsp;review",
         "APPROVED": "Published",
         "REJECTED": "Rejected",
-        "UNPUBLISHED": "Un&#8209;published",
     }
     return status_names.get(state, state.replace("_", "&nbsp;").capitalize())
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -23,9 +23,7 @@ from application.cms.exceptions import (
 from application.utils import get_token_age, create_guid
 from application.utils import cleanup_filename
 
-publish_status = bidict(
-    REJECTED=0, DRAFT=1, INTERNAL_REVIEW=2, DEPARTMENT_REVIEW=3, APPROVED=4, UNPUBLISH=5, UNPUBLISHED=6
-)
+publish_status = bidict(REJECTED=0, DRAFT=1, INTERNAL_REVIEW=2, DEPARTMENT_REVIEW=3, APPROVED=4)
 
 TESTING_SPACE_SLUG = "testing-space"
 
@@ -413,10 +411,10 @@ class MeasureVersion(db.Model, CopyableModel):
         if self.status == "DEPARTMENT_REVIEW":
             return ["APPROVE", "REJECT"]
 
-        if self.status in ["REJECTED", "UNPUBLISHED"]:
+        if self.status == "REJECTED":
             return ["RETURN_TO_DRAFT"]
-        else:
-            return []
+
+        return []
 
     def next_state(self):
         num_status = self.publish_status(numerical=True)
@@ -443,10 +441,7 @@ class MeasureVersion(db.Model, CopyableModel):
         return message
 
     def not_editable(self):
-        if self.publish_status(numerical=True) == 5:
-            return False
-        else:
-            return self.publish_status(numerical=True) >= 2
+        return self.publish_status(numerical=True) >= 2
 
     def eligible_for_build(self):
         return self.status == "APPROVED"

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -327,9 +327,7 @@ class PageService(Service):
         self, measure_version, measure_version_form, data_source_forms, last_updated_by_email, **kwargs
     ):
         if measure_version.not_editable():
-            message = "Error updating '{}': Versions not in DRAFT, REJECT, UNPUBLISHED can't be edited".format(
-                measure_version.title
-            )
+            message = "Error updating '{}': Versions not in DRAFT, REJECT can't be edited".format(measure_version.title)
             self.logger.error(message)
             raise PageUnEditable(message)
         elif page_service._is_stale_update(measure_version_form.data, measure_version):
@@ -378,7 +376,7 @@ class PageService(Service):
             reference = measure_version_form.data["internal_reference"]
             measure_version.measure.reference = reference if reference else None
 
-        if measure_version.publish_status() in ["REJECTED", "UNPUBLISHED"]:
+        if measure_version.publish_status() == "REJECTED":
             new_status = publish_status.inv[1]
             measure_version.status = new_status
 
@@ -483,22 +481,6 @@ class PageService(Service):
     def first_published_date(measure_version):
         versions = measure_version.previous_minor_versions()
         return versions[-1].published_at if versions else measure_version.published_at
-
-    @staticmethod
-    def get_measure_versions_to_unpublish():
-        return (
-            MeasureVersion.query.filter_by(status="UNPUBLISH")
-            .order_by(MeasureVersion.title, desc(MeasureVersion.version))
-            .all()
-        )
-
-    @staticmethod
-    def mark_measure_versions_unpublished(measure_versions):
-        for measure_version in measure_versions:
-            measure_version.unpublished_at = datetime.utcnow()
-            measure_version.status = "UNPUBLISHED"
-
-            db.session.commit()
 
     @staticmethod
     def get_measure_version_pairs_with_data_corrections() -> List[Tuple[MeasureVersion, MeasureVersion]]:

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -377,8 +377,7 @@ class PageService(Service):
             measure_version.measure.reference = reference if reference else None
 
         if measure_version.publish_status() == "REJECTED":
-            new_status = publish_status.inv[1]
-            measure_version.status = new_status
+            measure_version.status = "DRAFT"
 
         measure_version.updated_at = datetime.utcnow()
         measure_version.last_updated_by = last_updated_by_email
@@ -406,8 +405,7 @@ class PageService(Service):
 
     def send_measure_version_to_draft(self, measure_version: MeasureVersion):
         if "RETURN_TO_DRAFT" in measure_version.available_actions:
-            numerical_status = measure_version.publish_status(numerical=True)
-            measure_version.status = publish_status.inv[(numerical_status + 1) % 6]
+            measure_version.status = "DRAFT"
             db.session.commit()
             message = 'Sent measure_version "{}" back to {}'.format(measure_version.title, measure_version.status)
         else:

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -916,8 +916,6 @@ def get_measure_version_uploads(topic_slug, subtopic_slug, measure_slug, version
 
 
 def _build_is_required(page, req, beta_publication_states):
-    if page.status == "UNPUBLISH":
-        return True
     if get_bool(req.args.get("build")) and page.eligible_for_build(beta_publication_states):
         return True
     return False
@@ -1087,10 +1085,7 @@ def set_measure_order():
 
 
 def _build_if_necessary(measure_version):
-    if measure_version.status == "UNPUBLISH":
-        build_service.request_build()
-
-    elif measure_version.eligible_for_build():
+    if measure_version.eligible_for_build():
         page_service.mark_measure_version_published(measure_version)
         build_service.request_build()
 

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -87,7 +87,7 @@
                 <button id="reject-measure" name="measure-action" value="reject-measure" class="govuk-button eff-button--destructive">Reject</button>
             {% endif %}
 
-            {% if measure_version.status == 'REJECTED' or measure_version.status == 'UNPUBLISHED' %}
+            {% if measure_version.status == 'REJECTED' %}
                 <button id="send-back-to-draft" name="measure-action" value="send-back-to-draft" class="govuk-button">Send back to draft</button>
             {%  endif %}
 

--- a/scripts/oneoff/import_new_dimension_titles.py
+++ b/scripts/oneoff/import_new_dimension_titles.py
@@ -105,14 +105,7 @@ def import_dimension_titles(user_email, app, dimension_rows: List):  # noqa: C90
                         error_count += 1
                         continue
 
-                    if latest_measure_version.status in (
-                        "REJECTED",
-                        "INTERNAL_REVIEW",
-                        "DRAFT",
-                        "DEPARTMENT_REVIEW",
-                        "UNPUBLISH",
-                        "UNPUBLISHED",
-                    ):
+                    if latest_measure_version.status in ("REJECTED", "INTERNAL_REVIEW", "DRAFT", "DEPARTMENT_REVIEW"):
                         print(
                             f"---> ERROR: Need latest measure version to be PUBLISHED; "
                             f"state is {latest_measure_version.status}."

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -670,8 +670,6 @@ class TestMeasureVersionModel:
             ("INTERNAL_REVIEW", False),
             ("DEPARTMENT_REVIEW", False),
             ("REJECTED", False),
-            ("UNPUBLISH", False),
-            ("UNPUBLISHED", False),
             ("APPROVED", True),
         ],
     )
@@ -707,18 +705,6 @@ class TestMeasureVersionModel:
     def test_available_actions_for_approved_page(self):
         measure_version = MeasureVersionFactory(status="APPROVED")
         expected_available_actions = []
-
-        assert expected_available_actions == measure_version.available_actions
-
-    def test_no_available_actions_for_page_awaiting_unpublication(self):
-        measure_version = MeasureVersionFactory(status="UNPUBLISH")
-        expected_available_actions = []
-
-        assert expected_available_actions == measure_version.available_actions
-
-    def test_available_actions_for_unpublished(self):
-        measure_version = MeasureVersionFactory(status="UNPUBLISHED")
-        expected_available_actions = ["RETURN_TO_DRAFT"]
 
         assert expected_available_actions == measure_version.available_actions
 

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -178,7 +178,7 @@ def test_admin_user_can_publish_page_in_dept_review(test_app_client, logged_in_a
     mock_request_build.assert_called_once()
 
 
-@pytest.mark.parametrize("cannot_publish_status", ("DRAFT", "INTERNAL_REVIEW", "APPROVED", "REJECTED", "UNPUBLISH"))
+@pytest.mark.parametrize("cannot_publish_status", ("DRAFT", "INTERNAL_REVIEW", "APPROVED", "REJECTED"))
 def test_admin_user_can_not_publish_page_not_in_department_review(
     test_app_client, logged_in_admin_user, mock_request_build, cannot_publish_status
 ):

--- a/tests/scripts/oneoff/test_import_new_dimension_titles.py
+++ b/tests/scripts/oneoff/test_import_new_dimension_titles.py
@@ -77,9 +77,7 @@ class TestImportNewDimensionTitles:
         assert measure.versions[1].dimensions[0].title == "my dimension 1"
         assert measure.versions[1].dimensions[1].title == "my dimension 2"
 
-    @pytest.mark.parametrize(
-        "new_version_state", ["REJECTED", "DRAFT", "INTERNAL_REVIEW", "DEPARTMENT_REVIEW", "UNPUBLISH", "UNPUBLISHED"]
-    )
+    @pytest.mark.parametrize("new_version_state", ["REJECTED", "DRAFT", "INTERNAL_REVIEW", "DEPARTMENT_REVIEW"])
     def test_script_ignores_measure_versions_where_a_new_minor_version_already_exists(
         self, single_use_app, new_version_state
     ):
@@ -119,8 +117,7 @@ class TestImportNewDimensionTitles:
         assert measure.versions[1].dimensions[0].title == "my dimension"
 
     @pytest.mark.parametrize(
-        "new_version_state",
-        ["REJECTED", "DRAFT", "INTERNAL_REVIEW", "DEPARTMENT_REVIEW", "APPROVED", "UNPUBLISH", "UNPUBLISHED"],
+        "new_version_state", ["REJECTED", "DRAFT", "INTERNAL_REVIEW", "DEPARTMENT_REVIEW", "APPROVED"]
     )
     def test_script_creates_new_minor_version_where_new_major_version_exists(self, single_use_app, new_version_state):
         user = UserFactory(user_type=TypeOfUser.ADMIN_USER, email="admin@eff.gov.uk")


### PR DESCRIPTION
All code that understands and facilitates unpublishing, except for model
declarations, can now be removed given that we no longer have any
measure versions in that state.

 ## Ticket
https://trello.com/c/h1gSEhgZ