### PR TITLE
Add question to select updated version

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -283,6 +283,10 @@ class MeasureVersion(db.Model, CopyableModel):
     internal_edit_summary = db.Column(db.TEXT)  # internal notes on new version, not displayed on public measure page
     update_corrects_data_mistake = db.Column(db.Boolean)  # Whether or not a minor updates fixes a mistake in the data
 
+    # Where a measure version is a correction, this points to the earliest version (within the same major version)
+    # that contains the error.
+    update_corrects_measure_version = db.Column(db.Integer, ForeignKey("measure_version.id"))
+
     # lowest_level_of_geography is not displayed on the public site but is used for geographic dashboard
     lowest_level_of_geography_id = db.Column(
         db.String(255), ForeignKey("lowest_level_of_geography.name", ondelete="restrict"), nullable=True
@@ -313,6 +317,12 @@ class MeasureVersion(db.Model, CopyableModel):
         secondary="data_source_in_measure_version",
         back_populates="measure_versions",
         order_by=asc(DataSource.id),
+    )
+    corrected_by_measure_version = db.relationship(
+        "MeasureVersion",
+        remote_side=[update_corrects_measure_version],
+        uselist=False,
+        backref=db.backref("correction_for_measure_version", remote_side=[id]),
     )
 
     @property
@@ -568,7 +578,9 @@ class MeasureVersion(db.Model, CopyableModel):
         if *this* version is correcting a mistake - because it might be that not all the mistakes were fixed by this
         version."""
         return any(
-            later_minor_version.update_corrects_data_mistake for later_minor_version in self.later_minor_versions
+            later_minor_version.update_corrects_data_mistake
+            and later_minor_version.correction_for_measure_version <= self
+            for later_minor_version in self.later_minor_versions
         )
 
     @property

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -65,7 +65,10 @@ def create_measure(topic_slug, subtopic_slug):
         abort(404)
 
     form = MeasureVersionForm(
-        is_minor_update=False, internal_edit_summary="Initial version", external_edit_summary="First published"
+        is_minor_update=False,
+        internal_edit_summary="Initial version",
+        external_edit_summary="First published",
+        previous_minor_versions=tuple(),
     )
     data_source_form, data_source_2_form = get_data_source_forms(request, measure_version=None)
 
@@ -291,7 +294,10 @@ def edit_measure_version(topic_slug, subtopic_slug, measure_slug, version):
             is_minor_update=measure_version.is_minor_version(), obj=measure_version
         )
     elif request.method == "POST":
-        measure_version_form = MeasureVersionForm(is_minor_update=measure_version.is_minor_version())
+        measure_version_form = MeasureVersionForm(
+            is_minor_update=measure_version.is_minor_version(),
+            previous_minor_versions=measure_version.previous_minor_versions,
+        )
 
     saved = False
     errors_preamble = None

--- a/application/factory.py
+++ b/application/factory.py
@@ -172,6 +172,9 @@ def create_app(config_object):
 
     mail.init_app(app)
 
+    def jinja_raise_exception(message):
+        raise RuntimeError(message)
+
     @app.context_processor
     def inject_globals():
         from application.auth.models import (
@@ -205,6 +208,7 @@ def create_app(config_object):
             current_timestamp=datetime.datetime.now().isoformat(),
             get_form_errors=get_form_errors,
             static_mode=get_bool(request.args.get("static_mode", app.config["STATIC_MODE"])),
+            raise_exception=jinja_raise_exception,
         )
 
     return app

--- a/application/form_fields.py
+++ b/application/form_fields.py
@@ -10,7 +10,6 @@ from enum import Enum
 
 from functools import partial
 
-
 from flask import render_template
 from markupsafe import Markup
 from wtforms.fields import SelectMultipleField, RadioField, StringField
@@ -152,7 +151,7 @@ class _RDUChoiceInput(_FormFieldTemplateRenderer):
         super().__init__(*args, **kwargs)
         self.field_type = field_type
 
-    def __call__(self, field, class_="", diffs=None, disabled=False, **kwargs):
+    def __call__(self, field, class_="", diffs=None, disabled=False, conditional_question=None, **kwargs):
         if getattr(field, "checked", field.data):
             kwargs["checked"] = True
 
@@ -163,7 +162,11 @@ class _RDUChoiceInput(_FormFieldTemplateRenderer):
             class_=class_,
             diffs=diffs,
             disabled=disabled,
-            render_params={"value": field.data, "field_type": self.field_type.value},
+            render_params={
+                "value": field.data,
+                "field_type": self.field_type.value,
+                "conditional_question": conditional_question,
+            },
             field_params={**kwargs},
         )
 
@@ -186,6 +189,7 @@ class _FormGroup(_FormFieldTemplateRenderer):
         diffs=None,
         disabled=False,
         inline=False,
+        conditional_questions=None,
         **kwargs,
     ):
         subfields = [subfield for subfield in field]
@@ -205,6 +209,7 @@ class _FormGroup(_FormFieldTemplateRenderer):
                 "field_class": field_class,
                 "field_type": self.field_type.value,
                 "inline": inline,
+                "conditional_questions": conditional_questions,
             },
             field_params={**kwargs},
         )

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -196,9 +196,8 @@
                     <h3 class="govuk-heading-m">Updates and corrections</h3>
                     {% if new or measure_version.version == '1.0' %}<div class="hidden">{% endif %}
                         {% if form.is_minor_update %}
-                            {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, inline=True) }}
-
-                            {{ form.update_corrects_measure_version(disabled=form_disabled, diffs=diffs) }}
+                            {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, inline=True,
+                                                                 conditional_questions={"Yes": form.update_corrects_measure_version(disabled=form_disabled, diffs=diffs)}) }}
                         {% endif %}
 
                         {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -197,6 +197,8 @@
                     {% if new or measure_version.version == '1.0' %}<div class="hidden">{% endif %}
                         {% if form.is_minor_update %}
                             {{ form.update_corrects_data_mistake(disabled=form_disabled, diffs=diffs, inline=True) }}
+
+                            {{ form.update_corrects_measure_version(disabled=form_disabled, diffs=diffs) }}
                         {% endif %}
 
                         {{ form.external_edit_summary(disabled=form_disabled, diffs=diffs, rows=4) }}

--- a/application/templates/forms/_choice_input.html
+++ b/application/templates/forms/_choice_input.html
@@ -1,8 +1,19 @@
 {# Required parameters: field, id_, name, class, value, field_params #}
 
 {% set govukBaseClass = 'govuk-' + ('checkboxes' if field_type == 'checkbox' else 'radios') %}
+{% set conditionalId = 'conditional-' + field.id %}
 
 <div class="{{ govukBaseClass }}__item">
-  <input id="{{ id_ }}" name="{{ name }}" class="{{ govukBaseClass }}__input {{ class_ }}" value="{{ value }}" type="{{ field_type }}" {{ field_params }}>
+  <input id="{{ id_ }}" name="{{ name }}" class="{{ govukBaseClass }}__input {{ class_ }}" value="{{ value }}"
+         type="{{ field_type }}"
+         {{ field_params }}
+         {% if conditional_question %} data-aria-controls="{{ conditionalId }}"{% endif %}
+  >
   <label class="govuk-label {{ govukBaseClass }}__label" for="{{ field.id }}">{{ field.label.text }}</label>
 </div>
+
+{% if conditional_question %}
+<div class="{{ govukBaseClass }}__conditional {% if field %} {{ govukBaseClass }}__conditional--hidden"{% endif %} id="{{ conditionalId }}">
+  {{ conditional_question | safe }}
+</div>
+{% endif %}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -1,6 +1,8 @@
-{# Required parameters: id_, name, class_, fieldset_class, field_class, field_type, legend, fields, errors, label_class, disabled #}
+{# Required parameters: id_, name, class_, fieldset_class, field_class, field_type, legend, fields, errors, label_class, disabled, inline #}
 
-{% set govukBaseClass = 'govuk-' + ('checkboxes' if field_type == 'checkbox' else 'radios') %}
+{% set baseFieldType = ('checkboxes' if field_type == 'checkbox' else 'radios') %}
+{% set govukBaseClass = 'govuk-' + baseFieldType %}
+{% set hasConditionalQuestions = conditional_questions is not none %}
 
 <div id="{{ id_ }}" name="{{ name }}" class="govuk-form-group{% if class_ %} {{ class_ }}{% endif %}{% if errors is defined and errors %} govuk-form-group--error{% endif %}">
   {% if fields|length == 1 %}
@@ -13,15 +15,25 @@
     {% if field.hint or hint | default(false) %}
     <span class="govuk-hint">{{ field.hint or hint }}</span>
     {% endif %}
-      <div class="{{ govukBaseClass }}{% if inline %} {{ govukBaseClass }}--inline{% endif %}">
-        {% for field in fields %}
+      <div class="{{ govukBaseClass }}{% if inline %} {{ govukBaseClass }}--inline{% endif %}{% if conditional_questions %} {{ govukBaseClass }}--conditional{% endif %}"
+           {% if conditional_questions %} data-module="{{ baseFieldType }}"{% endif %}
+      >
+        {% for subfield in fields %}
             {% set field_options = {"disabled": disabled, "class_": field_class} %}
             {% if loop.last and other_field %}
               {% do field_options.update({"aria-controls": other_field.id + "-wrapper", "aria-expanded": "false"}) %}
             {% endif %}
-            {{ field(**field_options) }}
+            {% if conditional_questions and subfield.label.text in conditional_questions %}
+              {% do field_options.update({"conditional_question": conditional_questions.pop(subfield.label.text)}) %}
+            {% endif %}
+            {{ subfield(**field_options) }}
         {% endfor %}
       </div>
+
+      {# Fail fast to catch conditionals which have are associated with labels not present in this field #}
+      {% if hasConditionalQuestions and conditional_questions | length > 0 %}
+        {{ raise_exception("Not all conditional questions have been rendered.") }}
+      {% endif %}
 
       {% if fields and other_field %}
         <div class="panel panel-border-narrow govuk-form-group{% if other_field.errors %} govuk-form-group--error{% endif %}"

--- a/migrations/versions/2019_05_28_mv_error_update_add_a_field_to_measure_version_fk_on_.py
+++ b/migrations/versions/2019_05_28_mv_error_update_add_a_field_to_measure_version_fk_on_.py
@@ -1,0 +1,35 @@
+"""Add a field to measure_version, fk on itself, to say which version an update is fixing
+
+Revision ID: 2019_05_28_mv_error_update
+Revises: 2019_04_18_add_topic_short_title
+Create Date: 2019-05-28 08:31:21.119363
+
+"""
+from alembic import op
+
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2019_05_28_mv_error_update"
+down_revision = "2019_04_18_add_topic_short_title"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("measure_version", sa.Column("update_corrects_measure_version", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        op.f("measure_version_update_corrects_measure_version_fkey"),
+        "measure_version",
+        "measure_version",
+        ["update_corrects_measure_version"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("measure_version_update_corrects_measure_version_fkey"), "measure_version", type_="foreignkey"
+    )
+    op.drop_column("measure_version", "update_corrects_measure_version")

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -922,48 +922,63 @@ class TestMeasureVersionModel:
         assert mv_2_0.previous_minor_versions == []
         assert mv_2_0.later_minor_versions == []
 
-    def test_has_known_statistical_errors(self):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
-        mv_1_1: MeasureVersion = MeasureVersionFactory.build(
+    def test_has_known_statistical_errors(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
+        mv_1_1: MeasureVersion = MeasureVersionFactory.create(
             version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
-        mv_1_2: MeasureVersion = MeasureVersionFactory.build(
-            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        mv_1_2: MeasureVersion = MeasureVersionFactory.create(
+            version="1.2",
+            measure=mv_1_0.measure,
+            update_corrects_data_mistake=True,
+            update_corrects_measure_version=mv_1_1.id,
         )
-        mv_1_3: MeasureVersion = MeasureVersionFactory.build(
+        mv_1_3: MeasureVersion = MeasureVersionFactory.create(
             version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
-        mv_1_4: MeasureVersion = MeasureVersionFactory.build(
-            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        mv_1_4: MeasureVersion = MeasureVersionFactory.create(
+            version="1.4",
+            measure=mv_1_0.measure,
+            update_corrects_data_mistake=True,
+            update_corrects_measure_version=mv_1_3.id,
         )
-        mv_1_5: MeasureVersion = MeasureVersionFactory.build(
+        mv_1_5: MeasureVersion = MeasureVersionFactory.create(
             version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
 
-        assert mv_1_0.has_known_statistical_errors is True
+        db_session.session.commit()
+
+        assert mv_1_0.has_known_statistical_errors is False
         assert mv_1_1.has_known_statistical_errors is True
-        assert mv_1_2.has_known_statistical_errors is True
+        assert mv_1_2.has_known_statistical_errors is False
         assert mv_1_3.has_known_statistical_errors is True
         assert mv_1_4.has_known_statistical_errors is False
         assert mv_1_5.has_known_statistical_errors is False
 
-    def test_has_known_statistical_corrections(self):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
-        mv_1_1: MeasureVersion = MeasureVersionFactory.build(
+    def test_has_known_statistical_corrections(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
+        mv_1_1: MeasureVersion = MeasureVersionFactory.create(
             version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
-        mv_1_2: MeasureVersion = MeasureVersionFactory.build(
-            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        mv_1_2: MeasureVersion = MeasureVersionFactory.create(
+            version="1.2",
+            measure=mv_1_0.measure,
+            update_corrects_data_mistake=True,
+            update_corrects_measure_version=mv_1_1.id,
         )
-        mv_1_3: MeasureVersion = MeasureVersionFactory.build(
+        mv_1_3: MeasureVersion = MeasureVersionFactory.create(
             version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
-        mv_1_4: MeasureVersion = MeasureVersionFactory.build(
-            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+        mv_1_4: MeasureVersion = MeasureVersionFactory.create(
+            version="1.4",
+            measure=mv_1_0.measure,
+            update_corrects_data_mistake=True,
+            update_corrects_measure_version=mv_1_3.id,
         )
-        mv_1_5: MeasureVersion = MeasureVersionFactory.build(
+        mv_1_5: MeasureVersion = MeasureVersionFactory.create(
             version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
         )
+        db_session.session.commit()
 
         assert mv_1_0.has_known_statistical_corrections is False
         assert mv_1_1.has_known_statistical_corrections is False

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -127,6 +127,7 @@ class EditMeasureLocators:
     FURTHER_TECHNICAL_INFORMATION_INPUT = (By.NAME, "further_technical_information")
 
     UPDATE_CORRECTS_DATA_MISTAKE = (By.NAME, "update_corrects_data_mistake")
+    UPDATE_CORRECTS_DATA_MISTAKE = (By.NAME, "update_corrects_measure_version")
     EXTERNAL_EDIT_SUMMARY = (By.ID, "external_edit_summary")
 
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -554,6 +554,12 @@ class MeasureEditPage(BasePage):
         radio = element.find_element_by_xpath(f"//input[@value='{value}']")
         self.select_checkbox_or_radio(radio)
 
+    def set_corrected_measure_version(self, version):
+        element = self.driver.find_element(*EditMeasureLocators.UPDATE_CORRECTS_DATA_MISTAKE)
+        label = element.find_element_by_xpath(f"//label[contains(., '{version}')]")
+        radio = element.find_element_by_xpath(f"//input[@id='{label.get_attribute('for')}']")
+        self.select_checkbox_or_radio(radio)
+
     def fill_measure_page(self, measure_version, data_source):
         self.set_time_period_covered(measure_version.time_covered)
         self.set_area_covered(area="England")
@@ -587,6 +593,9 @@ class MeasureEditPage(BasePage):
 
     def fill_measure_page_minor_edit_fields(self, measure_version):
         self.set_update_corrects_data_mistake(measure_version.update_corrects_data_mistake)
+
+        if measure_version.update_corrects_data_mistake:
+            self.set_corrected_measure_version("1.0")
 
         self.set_text_field(EditMeasureLocators.EXTERNAL_EDIT_SUMMARY, measure_version.external_edit_summary)
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -10,7 +10,11 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.expected_conditions import _find_element
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    ElementClickInterceptedException,
+    ElementNotVisibleException,
+)
 
 from application.cms.models import TypeOfData, TypeOfStatistic, DataSource, FrequencyOfRelease, Organisation
 
@@ -113,7 +117,10 @@ class BasePage:
         return check_does_not_contain
 
     def select_checkbox_or_radio(self, element):
-        self.driver.execute_script("arguments[0].setAttribute('checked', 'checked')", element)
+        try:
+            element.click()
+        except (ElementClickInterceptedException, ElementNotVisibleException):
+            self.driver.execute_script("arguments[0].setAttribute('checked', 'checked')", element)
 
     def search_site(self, text):
         element = self.wait_for_element(BasePage.search_input)

--- a/tests/functional/test_cms_measure_lifecycle.py
+++ b/tests/functional/test_cms_measure_lifecycle.py
@@ -27,7 +27,9 @@ def test_create_a_measure_as_editor(driver, live_server, government_departments,
         data_sources__publisher=random.choice(government_departments),
         data_sources__frequency_of_release=random.choice(frequencies_of_release),
     )
-    sample_measure_version = MeasureVersionFactory.build(version="1.1", data_sources=[])
+    sample_measure_version = MeasureVersionFactory.build(
+        version="1.1", data_sources=[], update_corrects_data_mistake=True
+    )
     sample_data_source = DataSourceFactory.build(
         publisher__name=random.choice(government_departments).name,
         frequency_of_release__description=random.choice(frequencies_of_release).description,

--- a/tests/models.py
+++ b/tests/models.py
@@ -290,6 +290,7 @@ class MeasureVersionFactory(factory.alchemy.SQLAlchemyModelFactory):
     update_corrects_data_mistake = factory.Maybe(
         "_is_major_version", yes_declaration=False, no_declaration=random.choice((True, False))
     )
+    update_corrects_measure_version = None  # Needs to be manually assigned if `update_corrects_data_mistake` is True
     lowest_level_of_geography_id = factory.SelfAttribute("lowest_level_of_geography.name")
     methodology = factory.Faker("paragraph", nb_sentences=3)
     suppression_and_disclosure = factory.Faker("paragraph", nb_sentences=3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,6 +52,8 @@ def multidict_from_measure_version_and_kwargs(measure_version: MeasureVersion, *
             "estimation": measure_version.estimation,
             "qmi_url": measure_version.qmi_url,
             "further_technical_information": measure_version.further_technical_information,
+            "update_corrects_data_mistake": measure_version.update_corrects_data_mistake,
+            "update_corrects_measure_version": measure_version.update_corrects_measure_version,
             "db_version_id": measure_version.db_version_id,
             **kwargs,
         }


### PR DESCRIPTION
When a measure version update is correcting a factual mistake, the user
has to specifically note that this is the case. Where it is correcting a
fact, it's also useful to know how long the mistake has been published
(i.e. which version introduced the mistake). This patch adds a radio
question allowing the user to pick the earliest version that included
the error. This allows us to only show a banner declaring a factual
error for the real duration of the error.

 ## Ticket
https://trello.com/c/05vv68FM