### PR TITLE
Corrections banners

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -520,7 +520,9 @@ class MeasureVersion(db.Model, CopyableModel):
     def latest_published_minor_version(self):
         """This returns the latest published version which matches the same major version
         as the current version.
-        Note: this may return the same version (if it’s the only one published), or a previous version (if this one is not yet published). If there is no published version available yet, it returns None.
+        Note: this may return the same version (if it’s the only one published),
+        or a previous version (if this one is not yet published). If there is no published
+        version available yet, it returns None.
         """
         published_minor_versions = [
             v for v in self.measure.versions if v.major() == self.major() and v.status == "APPROVED"

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -613,7 +613,7 @@ class MeasureVersion(db.Model, CopyableModel):
         return any(
             later_minor_version.update_corrects_data_mistake
             and later_minor_version.correction_for_measure_version <= self
-            for later_minor_version in self.later_minor_versions
+            for later_minor_version in self.later_published_minor_versions
         )
 
     @property

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -497,8 +497,24 @@ class MeasureVersion(db.Model, CopyableModel):
         return [v for v in self.measure.versions if v.major() == self.major() and v.minor() < self.minor()]
 
     @property
+    def previous_published_minor_versions(self):
+        return [
+            v
+            for v in self.measure.versions
+            if v.major() == self.major() and v.minor() < self.minor() and v.status == "APPROVED"
+        ]
+
+    @property
     def later_minor_versions(self):
         return [v for v in self.measure.versions if v.major() == self.major() and v.minor() > self.minor()]
+
+    @property
+    def later_published_minor_versions(self):
+        return [
+            v
+            for v in self.measure.versions
+            if v.major() == self.major() and v.minor() > self.minor() and v.status == "APPROVED"
+        ]
 
     @property
     def latest_published_minor_version(self):
@@ -506,7 +522,9 @@ class MeasureVersion(db.Model, CopyableModel):
         as the current version.
         Note: this may return the same version (if it’s the only one published), or a previous version (if this one is not yet published). If there is no published version available yet, it returns None.
         """
-        published_minor_versions = [v for v in self.measure.versions if v.major() == self.major() and v.status == 'APPROVED']
+        published_minor_versions = [
+            v for v in self.measure.versions if v.major() == self.major() and v.status == "APPROVED"
+        ]
 
         if len(published_minor_versions) > 0:
             return published_minor_versions[0]
@@ -581,7 +599,8 @@ class MeasureVersion(db.Model, CopyableModel):
         if *this* version is correcting a mistake - because it might be that not all the mistakes were fixed by this
         version."""
         return any(
-            later_minor_version.update_corrects_data_mistake for later_minor_version in self.later_minor_versions
+            later_minor_version.update_corrects_data_mistake
+            for later_minor_version in self.later_published_minor_versions
         )
 
     @property
@@ -591,7 +610,7 @@ class MeasureVersion(db.Model, CopyableModel):
         still also having errors itself (presumably discovered at a later date)."""
         return self.update_corrects_data_mistake or any(
             previous_minor_version.update_corrects_data_mistake
-            for previous_minor_version in self.previous_minor_versions
+            for previous_minor_version in self.previous_published_minor_versions
         )
 
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -539,7 +539,7 @@ class MeasureVersion(db.Model, CopyableModel):
         ]
 
         if len(published_minor_versions) > 0:
-            return published_minor_versions[0]
+            return max(published_minor_versions)
         else:
             return None
 

--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -501,6 +501,19 @@ class MeasureVersion(db.Model, CopyableModel):
         return [v for v in self.measure.versions if v.major() == self.major() and v.minor() > self.minor()]
 
     @property
+    def latest_published_minor_version(self):
+        """This returns the latest published version which matches the same major version
+        as the current version.
+        Note: this may return the same version (if it’s the only one published), or a previous version (if this one is not yet published). If there is no published version available yet, it returns None.
+        """
+        published_minor_versions = [v for v in self.measure.versions if v.major() == self.major() and v.status == 'APPROVED']
+
+        if len(published_minor_versions) > 0:
+            return published_minor_versions[0]
+        else:
+            return None
+
+    @property
     def first_published_date(self):
         return self.previous_minor_versions[-1].published_at if self.previous_minor_versions else self.published_at
 

--- a/application/src/js/all/_open_details_if_hash_target.js
+++ b/application/src/js/all/_open_details_if_hash_target.js
@@ -1,0 +1,14 @@
+
+function checkForDetailsHashTarget() {
+
+  var element = document.getElementById(location.hash.substring(1))
+
+  if (element && element.tagName === 'DETAILS' && 'open' in element) {
+    element.open = true
+  }
+
+}
+
+window.addEventListener('hashchange', checkForDetailsHashTarget)
+document.addEventListener('DOMContentLoaded', checkForDetailsHashTarget)
+

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -13,6 +13,8 @@ $govuk-assets-path: '/static/assets/';
 @import 'components/details';
 @import 'components/diffs';
 @import 'components/document_footer';
+@import 'components/factual_corrections';
+@import 'components/factual_mistake';
 @import 'components/flash_message';
 @import 'components/header';
 @import 'components/header_search_box';

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -13,7 +13,6 @@ $govuk-assets-path: '/static/assets/';
 @import 'components/details';
 @import 'components/diffs';
 @import 'components/document_footer';
-@import 'components/factual_corrections';
 @import 'components/factual_mistake';
 @import 'components/flash_message';
 @import 'components/header';

--- a/application/src/sass/components/_factual_corrections.scss
+++ b/application/src/sass/components/_factual_corrections.scss
@@ -1,0 +1,5 @@
+.eff-factual-corrections {
+  @include govuk-font($size: 19, $weight: normal);
+  border-left: $govuk-border-width-wide solid govuk-colour("green");
+  padding: govuk-spacing(3);
+}

--- a/application/src/sass/components/_factual_corrections.scss
+++ b/application/src/sass/components/_factual_corrections.scss
@@ -1,5 +1,0 @@
-.eff-factual-corrections {
-  @include govuk-font($size: 19, $weight: normal);
-  border-left: $govuk-border-width-wide solid govuk-colour("green");
-  padding: govuk-spacing(3);
-}

--- a/application/src/sass/components/_factual_mistake.scss
+++ b/application/src/sass/components/_factual_mistake.scss
@@ -1,0 +1,13 @@
+.eff-factual-mistake {
+  @include govuk-font($size: 19, $weight: normal);
+  @include govuk-responsive-margin(3, "bottom");
+  color: govuk-colour("white");
+  background-color: $govuk-error-colour;
+  padding: govuk-spacing(3);
+}
+
+.eff-factual-mistake__link:link,
+.eff-factual-mistake__link:visited {
+  color: govuk-colour("white");
+  @include govuk-font($size: 19, $weight: bold);
+}

--- a/application/src/sass/components/_factual_mistake.scss
+++ b/application/src/sass/components/_factual_mistake.scss
@@ -1,13 +1,18 @@
 .eff-factual-mistake {
-  @include govuk-font($size: 19, $weight: normal);
+  @include govuk-font($size: 19, $weight: bold);
   @include govuk-responsive-margin(3, "bottom");
-  color: govuk-colour("white");
+  border-color: $govuk-error-colour;
+  border-width: $govuk-border-width;
+  border-style: solid;
+  padding: govuk-spacing(4);
   background-color: $govuk-error-colour;
-  padding: govuk-spacing(3);
+  color: govuk-colour('white');
 }
 
-.eff-factual-mistake__link:link,
-.eff-factual-mistake__link:visited {
-  color: govuk-colour("white");
-  @include govuk-font($size: 19, $weight: bold);
+.eff-factual-mistake__details,
+.eff-factual-mistake .govuk-heading-l,
+.eff-factual-mistake__details a:link,
+.eff-factual-mistake__details a:visited {
+  color: govuk-colour('white');
+  font-weight: bold;
 }

--- a/application/templates/_shared/_contains_corrections.html
+++ b/application/templates/_shared/_contains_corrections.html
@@ -1,0 +1,3 @@
+<div class="eff-factual-corrections">
+  This page corrects mistakes in a previous version. <a class="govuk-link" href="#full-page-history">See details</a>.
+</div>

--- a/application/templates/_shared/_contains_corrections.html
+++ b/application/templates/_shared/_contains_corrections.html
@@ -1,3 +1,3 @@
-<div class="eff-factual-corrections">
+<div class="govuk-inset-text">
   This page corrects mistakes in a previous version. <a class="govuk-link" href="#full-page-history">See details</a>.
 </div>

--- a/application/templates/_shared/_contains_factual_mistake.html
+++ b/application/templates/_shared/_contains_factual_mistake.html
@@ -1,7 +1,9 @@
 <div class="eff-factual-mistake">
-  This page contains a factual mistake. Details can be found on <a href="{{ url_for('static_site.measure_version',
+  <h2 class="govuk-heading-l">This page contains a factual mistake</h2>
+
+  <p class="govuk-body govuk-!-margin-bottom-0 eff-factual-mistake__details">Details can be found on <a href="{{ url_for('static_site.measure_version',
                         topic_slug=topic_slug,
                         subtopic_slug=subtopic_slug,
                         measure_slug=measure_version.measure.slug,
-                        version=measure_version.latest_published_minor_version.version) }}" class="eff-factual-mistake__link">the corrected page</a>.
+                        version=measure_version.latest_published_minor_version.version) }}" class="eff-factual-mistake__link">the corrected page</a>.</p>
 </div>

--- a/application/templates/_shared/_contains_factual_mistake.html
+++ b/application/templates/_shared/_contains_factual_mistake.html
@@ -1,0 +1,7 @@
+<div class="eff-factual-mistake">
+  This page contains a factual mistake. Details can be found on <a href="{{ url_for('static_site.measure_version',
+                        topic_slug=topic_slug,
+                        subtopic_slug=subtopic_slug,
+                        measure_slug=measure_version.measure.slug,
+                        version=measure_version.latest_published_minor_version.version) }}" class="eff-factual-mistake__link">the corrected page</a>.
+</div>

--- a/application/templates/_shared/_newer_version_available.html
+++ b/application/templates/_shared/_newer_version_available.html
@@ -1,9 +1,8 @@
 <div class="old-edition-notice">
-  <h2 class="govuk-heading-l">There is a new version of this page</h2>
-  <p class="govuk-body">View the <a class="govuk-link" href="{{ url_for('static_site.measure_version',
+  <p class="govuk-body">There is a new version of this page. View the <a class="govuk-link" href="{{ url_for('static_site.measure_version',
     topic_slug=topic_slug,
     subtopic_slug=subtopic_slug,
     measure_slug=measure_version.measure.slug,
-    version='latest') }}">latest version</a>
+    version='latest') }}">latest version</a>.
   </p>
 </div>

--- a/application/templates/_shared/_newer_version_available.html
+++ b/application/templates/_shared/_newer_version_available.html
@@ -1,0 +1,9 @@
+<div class="old-edition-notice">
+  <h2 class="govuk-heading-l">There is a new version of this page</h2>
+  <p class="govuk-body">View the <a class="govuk-link" href="{{ url_for('static_site.measure_version',
+    topic_slug=topic_slug,
+    subtopic_slug=subtopic_slug,
+    measure_slug=measure_version.measure.slug,
+    version='latest') }}">latest version</a>
+  </p>
+</div>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -109,6 +109,20 @@
         </p>
       {%  endif %}
 
+    </div>
+  </div>
+
+  {% if measure_version.has_known_statistical_errors %}
+    {% include "_shared/_contains_factual_mistake.html" %}
+  {% elif measure_version.has_known_statistical_corrections %}
+    {% include "_shared/_contains_corrections.html" %}
+  {% elif version != 'latest' %}
+    {% include "_shared/_newer_version_available.html" %}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
       <div class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</div>
       <ol class="eff-table-of-contents">
         <li><a class="govuk-link" href="#main-facts-and-figures" data-on="click" data-event-category="Table of contents link clicked" data-event-action="Main facts and figures" data-event-label=""><span class="eff-table-of-contents__number">1. </span><span class="eff-table-of-contents__content">Main facts and figures</span></a></li>
@@ -129,17 +143,6 @@
       </ol>
     </div>
   </div>
-
-  {% if version != 'latest' %}
-    <div class="old-edition-notice">
-      <h2 class="govuk-heading-l">There is a new version of this page</h2>
-      <p class="govuk-body">View the <a class="govuk-link" href="{{ url_for('static_site.measure_version',
-                            topic_slug=topic_slug,
-                            subtopic_slug=subtopic_slug,
-                            measure_slug=measure_version.measure.slug,
-                            version='latest') }}">latest version</a></p>
-    </div>
-  {% endif %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -945,6 +945,21 @@ class TestMeasureVersionModel:
         assert mv_1_3.later_minor_versions == []
         assert mv_2_0.later_minor_versions == []
 
+    def test_latest_published_minor_version(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.create(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.create(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
+
+        assert mv_1_0.latest_published_minor_version == mv_1_2
+        assert mv_1_1.latest_published_minor_version == mv_1_2
+        assert mv_1_2.latest_published_minor_version == mv_1_2
+        assert mv_1_3.latest_published_minor_version == mv_1_2
+        assert mv_2_0.latest_published_minor_version is None
+
     def test_has_known_statistical_errors(self, db_session):
         mv_1_0: MeasureVersion = MeasureVersionFactory.create(
             version="1.0", update_corrects_data_mistake=False, status="APPROVED"

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -922,6 +922,24 @@ class TestMeasureVersionModel:
         assert mv_2_0.previous_minor_versions == []
         assert mv_2_0.later_minor_versions == []
 
+
+    def test_latest_published_minor_version(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
+
+        assert mv_1_0.latest_published_minor_version == mv_1_2
+        assert mv_1_1.latest_published_minor_version == mv_1_2
+        assert mv_1_2.latest_published_minor_version == mv_1_2
+        assert mv_1_3.latest_published_minor_version == mv_1_2
+        assert mv_2_0.latest_published_minor_version is None
+
+
     def test_has_known_statistical_errors(self):
         mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
         mv_1_1: MeasureVersion = MeasureVersionFactory.build(

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -946,27 +946,43 @@ class TestMeasureVersionModel:
         assert mv_2_0.later_minor_versions == []
 
     def test_has_known_statistical_errors(self, db_session):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(
+            version="1.0", update_corrects_data_mistake=False, status="APPROVED"
+        )
         mv_1_1: MeasureVersion = MeasureVersionFactory.create(
-            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_2: MeasureVersion = MeasureVersionFactory.create(
             version="1.2",
             measure=mv_1_0.measure,
             update_corrects_data_mistake=True,
             update_corrects_measure_version=mv_1_1.id,
+            status="APPROVED",
         )
         mv_1_3: MeasureVersion = MeasureVersionFactory.create(
-            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_4: MeasureVersion = MeasureVersionFactory.create(
             version="1.4",
             measure=mv_1_0.measure,
             update_corrects_data_mistake=True,
             update_corrects_measure_version=mv_1_3.id,
+            status="APPROVED",
         )
         mv_1_5: MeasureVersion = MeasureVersionFactory.create(
-            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
+        )
+
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(
+            version="2.0", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
+        )
+
+        mv_2_1: MeasureVersion = MeasureVersionFactory.build(
+            version="2.1",
+            measure=mv_1_0.measure,
+            update_corrects_data_mistake=True,
+            status="DRAFT",
+            update_corrects_measure_version=mv_2_0.id,
         )
 
         db_session.session.commit()
@@ -981,29 +997,43 @@ class TestMeasureVersionModel:
         assert mv_2_1.has_known_statistical_errors is False
 
     def test_has_known_statistical_corrections(self, db_session):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(
+            version="1.0", update_corrects_data_mistake=False, status="APPROVED"
+        )
 
         mv_1_1: MeasureVersion = MeasureVersionFactory.create(
-            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_2: MeasureVersion = MeasureVersionFactory.create(
             version="1.2",
             measure=mv_1_0.measure,
             update_corrects_data_mistake=True,
             update_corrects_measure_version=mv_1_1.id,
+            status="APPROVED",
         )
         mv_1_3: MeasureVersion = MeasureVersionFactory.create(
-            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_4: MeasureVersion = MeasureVersionFactory.create(
             version="1.4",
             measure=mv_1_0.measure,
             update_corrects_data_mistake=True,
             update_corrects_measure_version=mv_1_3.id,
+            status="APPROVED",
         )
         mv_1_5: MeasureVersion = MeasureVersionFactory.create(
-            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(
+            version="2.0", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
+        )
+        mv_2_1: MeasureVersion = MeasureVersionFactory.build(
+            version="2.1", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="DRAFT"
+        )
+        mv_2_2: MeasureVersion = MeasureVersionFactory.build(
+            version="2.2", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="DRAFT"
+        )
+
         db_session.session.commit()
 
         assert mv_1_0.has_known_statistical_corrections is False

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -945,7 +945,6 @@ class TestMeasureVersionModel:
         assert mv_1_3.later_minor_versions == []
         assert mv_2_0.later_minor_versions == []
 
-        
     def test_has_known_statistical_errors(self, db_session):
         mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
         mv_1_1: MeasureVersion = MeasureVersionFactory.create(

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -900,28 +900,65 @@ class TestMeasureVersionModel:
 
         assert measure_version.social_description is None
 
-    def test_later_minor_versions(self):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.0")
+    def test_previous_minor_versions(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
         mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
         mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.2", measure=mv_1_0.measure)
-        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.3", measure=mv_1_0.measure)
-        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="2.0", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
 
         assert mv_1_0.previous_minor_versions == []
-        assert mv_1_0.later_minor_versions == [mv_1_1, mv_1_2, mv_1_3]
-
         assert mv_1_1.previous_minor_versions == [mv_1_0]
-        assert mv_1_1.later_minor_versions == [mv_1_2, mv_1_3]
-
-        assert mv_1_2.previous_minor_versions == [mv_1_0, mv_1_1]
-        assert mv_1_2.later_minor_versions == [mv_1_3]
-
-        assert mv_1_3.previous_minor_versions == [mv_1_0, mv_1_1, mv_1_2]
-        assert mv_1_3.later_minor_versions == []
-
+        assert mv_1_2.previous_minor_versions == [mv_1_1, mv_1_0]
+        assert mv_1_3.previous_minor_versions == [mv_1_2, mv_1_1, mv_1_0]
         assert mv_2_0.previous_minor_versions == []
+
+    def test_previous_published_minor_versions(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
+
+        assert mv_1_0.previous_published_minor_versions == []
+        assert mv_1_1.previous_published_minor_versions == [mv_1_0]
+        assert mv_1_2.previous_published_minor_versions == [mv_1_1, mv_1_0]
+        assert mv_1_3.previous_published_minor_versions == [mv_1_1, mv_1_0]
+        assert mv_2_0.previous_published_minor_versions == []
+
+    def test_later_minor_versions(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
+
+        assert mv_1_0.later_minor_versions == [mv_1_3, mv_1_2, mv_1_1]
+        assert mv_1_1.later_minor_versions == [mv_1_3, mv_1_2]
+        assert mv_1_2.later_minor_versions == [mv_1_3]
+        assert mv_1_3.later_minor_versions == []
         assert mv_2_0.later_minor_versions == []
 
+    def test_later_published_minor_versions(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
+        mv_1_1: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.1", measure=mv_1_0.measure)
+        mv_1_2: MeasureVersion = MeasureVersionFactory.build(status="APPROVED", version="1.2", measure=mv_1_0.measure)
+        mv_1_3: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="1.3", measure=mv_1_0.measure)
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(status="DRAFT", version="2.0", measure=mv_1_0.measure)
+
+        db_session.session.commit()
+
+        assert mv_1_0.later_published_minor_versions == [mv_1_2, mv_1_1]
+        assert mv_1_1.later_published_minor_versions == [mv_1_2]
+        assert mv_1_2.later_published_minor_versions == []
+        assert mv_1_3.later_published_minor_versions == []
+        assert mv_2_0.later_published_minor_versions == []
 
     def test_latest_published_minor_version(self, db_session):
         mv_1_0: MeasureVersion = MeasureVersionFactory.create(status="APPROVED", version="1.0")
@@ -939,24 +976,31 @@ class TestMeasureVersionModel:
         assert mv_1_3.latest_published_minor_version == mv_1_2
         assert mv_2_0.latest_published_minor_version is None
 
-
-    def test_has_known_statistical_errors(self):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
+    def test_has_known_statistical_errors(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
         mv_1_1: MeasureVersion = MeasureVersionFactory.build(
-            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_2: MeasureVersion = MeasureVersionFactory.build(
-            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="APPROVED"
         )
         mv_1_3: MeasureVersion = MeasureVersionFactory.build(
-            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_4: MeasureVersion = MeasureVersionFactory.build(
-            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="APPROVED"
         )
         mv_1_5: MeasureVersion = MeasureVersionFactory.build(
-            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(
+            version="2.0", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
+        )
+        mv_2_1: MeasureVersion = MeasureVersionFactory.build(
+            version="2.1", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="DRAFT"
+        )
+
+        db_session.session.commit()
 
         assert mv_1_0.has_known_statistical_errors is True
         assert mv_1_1.has_known_statistical_errors is True
@@ -964,24 +1008,37 @@ class TestMeasureVersionModel:
         assert mv_1_3.has_known_statistical_errors is True
         assert mv_1_4.has_known_statistical_errors is False
         assert mv_1_5.has_known_statistical_errors is False
+        assert mv_2_0.has_known_statistical_errors is False
+        assert mv_2_1.has_known_statistical_errors is False
 
-    def test_has_known_statistical_corrections(self):
-        mv_1_0: MeasureVersion = MeasureVersionFactory.build(version="1.0", update_corrects_data_mistake=False)
+    def test_has_known_statistical_corrections(self, db_session):
+        mv_1_0: MeasureVersion = MeasureVersionFactory.create(version="1.0", update_corrects_data_mistake=False)
         mv_1_1: MeasureVersion = MeasureVersionFactory.build(
-            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.1", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_2: MeasureVersion = MeasureVersionFactory.build(
-            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True
+            version="1.2", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="APPROVED"
         )
         mv_1_3: MeasureVersion = MeasureVersionFactory.build(
-            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.3", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
         mv_1_4: MeasureVersion = MeasureVersionFactory.build(
-            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True
+            version="1.4", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="APPROVED"
         )
         mv_1_5: MeasureVersion = MeasureVersionFactory.build(
-            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False
+            version="1.5", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
         )
+        mv_2_0: MeasureVersion = MeasureVersionFactory.build(
+            version="2.0", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="APPROVED"
+        )
+        mv_2_1: MeasureVersion = MeasureVersionFactory.build(
+            version="2.1", measure=mv_1_0.measure, update_corrects_data_mistake=True, status="DRAFT"
+        )
+        mv_2_2: MeasureVersion = MeasureVersionFactory.build(
+            version="2.2", measure=mv_1_0.measure, update_corrects_data_mistake=False, status="DRAFT"
+        )
+
+        db_session.session.commit()
 
         assert mv_1_0.has_known_statistical_corrections is False
         assert mv_1_1.has_known_statistical_corrections is False
@@ -989,6 +1046,9 @@ class TestMeasureVersionModel:
         assert mv_1_3.has_known_statistical_corrections is True
         assert mv_1_4.has_known_statistical_corrections is True
         assert mv_1_5.has_known_statistical_corrections is True
+        assert mv_2_0.has_known_statistical_corrections is False
+        assert mv_2_1.has_known_statistical_corrections is True
+        assert mv_2_2.has_known_statistical_corrections is False
 
 
 class TestChartModel:

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -872,10 +872,13 @@ class TestMeasurePage:
 
         measure_1_0 = MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.0")
 
-        MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.1",
+        MeasureVersionFactory.create(
+            measure=measure,
+            status="APPROVED",
+            version="1.1",
             update_corrects_data_mistake=True,
-            update_corrects_measure_version=measure_1_0.id)
-
+            update_corrects_measure_version=measure_1_0.id,
+        )
 
         measure_1_0_url = url_for(
             "static_site.measure_version",

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -892,7 +892,7 @@ class TestMeasurePage:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         # THEN it should contain a banner explaining that the page contains an error
-        assert page.find('h2', string="This page contains a factual mistake")
+        assert page.find("h2", string="This page contains a factual mistake")
         assert "Details can be found on the corrected page." in page.get_text()
 
     def test_version_with_factual_corrections(self, test_app_client, logged_in_rdu_user):

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -865,6 +865,69 @@ class TestMeasurePage:
         measure_1_0_links = page.find_all("a", attrs={"href": measure_1_0_url})
         assert len(measure_1_0_links) == 0
 
+    def test_version_with_factual_error(self, test_app_client, logged_in_rdu_user):
+
+        # GIVEN a 1.0 measure which contains factual errors
+        measure = MeasureFactory()
+
+        measure_1_0 = MeasureVersionFactory.create(
+            measure=measure, status="APPROVED", version="1.0"
+        )
+
+        MeasureVersionFactory.create(
+            measure=measure, status="APPROVED", version="1.1",update_corrects_data_mistake=True
+        )
+
+        measure_1_0_url = url_for(
+            "static_site.measure_version",
+            topic_slug=measure_1_0.measure.subtopic.topic.slug,
+            subtopic_slug=measure_1_0.measure.subtopic.slug,
+            measure_slug=measure_1_0.measure.slug,
+            version=measure_1_0.version,
+        )
+
+        # WHEN we get the 1.0 measure page
+        resp = test_app_client.get(measure_1_0_url)
+
+        assert resp.status_code == 200
+
+        page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+
+        # THEN it should contain a banner explaining that the page contains an error
+        assert 'This page contains a factual mistake. Details can be found on the corrected page.' in page.get_text()
+
+
+    def test_version_with_factual_corrections(self, test_app_client, logged_in_rdu_user):
+
+        # GIVEN a 1.0 measure which contains factual errors
+        measure = MeasureFactory()
+
+        MeasureVersionFactory.create(
+            measure=measure, status="APPROVED", version="1.0"
+        )
+
+        measure_1_1 = MeasureVersionFactory.create(
+            measure=measure, status="APPROVED", version="1.1",update_corrects_data_mistake=True
+        )
+
+        measure_1_1_url = url_for(
+            "static_site.measure_version",
+            topic_slug=measure_1_1.measure.subtopic.topic.slug,
+            subtopic_slug=measure_1_1.measure.subtopic.slug,
+            measure_slug=measure_1_1.measure.slug,
+            version=measure_1_1.version,
+        )
+
+        # WHEN we get the 1.1 measure page
+        resp = test_app_client.get(measure_1_1_url)
+
+        assert resp.status_code == 200
+
+        page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+
+        # THEN it should contain a banner explaining that the page contains corrections
+        assert 'This page corrects mistakes in a previous version. See details.' in page.get_text()
+
 
 class TestCorrections:
     def setup(self):

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -931,7 +931,7 @@ class TestMeasurePage:
         see_details_link = page.find("a", string="See details")
 
         assert see_details_link
-        assert page.select(see_details_link.get('href')) # ID hash
+        assert page.select(see_details_link.get("href"))  # ID hash
 
 
 class TestCorrections:

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -892,7 +892,8 @@ class TestMeasurePage:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         # THEN it should contain a banner explaining that the page contains an error
-        assert "This page contains a factual mistake. Details can be found on the corrected page." in page.get_text()
+        assert page.find('h2', string="This page contains a factual mistake")
+        assert "Details can be found on the corrected page." in page.get_text()
 
     def test_version_with_factual_corrections(self, test_app_client, logged_in_rdu_user):
 

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -928,6 +928,11 @@ class TestMeasurePage:
         # THEN it should contain a banner explaining that the page contains corrections
         assert "This page corrects mistakes in a previous version. See details." in page.get_text()
 
+        see_details_link = page.find("a", string="See details")
+
+        assert see_details_link
+        assert page.select(see_details_link.get('href')) # ID hash
+
 
 class TestCorrections:
     def setup(self):

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -872,9 +872,10 @@ class TestMeasurePage:
 
         measure_1_0 = MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.0")
 
-        MeasureVersionFactory.create(
-            measure=measure, status="APPROVED", version="1.1", update_corrects_data_mistake=True
-        )
+        MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.1",
+            update_corrects_data_mistake=True,
+            update_corrects_measure_version=measure_1_0.id)
+
 
         measure_1_0_url = url_for(
             "static_site.measure_version",

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -870,12 +870,10 @@ class TestMeasurePage:
         # GIVEN a 1.0 measure which contains factual errors
         measure = MeasureFactory()
 
-        measure_1_0 = MeasureVersionFactory.create(
-            measure=measure, status="APPROVED", version="1.0"
-        )
+        measure_1_0 = MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.0")
 
         MeasureVersionFactory.create(
-            measure=measure, status="APPROVED", version="1.1",update_corrects_data_mistake=True
+            measure=measure, status="APPROVED", version="1.1", update_corrects_data_mistake=True
         )
 
         measure_1_0_url = url_for(
@@ -894,20 +892,17 @@ class TestMeasurePage:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         # THEN it should contain a banner explaining that the page contains an error
-        assert 'This page contains a factual mistake. Details can be found on the corrected page.' in page.get_text()
-
+        assert "This page contains a factual mistake. Details can be found on the corrected page." in page.get_text()
 
     def test_version_with_factual_corrections(self, test_app_client, logged_in_rdu_user):
 
         # GIVEN a 1.0 measure which contains factual errors
         measure = MeasureFactory()
 
-        MeasureVersionFactory.create(
-            measure=measure, status="APPROVED", version="1.0"
-        )
+        MeasureVersionFactory.create(measure=measure, status="APPROVED", version="1.0")
 
         measure_1_1 = MeasureVersionFactory.create(
-            measure=measure, status="APPROVED", version="1.1",update_corrects_data_mistake=True
+            measure=measure, status="APPROVED", version="1.1", update_corrects_data_mistake=True
         )
 
         measure_1_1_url = url_for(
@@ -926,7 +921,7 @@ class TestMeasurePage:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         # THEN it should contain a banner explaining that the page contains corrections
-        assert 'This page corrects mistakes in a previous version. See details.' in page.get_text()
+        assert "This page corrects mistakes in a previous version. See details." in page.get_text()
 
 
 class TestCorrections:


### PR DESCRIPTION
This adds banners to pages where there is a 'correction' to some factual data.

When this happens, previous versions of the page (which contained the error) get this banner:

<img width="989" alt="mistake-banner-v2" src="https://user-images.githubusercontent.com/30665/58485492-11f8c080-815c-11e9-882d-1be90c2d41f2.png">

And versions which contain the correction get this banner:

<img width="915" alt="correciton-banner-v2" src="https://user-images.githubusercontent.com/30665/58485554-318fe900-815c-11e9-8d85-c567389c828d.png">

If neither of this banners appear, only then do we display this banner, which links to the latest version (if you're not already looking at it). This has moved up the page slightly to before the table of contents:

<img width="993" alt="link-to-latest-version" src="https://user-images.githubusercontent.com/30665/58485684-656b0e80-815c-11e9-8549-fa2b9dc159a1.png">

See https://trello.com/c/4GaHZRgR/1574-3-design-and-implement-banners-for-the-top-of-measure-versions-which-contain-factual-corrections-and-or-factual-errors-5