### PR TITLE
Publish all versions

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -1125,12 +1125,8 @@ class Measure(db.Model):
 
     @property
     def versions_to_publish(self):
-        # Need to publish:
-        # 1. Latest published version
-        # 2. Latest published version of all previous major versions
-        if self.latest_published_version:
-            return [self.latest_published_version] + self.latest_published_version.previous_major_versions
-        return []
+        # Need to publish all approved versions with a publication date
+        return [version for version in self.versions if (version.status == "APPROVED" and version.published_at is not None)]
 
     @property
     def subtopic(self):

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -1126,7 +1126,9 @@ class Measure(db.Model):
     @property
     def versions_to_publish(self):
         # Need to publish all approved versions with a publication date
-        return [version for version in self.versions if (version.status == "APPROVED" and version.published_at is not None)]
+        return [
+            version for version in self.versions if (version.status == "APPROVED" and version.published_at is not None)
+        ]
 
     @property
     def subtopic(self):

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -155,28 +155,36 @@ def write_measure_versions(measure, build_dir, local_build=False):
 
     for measure_version in measure.versions_to_publish:
         slug = os.path.join(
-            build_dir,
-            measure.subtopic.topic.slug,
-            measure.subtopic.slug,
-            measure.slug,
-            "latest" if measure_version == measure.latest_published_version else measure_version.version,
-        )
-        os.makedirs(slug, exist_ok=True)
-
-        process_dimensions(measure_version, slug)
-
-        content = render_template(
-            "static_site/measure.html",
-            topic_slug=measure.subtopic.topic.slug,
-            subtopic_slug=measure.subtopic.slug,
-            measure_version=measure_version,
+            build_dir, measure.subtopic.topic.slug, measure.subtopic.slug, measure.slug, measure_version.version
         )
 
-        file_path = os.path.join(slug, "index.html")
-        write_html(file_path, content)
+        write_measure_vesion_at_slug(measure, measure_version, slug, local_build)
 
-        if not local_build:
-            write_measure_version_downloads(measure_version, slug)
+        # ALSO publish the same version at a '/latests' URL if it’s the latest one.
+        if measure_version == measure.latest_published_version:
+
+            slug = os.path.join(build_dir, measure.subtopic.topic.slug, measure.subtopic.slug, measure.slug, "latest")
+
+            write_measure_vesion_at_slug(measure, measure_version, slug, local_build)
+
+
+def write_measure_vesion_at_slug(measure, measure_version, slug, local_build=False):
+    os.makedirs(slug, exist_ok=True)
+
+    process_dimensions(measure_version, slug)
+
+    content = render_template(
+        "static_site/measure.html",
+        topic_slug=measure.subtopic.topic.slug,
+        subtopic_slug=measure.subtopic.slug,
+        measure_version=measure_version,
+    )
+
+    file_path = os.path.join(slug, "index.html")
+    write_html(file_path, content)
+
+    if not local_build:
+        write_measure_version_downloads(measure_version, slug)
 
 
 def write_measure_version_downloads(measure_version, slug):

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -160,7 +160,7 @@ def write_measure_versions(measure, build_dir, local_build=False):
 
         write_measure_vesion_at_slug(measure, measure_version, slug, local_build)
 
-        # ALSO publish the same version at a '/latests' URL if it’s the latest one.
+        # ALSO publish the same version at a '/latest' URL if it’s the latest one.
         if measure_version == measure.latest_published_version:
 
             slug = os.path.join(build_dir, measure.subtopic.topic.slug, measure.subtopic.slug, measure.slug, "latest")

--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -119,7 +119,7 @@
               {% set row_scope = 'rowgroup' if data.relationships is defined and data.relationships.is_parent else 'row' %}
 
               {% set th_class = 'eff-table__header--child' if dimension.dimension_table.table_object.parent_child is defined and dimension.dimension_table.table_object.parent_child and not data.relationships.is_parent else '' %}
-              <th class="govuk-table__header eff-table__header--border-right eff-table__header--dense {{ th_class }}" data-sort-value="{{ data_order }}" scope="{{ row_scope }}">{{ data.category }}</th>
+              <th class="govuk-table__header eff-table__header--border-right eff-table__header--dense {{ th_class }}" data-sort-value="{{ data_order }}" scope="{{ row_scope }}">{% if data.category is defined %}{{ data.category }}{% endif %}</th>
             {% endif %}
 
             {# We only want the 'eff-table-__header-border-right' class on the last column within each group #}

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -648,9 +648,7 @@ class TestMeasureModel:
         measure_version_2_0 = MeasureVersionFactory.create(
             measure=measure, version="2.0", status="APPROVED", published_at=datetime(2019, 1, 19).date()
         )
-        MeasureVersionFactory.create(
-            measure=measure, version="2.1", status="DRAFT", published_at=None
-        )
+        MeasureVersionFactory.create(measure=measure, version="2.1", status="DRAFT", published_at=None)
 
         assert len(measure.versions_to_publish) == 4
         assert measure.versions_to_publish[0] == measure_version_2_0

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -651,7 +651,12 @@ class TestMeasureModel:
         MeasureVersionFactory.build(measure=measure, version="2.1", status="DRAFT", published_at=None)
 
         assert len(measure.versions_to_publish) == 4
-        assert measure.versions_to_publish == [measure_version_2_0, measure_version_1_2, measure_version_1_1, measure_version_1_0]
+        assert measure.versions_to_publish == [
+            measure_version_2_0,
+            measure_version_1_2,
+            measure_version_1_1,
+            measure_version_1_0,
+        ]
 
 
 class TestMeasureVersionModel:

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -631,6 +631,24 @@ class TestDimensionModel:
         assert dimension.static_file_name == "dimension-guid.csv"
         assert dimension.static_table_file_name == "dimension-guid-table.csv"
 
+class TestMeasureModel:
+
+    def test_versions_to_publish(self):
+
+        measure = MeasureFactory.create()
+        measure_version_1_0 = MeasureVersionFactory.create(measure=measure,version="1.0",status="APPROVED", published_at=datetime(2018, 1, 19).date())
+        measure_version_1_1 = MeasureVersionFactory.create(measure=measure,version="1.1",status="APPROVED", published_at=datetime(2018, 1, 20).date())
+        measure_version_1_2 = MeasureVersionFactory.create(measure=measure,version="1.2",status="APPROVED", published_at=datetime(2018, 1, 21).date())
+        measure_version_2_0 = MeasureVersionFactory.create(measure=measure,version="2.0",status="APPROVED", published_at=datetime(2019, 1, 19).date())
+        measure_version_2_1 = MeasureVersionFactory.create(measure=measure,version="2.1",status="DRAFT", published_at=None)
+
+
+        assert len(measure.versions_to_publish)==4
+        assert measure.versions_to_publish[0] == measure_version_2_0
+        assert measure.versions_to_publish[1] == measure_version_1_2
+        assert measure.versions_to_publish[2] == measure_version_1_1
+        assert measure.versions_to_publish[3] == measure_version_1_0
+
 
 class TestMeasureVersionModel:
     def test_publish_to_internal_review(self):

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -651,10 +651,7 @@ class TestMeasureModel:
         MeasureVersionFactory.build(measure=measure, version="2.1", status="DRAFT", published_at=None)
 
         assert len(measure.versions_to_publish) == 4
-        assert measure.versions_to_publish[0] == measure_version_2_0
-        assert measure.versions_to_publish[1] == measure_version_1_2
-        assert measure.versions_to_publish[2] == measure_version_1_1
-        assert measure.versions_to_publish[3] == measure_version_1_0
+        assert measure.versions_to_publish == [measure_version_2_0, measure_version_1_2, measure_version_1_1, measure_version_1_0]
 
 
 class TestMeasureVersionModel:

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -636,19 +636,19 @@ class TestMeasureModel:
     def test_versions_to_publish(self):
 
         measure = MeasureFactory.create()
-        measure_version_1_0 = MeasureVersionFactory.create(
+        measure_version_1_0 = MeasureVersionFactory.build(
             measure=measure, version="1.0", status="APPROVED", published_at=datetime(2018, 1, 19).date()
         )
-        measure_version_1_1 = MeasureVersionFactory.create(
+        measure_version_1_1 = MeasureVersionFactory.build(
             measure=measure, version="1.1", status="APPROVED", published_at=datetime(2018, 1, 20).date()
         )
-        measure_version_1_2 = MeasureVersionFactory.create(
+        measure_version_1_2 = MeasureVersionFactory.build(
             measure=measure, version="1.2", status="APPROVED", published_at=datetime(2018, 1, 21).date()
         )
-        measure_version_2_0 = MeasureVersionFactory.create(
+        measure_version_2_0 = MeasureVersionFactory.build(
             measure=measure, version="2.0", status="APPROVED", published_at=datetime(2019, 1, 19).date()
         )
-        MeasureVersionFactory.create(measure=measure, version="2.1", status="DRAFT", published_at=None)
+        MeasureVersionFactory.build(measure=measure, version="2.1", status="DRAFT", published_at=None)
 
         assert len(measure.versions_to_publish) == 4
         assert measure.versions_to_publish[0] == measure_version_2_0

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -648,7 +648,7 @@ class TestMeasureModel:
         measure_version_2_0 = MeasureVersionFactory.create(
             measure=measure, version="2.0", status="APPROVED", published_at=datetime(2019, 1, 19).date()
         )
-        measure_version_2_1 = MeasureVersionFactory.create(
+        MeasureVersionFactory.create(
             measure=measure, version="2.1", status="DRAFT", published_at=None
         )
 

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -631,19 +631,28 @@ class TestDimensionModel:
         assert dimension.static_file_name == "dimension-guid.csv"
         assert dimension.static_table_file_name == "dimension-guid-table.csv"
 
-class TestMeasureModel:
 
+class TestMeasureModel:
     def test_versions_to_publish(self):
 
         measure = MeasureFactory.create()
-        measure_version_1_0 = MeasureVersionFactory.create(measure=measure,version="1.0",status="APPROVED", published_at=datetime(2018, 1, 19).date())
-        measure_version_1_1 = MeasureVersionFactory.create(measure=measure,version="1.1",status="APPROVED", published_at=datetime(2018, 1, 20).date())
-        measure_version_1_2 = MeasureVersionFactory.create(measure=measure,version="1.2",status="APPROVED", published_at=datetime(2018, 1, 21).date())
-        measure_version_2_0 = MeasureVersionFactory.create(measure=measure,version="2.0",status="APPROVED", published_at=datetime(2019, 1, 19).date())
-        measure_version_2_1 = MeasureVersionFactory.create(measure=measure,version="2.1",status="DRAFT", published_at=None)
+        measure_version_1_0 = MeasureVersionFactory.create(
+            measure=measure, version="1.0", status="APPROVED", published_at=datetime(2018, 1, 19).date()
+        )
+        measure_version_1_1 = MeasureVersionFactory.create(
+            measure=measure, version="1.1", status="APPROVED", published_at=datetime(2018, 1, 20).date()
+        )
+        measure_version_1_2 = MeasureVersionFactory.create(
+            measure=measure, version="1.2", status="APPROVED", published_at=datetime(2018, 1, 21).date()
+        )
+        measure_version_2_0 = MeasureVersionFactory.create(
+            measure=measure, version="2.0", status="APPROVED", published_at=datetime(2019, 1, 19).date()
+        )
+        measure_version_2_1 = MeasureVersionFactory.create(
+            measure=measure, version="2.1", status="DRAFT", published_at=None
+        )
 
-
-        assert len(measure.versions_to_publish)==4
+        assert len(measure.versions_to_publish) == 4
         assert measure.versions_to_publish[0] == measure_version_2_0
         assert measure.versions_to_publish[1] == measure_version_1_2
         assert measure.versions_to_publish[2] == measure_version_1_1

--- a/tests/application/cms/test_page_service.py
+++ b/tests/application/cms/test_page_service.py
@@ -598,8 +598,8 @@ class TestPageService:
 
     def test_get_latest_publishable_versions_of_measures_for_subtopic(self):
         measure = MeasureFactory()
-        MeasureVersionFactory(version="1.0", status="APPROVED", measure=measure)
-        MeasureVersionFactory(version="1.1", status="APPROVED", measure=measure)
+        version_1_0 = MeasureVersionFactory(version="1.0", status="APPROVED", measure=measure)
+        version_1_1 = MeasureVersionFactory(version="1.1", status="APPROVED", measure=measure)
         latest_publishable_version = MeasureVersionFactory(version="1.2", status="APPROVED", measure=measure)
         MeasureVersionFactory(version="1.3", status="DRAFT", measure=measure)
 
@@ -609,7 +609,7 @@ class TestPageService:
         measures = page_service.get_publishable_measures_for_subtopic(measure.subtopic)
         assert len(measures) == 1
         assert measures[0] == measure
-        assert measure.versions_to_publish == [latest_publishable_version]
+        assert measure.versions_to_publish == [latest_publishable_version, version_1_1, version_1_0]
         assert measure_2.versions_to_publish == []
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This updates the static build process to publish ALL approved versions of each measure, rather than just the most recent one. This means, for example, that versions 1.0, 1.1 and 2.0 are all public, rather than 1.1 and 2.0. The 'latest' measure (eg 2.0 in this example) is published under two URLs, a versioned on (`/2.0`) and a `/latest` one.

See https://trello.com/c/huHel6Z0/1578-3-publish-all-versions-major-and-minor-of-measures-3