### PR TITLE
Add missing close tags

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -651,6 +651,9 @@
       </div>
 
       {% include "static_site/_share.html" %}
+
+    </div>
+  </div>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This fixes a bug with rendering which affects the rendering of the footer in IE11 and below.

Verified using Browser Stack and an HTML validator.

See https://trello.com/c/2LatREfb/1624-investigate-broken-styling-for-department-user-1