### PR TITLE
Set external edit summary for all 1.0 measures

### DIFF
--- a/scripts/data_migrations/2019-06-04_fix-missing-external-edit-summary.sql
+++ b/scripts/data_migrations/2019-06-04_fix-missing-external-edit-summary.sql
@@ -1,0 +1,4 @@
+UPDATE measure_version
+SET external_edit_summary = 'First published'
+WHERE version = '1.0'
+AND (TRIM(external_edit_summary) = '' OR external_edit_summary IS NULL);


### PR DESCRIPTION
When we last ran this migration, we had an erroneous 'published IS TRUE'
condition on this update. We had one legitimate measure that therefore
didn't get the external edit summary. Come time to publish this (2 years
later!), it now can't be submitted for review due to this field being
required.