### PR TITLE
Link to previous versions

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -567,7 +567,11 @@
               <ol class="govuk-list">
                 <li>
                   {% if measure_version.published_at %}
-                    <time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time>
+                    <a class="govuk-link" href="{{ url_for('static_site.measure_version',
+                            topic_slug=topic_slug,
+                            subtopic_slug=subtopic_slug,
+                            measure_slug=measure_version.measure.slug,
+                            version=measure_version.version) }}"><time datetime="{{ measure_version.published_at }}" class="timestamp">{{ measure_version.published_at|format_friendly_date }}</time></a>
                   {% else %}
                     <span class="timestamp">TBC</span>
                   {% endif %}
@@ -577,7 +581,11 @@
                 </li>
                 {% for old_page_version in measure_version.previous_minor_versions %}
                   <li>
-                    <time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time>
+                    <a class="govuk-link" href="{{ url_for('static_site.measure_version',
+                            topic_slug=topic_slug,
+                            subtopic_slug=subtopic_slug,
+                            measure_slug=measure_version.measure.slug,
+                            version=old_page_version.version) }}"><time datetime="{{ old_page_version.published_at }}" class="timestamp">{{ old_page_version.published_at|format_friendly_date }}</time></a>
 
                     {% if (loop.index == loop|length) %}
                       {% set edit_summary = old_page_version.external_edit_summary or "First published" %}

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -239,14 +239,16 @@ def test_version_history(test_app_client, logged_in_rdu_user):
 
     assert details_tag
 
-    details_text = details_tag.get_text()
+    details_text = details_tag.get_text(separator="\n", strip=True).split("\n")
 
-    assert '10 January 2018'  in details_text
-    assert 'First published'  in details_text
-    assert '20 February 2018' in details_text
-    assert 'Fixed a spelling mistake.' in details_text
-    assert '13 December 2018' in details_text
-    assert 'Updated headings for clarity.' in details_text
+    assert details_text == ['full page history',
+        '13 December 2018',
+        'Updated headings for clarity.',
+        '20 February 2018',
+        'Fixed a spelling mistake.',
+        '10 January 2018',
+        'First published']
+
 
     first_published_link = find_link_with_text(details_tag, '10 January 2018')
 

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -17,7 +17,7 @@ from tests.models import (
     MeasureVersionWithDimensionFactory,
     UserFactory,
 )
-from tests.utils import assert_strings_match_ignoring_whitespace, details_tag_with_summary,find_link_with_text
+from tests.utils import assert_strings_match_ignoring_whitespace, details_tag_with_summary, find_link_with_text
 
 
 def test_homepage_includes_mailing_list_sign_up(test_app_client, logged_in_rdu_user, app):
@@ -214,19 +214,28 @@ def test_version_history(test_app_client, logged_in_rdu_user):
 
     measure = MeasureFactory(slug="my-measure", subtopics=[subtopic])
 
-    measure_1_0 = MeasureVersionFactory(
-        measure=measure, status="APPROVED", version="1.0", published_at=datetime.datetime(2018, 1, 10),
-        external_edit_summary="First published"
+    MeasureVersionFactory(
+        measure=measure,
+        status="APPROVED",
+        version="1.0",
+        published_at=datetime.datetime(2018, 1, 10),
+        external_edit_summary="First published",
     )
 
-    measure_1_1 = MeasureVersionFactory(
-        measure=measure, status="APPROVED", version="1.1", published_at=datetime.datetime(2018, 2, 20),
-        external_edit_summary="Fixed a spelling mistake."
+    MeasureVersionFactory(
+        measure=measure,
+        status="APPROVED",
+        version="1.1",
+        published_at=datetime.datetime(2018, 2, 20),
+        external_edit_summary="Fixed a spelling mistake.",
     )
 
-    measure_1_2 = MeasureVersionFactory(
-        measure=measure, status="APPROVED", version="1.2", published_at=datetime.datetime(2018, 12, 13),
-        external_edit_summary="Updated headings for clarity."
+    MeasureVersionFactory(
+        measure=measure,
+        status="APPROVED",
+        version="1.2",
+        published_at=datetime.datetime(2018, 12, 13),
+        external_edit_summary="Updated headings for clarity.",
     )
 
     resp = test_app_client.get("/my-topic/my-subtopic/my-measure/latest")
@@ -241,29 +250,30 @@ def test_version_history(test_app_client, logged_in_rdu_user):
 
     details_text = details_tag.get_text(separator="\n", strip=True).split("\n")
 
-    assert details_text == ['full page history',
-        '13 December 2018',
-        'Updated headings for clarity.',
-        '20 February 2018',
-        'Fixed a spelling mistake.',
-        '10 January 2018',
-        'First published']
+    assert details_text == [
+        "full page history",
+        "13 December 2018",
+        "Updated headings for clarity.",
+        "20 February 2018",
+        "Fixed a spelling mistake.",
+        "10 January 2018",
+        "First published",
+    ]
 
-
-    first_published_link = find_link_with_text(details_tag, '10 January 2018')
+    first_published_link = find_link_with_text(details_tag, "10 January 2018")
 
     assert first_published_link
-    assert first_published_link.get('href') == "/my-topic/my-subtopic/my-measure/1.0"
+    assert first_published_link.get("href") == "/my-topic/my-subtopic/my-measure/1.0"
 
-    spelling_mistake_link = find_link_with_text(details_tag, '20 February 2018')
+    spelling_mistake_link = find_link_with_text(details_tag, "20 February 2018")
 
     assert spelling_mistake_link
-    assert spelling_mistake_link.get('href') == "/my-topic/my-subtopic/my-measure/1.1"
+    assert spelling_mistake_link.get("href") == "/my-topic/my-subtopic/my-measure/1.1"
 
-    updated_headings_link = find_link_with_text(details_tag, '13 December 2018')
+    updated_headings_link = find_link_with_text(details_tag, "13 December 2018")
 
     assert updated_headings_link
-    assert updated_headings_link.get('href') == "/my-topic/my-subtopic/my-measure/1.2"
+    assert updated_headings_link.get("href") == "/my-topic/my-subtopic/my-measure/1.2"
 
 
 def test_view_export_page(test_app_client, logged_in_rdu_user):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,9 +57,10 @@ def multidict_from_measure_version_and_kwargs(measure_version: MeasureVersion, *
         }
     )
 
+
 def details_tag_with_summary(dom_node, summary_text):
 
-    summary_tags = dom_node.find_all('summary')
+    summary_tags = dom_node.find_all("summary")
 
     summary_tags_with_matching_text = list(filter(lambda x: x.get_text().strip() == summary_text, summary_tags))
 
@@ -68,6 +69,7 @@ def details_tag_with_summary(dom_node, summary_text):
     else:
         return None
 
+
 def find_link_with_text(dom_node, link_text):
 
-    return dom_node.find('a', string=link_text)
+    return dom_node.find("a", string=link_text)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,3 +56,18 @@ def multidict_from_measure_version_and_kwargs(measure_version: MeasureVersion, *
             **kwargs,
         }
     )
+
+def details_tag_with_summary(dom_node, summary_text):
+
+    summary_tags = dom_node.find_all('summary')
+
+    summary_tags_with_matching_text = list(filter(lambda x: x.get_text().strip() == summary_text, summary_tags))
+
+    if len(summary_tags_with_matching_text) > 0:
+        return summary_tags_with_matching_text[0].parent
+    else:
+        return None
+
+def find_link_with_text(dom_node, link_text):
+
+    return dom_node.find('a', string=link_text)


### PR DESCRIPTION
This adds links to the previous versions of a page from the full version history in the footer:

<img width="645" alt="Screenshot 2019-05-28 at 16 21 20" src="https://user-images.githubusercontent.com/30665/58490303-d1ea0b80-8164-11e9-9b56-b8799baed8b0.png">

See https://trello.com/c/wcLiujoC/1580-4-update-the-measure-version-page-to-include-permalinks-to-all-measure-versions-major-and-minor-2