### PR TITLE
 Fix line panel chart ordering

### DIFF
--- a/application/src/js/charts/rd-data-tools.js
+++ b/application/src/js/charts/rd-data-tools.js
@@ -129,13 +129,6 @@ function decimalPlaces(valueStr) {
     }
 }
 
-function uniqueDataInColumn(data, index) {
-    var values = _.map(data.slice(start = 0), function (item) {
-        return item[index];
-    });
-    return _.uniq(values).sort();
-}
-
 function uniqueDataInColumnOrdered(data, index, order_column) {
     // Sort by the specified column
     var sorted = _.sortBy(data, function (item) {
@@ -249,7 +242,6 @@ if (typeof exports !== 'undefined') {
     exports.seriesCouldBeYear = seriesCouldBeYear;
     exports.formatNumberWithDecimalPlaces = formatNumberWithDecimalPlaces;
 
-    exports.uniqueDataInColumn = uniqueDataInColumn;
     exports.uniqueDataInColumnOrdered = uniqueDataInColumnOrdered;
     exports.uniqueDataInColumnMaintainOrder = uniqueDataInColumnMaintainOrder;
 

--- a/application/src/js/cms/rd-chart-objects.js
+++ b/application/src/js/cms/rd-chart-objects.js
@@ -336,7 +336,7 @@ function panelLinechartObject(data, x_axis_column, panel_column, chart_title, x_
     } else {
         panelNames = uniqueDataInColumnOrdered(dataRows, indices['category'], indices['custom'])
     }
-    var xAxisNames = uniqueDataInColumn(dataRows, indices['secondary']);
+    var xAxisNames = uniqueDataInColumnMaintainOrder(dataRows, indices['secondary']);
 
     var panelCharts = _.map(panelNames, function(panelName) {
             var values = _.map(xAxisNames, function(category) {

--- a/test/test-data-tools.js
+++ b/test/test-data-tools.js
@@ -165,42 +165,6 @@ describe('rd-data-tools', function () {
         });
     });
 
-    describe('#uniqueDataInColumn', function () {
-
-        it('should filter a column to unique values', function () {
-            var rows = [
-                ["a", 1, 2, 3],
-                ["b", 1, 2, 3],
-                ["c", 1, 2, 3],
-                ["a", 1, 2, 3]];
-            var values = dataTools.uniqueDataInColumn(rows, 0);
-            assert.equal(values.length, 3);
-            expect(values).to.have.same.members(["a", "b", "c"]);
-        });
-
-        it('should be able to find unique data in any column', function () {
-            var rows = [
-                ["a", "apple", 2, 3],
-                ["b", "banana", 2, 3],
-                ["c", "pear", 2, 3],
-                ["a", "apple", 2, 3]];
-            var values = dataTools.uniqueDataInColumn(rows, 1);
-            assert.equal(values.length, 3);
-            expect(values).to.have.same.members(["apple", "banana", "pear"]);
-        });
-
-        it('should sort results alphabetically', function () {
-            var rows = [
-                ["a", "pear", 2, 3],
-                ["b", "apple", 2, 3],
-                ["c", "banana", 2, 3],
-                ["a", "pear", 2, 3]];
-            var values = dataTools.uniqueDataInColumn(rows, 1);
-            assert.equal(values.length, 3);
-            expect(values).to.deep.equal(["apple", "banana", "pear"]);
-        });
-    });
-
     describe('#uniqueDataInColumnOrdered', function () {
 
         it('should filter a column to unique values', function () {


### PR DESCRIPTION
The labels for points along the x-axis were being sorted
lexicographically rather than maintaining the input order, meaning that
it is impossible for data analysts to define the order these points
should occur. This caused a bug for 6-monthly time series data (Jan/Jun
each year), as all the Jan datapoints were grouped together, following
by all the Jun datapoints. In lieu of being able to explicitly order
them, we should at least allow an implicit entry order to be preserved.

 ## Ticket
https://trello.com/c/h085EjzY