### PR TITLE
Always link to version containing correction

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -481,25 +481,14 @@ class PageService(Service):
         return versions[-1].published_at if versions else measure_version.published_at
 
     @staticmethod
-    def get_measure_version_pairs_with_data_corrections() -> List[Tuple[MeasureVersion, MeasureVersion]]:
-        measures_versions_with_data_corrections = (
-            MeasureVersion.query.filter(
-                MeasureVersion.update_corrects_data_mistake == True,
-                MeasureVersion.status == "APPROVED",
-                MeasureVersion.published_at != None,
-            )  # noqa
-            .order_by(desc(MeasureVersion.published_at))
-            .all()
-        )
+    def get_measure_versions_with_data_corrections() -> List[MeasureVersion]:
 
-        measure_versions_corrected_and_published = []
-        for measure_version in measures_versions_with_data_corrections:
-            published_version_with_correction = next(
-                filter(lambda mv: mv.major() == measure_version.major(), measure_version.measure.versions_to_publish)
-            )
-            measure_versions_corrected_and_published.append((measure_version, published_version_with_correction))
+        return MeasureVersion.query.filter(
+            MeasureVersion.update_corrects_data_mistake == True,
+            MeasureVersion.status == "APPROVED",
+            MeasureVersion.published_at != None,
+        ).order_by(desc(MeasureVersion.published_at)).all()
 
-        return measure_versions_corrected_and_published
 
 
 page_service = PageService()

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -483,12 +483,15 @@ class PageService(Service):
     @staticmethod
     def get_measure_versions_with_data_corrections() -> List[MeasureVersion]:
 
-        return MeasureVersion.query.filter(
-            MeasureVersion.update_corrects_data_mistake == True,
-            MeasureVersion.status == "APPROVED",
-            MeasureVersion.published_at != None,
-        ).order_by(desc(MeasureVersion.published_at)).all()
-
+        return (
+            MeasureVersion.query.filter(
+                MeasureVersion.update_corrects_data_mistake == True,
+                MeasureVersion.status == "APPROVED",
+                MeasureVersion.published_at != None,
+            )
+            .order_by(desc(MeasureVersion.published_at))
+            .all()
+        )
 
 
 page_service = PageService()

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -391,7 +391,7 @@ def build_other_static_pages(build_dir):
         os.path.join(output_dir, "index.html"),
         render_template(
             "static_site/corrections.html",
-            measure_versions_corrected_and_published=page_service.get_measure_version_pairs_with_data_corrections(),
+            measure_versions_with_corrections=page_service.get_measure_versions_with_data_corrections(),
         ),
     )
 

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -234,9 +234,9 @@ def search():
 @static_site_blueprint.route("/corrections")
 @login_required
 def corrections():
-    measure_versions_corrected_and_published = page_service.get_measure_version_pairs_with_data_corrections()
+    measure_versions_with_corrections = page_service.get_measure_versions_with_data_corrections()
 
     return render_template(
         "static_site/corrections.html",
-        measure_versions_corrected_and_published=measure_versions_corrected_and_published,
+        measure_versions_with_corrections=measure_versions_with_corrections,
     )

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -237,6 +237,5 @@ def corrections():
     measure_versions_with_corrections = page_service.get_measure_versions_with_data_corrections()
 
     return render_template(
-        "static_site/corrections.html",
-        measure_versions_with_corrections=measure_versions_with_corrections,
+        "static_site/corrections.html", measure_versions_with_corrections=measure_versions_with_corrections
     )

--- a/application/templates/static_site/corrections.html
+++ b/application/templates/static_site/corrections.html
@@ -19,7 +19,7 @@
                                topic_slug=corrected_measure_version.measure.subtopic.topic.slug,
                                subtopic_slug=corrected_measure_version.measure.subtopic.slug,
                                measure_slug=corrected_measure_version.measure.slug,
-                               version='latest' if corrected_measure_version == published_version_with_correction.measure.latest_published_version else published_version_with_correction.version) }}">
+                               version=corrected_measure_version.version) }}">
             {{ corrected_measure_version.title }}
           </a>
         </h2>

--- a/application/templates/static_site/corrections.html
+++ b/application/templates/static_site/corrections.html
@@ -11,24 +11,24 @@
 {% block content %}
     <h1 class="govuk-heading-xl">Corrections to published data</h1>
 
-    {% if measure_versions_corrected_and_published|length > 0 %}
-      {% for corrected_measure_version, published_version_with_correction in measure_versions_corrected_and_published %}
+    {% if measure_versions_with_corrections|length > 0 %}
+      {% for measure_version in measure_versions_with_corrections %}
         <div class="corrected-measure-version">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
           <a class="govuk-link" href="{{ url_for('static_site.measure_version',
-                               topic_slug=corrected_measure_version.measure.subtopic.topic.slug,
-                               subtopic_slug=corrected_measure_version.measure.subtopic.slug,
-                               measure_slug=corrected_measure_version.measure.slug,
-                               version=corrected_measure_version.version) }}">
-            {{ corrected_measure_version.title }}
+                               topic_slug=measure_version.measure.subtopic.topic.slug,
+                               subtopic_slug=measure_version.measure.subtopic.slug,
+                               measure_slug=measure_version.measure.slug,
+                               version=measure_version.version) }}">
+            {{ measure_version.title }}
           </a>
         </h2>
         <p class="govuk-body">
-          Version: {{ corrected_measure_version.version }}
+          Version: {{ measure_version.version }}
           <br>
-          {{ corrected_measure_version.published_at | format_friendly_date }}
+          {{ measure_version.published_at | format_friendly_date }}
           <br>
-          {{ corrected_measure_version.external_edit_summary }}
+          {{ measure_version.external_edit_summary }}
         </p>
         </div>
         <br>

--- a/tests/application/dashboard/test_views.py
+++ b/tests/application/dashboard/test_views.py
@@ -43,7 +43,7 @@ def test_data_corrections_page_with_no_corrections(test_app_client, logged_in_rd
     assert len(doc.xpath("//div[@class='corrected-measure-version']")) == 0
 
 
-def test_data_corrections_page_shows_corrected_versions_with_link_to_latest_minor_version_in_same_major_version(
+def test_data_corrections_page_shows_corrected_versions_with_link_to_page_containing_correction(
     test_app_client, logged_in_rdu_user, db_session
 ):
     measure = MeasureFactory(slug="measure", subtopics__slug="subtopic", subtopics__topic__slug="topic")
@@ -70,4 +70,4 @@ def test_data_corrections_page_shows_corrected_versions_with_link_to_latest_mino
 
     assert len(doc.xpath("//div[@class='corrected-measure-version']")) == 1
     assert "1 January 2001" in doc.xpath("//div[@class='corrected-measure-version']")[0].text_content()
-    assert doc.xpath("//div[@class='corrected-measure-version']//h2/a/@href")[0] == "/topic/subtopic/measure/1.2"
+    assert doc.xpath("//div[@class='corrected-measure-version']//h2/a/@href")[0] == "/topic/subtopic/measure/1.1"

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -917,7 +917,7 @@ class TestCorrections:
         assert corrected_measure_versions[0].find("a").text.strip() == "Measure 2 version 1.1"
         assert corrected_measure_versions[1].find("a").text.strip() == "Measure 1 version 1.1"
 
-    def test_latest_published_version_uses_latest_reference_rather_than_numerical_version_if_no_later_versions(
+    def test_latest_published_version_uses_numerical_version(
         self, test_app_client, logged_in_rdu_user
     ):
         resp = test_app_client.get("/corrections", follow_redirects=False)
@@ -925,5 +925,5 @@ class TestCorrections:
 
         corrected_measure_versions = page.findAll("div", {"class": "corrected-measure-version"})
 
-        assert corrected_measure_versions[0].find("a").attrs["href"].endswith("1.2")
-        assert corrected_measure_versions[1].find("a").attrs["href"].endswith("latest")
+        assert corrected_measure_versions[0].find("a").attrs["href"].endswith("1.1")
+        assert corrected_measure_versions[1].find("a").attrs["href"].endswith("1.1")

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -917,9 +917,7 @@ class TestCorrections:
         assert corrected_measure_versions[0].find("a").text.strip() == "Measure 2 version 1.1"
         assert corrected_measure_versions[1].find("a").text.strip() == "Measure 1 version 1.1"
 
-    def test_latest_published_version_uses_numerical_version(
-        self, test_app_client, logged_in_rdu_user
-    ):
+    def test_latest_published_version_uses_numerical_version(self, test_app_client, logged_in_rdu_user):
         resp = test_app_client.get("/corrections", follow_redirects=False)
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 


### PR DESCRIPTION
See https://trello.com/c/98kJ0Iiq/1575-4-update-corrections-page-to-point-to-specific-version-that-was-updated-1