### PR TITLE
Edit and update data sources

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1157,6 +1157,9 @@ def create_data_source(topic_slug, subtopic_slug, measure_slug, version):
         measure_version.data_sources.append(data_source)
         db.session.commit()
 
+        message = 'Saved data source "{}"'.format(data_source.title)
+        flash(message, "info")
+
         return redirect(
             url_for(
                 "cms.edit_measure_version",
@@ -1243,6 +1246,9 @@ def update_data_source(topic_slug, subtopic_slug, measure_slug, version, data_so
     if data_source_form.validate_on_submit() and data_source.title:
 
         db.session.commit()
+
+        message = 'Saved data source "{}"'.format(data_source.title)
+        flash(message, "info")
 
         return redirect(
             url_for(

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1142,6 +1142,7 @@ def new_data_source(topic_slug, subtopic_slug, measure_slug, version):
     "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources", methods=["POST"]
 )
 @login_required
+@user_has_access
 def create_data_source(topic_slug, subtopic_slug, measure_slug, version):
 
     topic, subtopic, measure, measure_version = page_service.get_measure_version_hierarchy(
@@ -1193,6 +1194,7 @@ def create_data_source(topic_slug, subtopic_slug, measure_slug, version):
     "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/<data_source_id>", methods=["GET"]
 )
 @login_required
+@user_has_access
 def edit_data_source(topic_slug, subtopic_slug, measure_slug, version, data_source_id):
 
     topic, subtopic, measure, measure_version = page_service.get_measure_version_hierarchy(
@@ -1226,6 +1228,7 @@ def edit_data_source(topic_slug, subtopic_slug, measure_slug, version, data_sour
     "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/<data_source_id>", methods=["POST"]
 )
 @login_required
+@user_has_access
 def update_data_source(topic_slug, subtopic_slug, measure_slug, version, data_source_id):
 
     topic, subtopic, measure, measure_version = page_service.get_measure_version_hierarchy(

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1114,9 +1114,7 @@ def view_measure_version_by_measure_version_id(measure_version_id):
     )
 
 
-@cms_blueprint.route(  # noqa: C901 (complexity)
-    "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/new", methods=["GET"]
-)
+@cms_blueprint.route("/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/new", methods=["GET"])
 @login_required
 @user_has_access
 def new_data_source(topic_slug, subtopic_slug, measure_slug, version):
@@ -1138,9 +1136,7 @@ def new_data_source(topic_slug, subtopic_slug, measure_slug, version):
     )
 
 
-@cms_blueprint.route(  # noqa: C901 (complexity)
-    "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources", methods=["POST"]
-)
+@cms_blueprint.route("/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources", methods=["POST"])
 @login_required
 @user_has_access
 def create_data_source(topic_slug, subtopic_slug, measure_slug, version):
@@ -1190,7 +1186,7 @@ def create_data_source(topic_slug, subtopic_slug, measure_slug, version):
         )
 
 
-@cms_blueprint.route(  # noqa: C901 (complexity)
+@cms_blueprint.route(
     "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/<data_source_id>", methods=["GET"]
 )
 @login_required
@@ -1224,7 +1220,7 @@ def edit_data_source(topic_slug, subtopic_slug, measure_slug, version, data_sour
     )
 
 
-@cms_blueprint.route(  # noqa: C901 (complexity)
+@cms_blueprint.route(
     "/<topic_slug>/<subtopic_slug>/<measure_slug>/<version>/edit/data-sources/<data_source_id>", methods=["POST"]
 )
 @login_required

--- a/application/templates/cms/_initialize_publisher_autocomplete.html
+++ b/application/templates/cms/_initialize_publisher_autocomplete.html
@@ -1,0 +1,8 @@
+<script>
+  govukGovernmentOrganisationsAutocomplete({
+    selectElement: document.querySelector('select.publisher'),
+    showAllValues: false,
+    minLength: 2,
+    defaultValue: ''
+  });
+</script>

--- a/application/templates/cms/edit_data_source.html
+++ b/application/templates/cms/edit_data_source.html
@@ -30,3 +30,15 @@
   </div>
 
 {% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}
+  <script>
+    govukGovernmentOrganisationsAutocomplete({
+        selectElement: document.querySelector('select.publisher'),
+        showAllValues: false,
+        minLength: 2,
+        defaultValue: ''
+    });
+  </script>
+{% endblock %}

--- a/application/templates/cms/edit_data_source.html
+++ b/application/templates/cms/edit_data_source.html
@@ -33,12 +33,5 @@
 
 {% block bodyEnd %}
   {{ super() }}
-  <script>
-    govukGovernmentOrganisationsAutocomplete({
-        selectElement: document.querySelector('select.publisher'),
-        showAllValues: false,
-        minLength: 2,
-        defaultValue: ''
-    });
-  </script>
+  {% include "cms/_initialize_publisher_autocomplete.html" %}
 {% endblock %}

--- a/application/templates/cms/edit_data_source.html
+++ b/application/templates/cms/edit_data_source.html
@@ -1,8 +1,15 @@
 {% extends "base.html" %}
-
+{% from "_shared/_breadcrumb.html" import breadcrumb %}
 {% from "cms/_data_source_form.html" import render_data_source_form %}
 
 {% block pageTitle %}Edit data source{% endblock %}
+
+{% set breadcrumbs =
+  [
+    {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
+    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title}
+  ]
+%}
 
 {% block content %}
 

--- a/application/templates/cms/edit_data_source.html
+++ b/application/templates/cms/edit_data_source.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% from "cms/_data_source_form.html" import render_data_source_form %}
+
+{% block pageTitle %}Edit data source{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Edit data source</h1>
+
+      <form method="POST" action="{{ url_for('cms.update_data_source', data_source_id = data_source.id)}}">
+
+        {{ render_data_source_form(data_source_form=data_source_form, organisations_by_type=organisations_by_type, form_disabled=False, diffs=[]) }}
+
+        <button class="govuk-button">Save</button>
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/application/templates/cms/edit_data_source.html
+++ b/application/templates/cms/edit_data_source.html
@@ -10,7 +10,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Edit data source</h1>
 
-      <form method="POST" action="{{ url_for('cms.update_data_source', data_source_id = data_source.id)}}">
+      <form method="POST" action="{{ url_for('cms.update_data_source', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version,
+      data_source_id=data_source.id )}}">
 
         {{ render_data_source_form(data_source_form=data_source_form, organisations_by_type=organisations_by_type, form_disabled=False, diffs=[]) }}
 

--- a/application/templates/cms/new_data_source.html
+++ b/application/templates/cms/new_data_source.html
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Add data source</h1>
 
-      <form method="POST" action="{{ url_for('cms.create_data_source' )}}">
+      <form method="POST" action="{{ url_for('cms.create_data_source', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version )}}">
 
         {{ render_data_source_form(data_source_form=data_source_form, organisations_by_type=organisations_by_type, form_disabled=False, diffs=[]) }}
 

--- a/application/templates/cms/new_data_source.html
+++ b/application/templates/cms/new_data_source.html
@@ -32,12 +32,5 @@
 
 {% block bodyEnd %}
   {{ super() }}
-  <script>
-    govukGovernmentOrganisationsAutocomplete({
-        selectElement: document.querySelector('select.publisher'),
-        showAllValues: false,
-        minLength: 2,
-        defaultValue: ''
-    });
-  </script>
+  {% include "cms/_initialize_publisher_autocomplete.html" %}
 {% endblock %}

--- a/application/templates/cms/new_data_source.html
+++ b/application/templates/cms/new_data_source.html
@@ -1,8 +1,15 @@
 {% extends "base.html" %}
-
+{% from "_shared/_breadcrumb.html" import breadcrumb %}
 {% from "cms/_data_source_form.html" import render_data_source_form %}
 
 {% block pageTitle %}Add data source{% endblock %}
+
+{% set breadcrumbs =
+  [
+    {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
+    {"url": url_for('cms.edit_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure.slug, version=measure_version.version), "text": measure_version.title}
+  ]
+%}
 
 {% block content %}
 

--- a/application/templates/cms/new_data_source.html
+++ b/application/templates/cms/new_data_source.html
@@ -29,3 +29,15 @@
   </div>
 
 {% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}
+  <script>
+    govukGovernmentOrganisationsAutocomplete({
+        selectElement: document.querySelector('select.publisher'),
+        showAllValues: false,
+        minLength: 2,
+        defaultValue: ''
+    });
+  </script>
+{% endblock %}

--- a/application/templates/cms/new_data_source.html
+++ b/application/templates/cms/new_data_source.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% from "cms/_data_source_form.html" import render_data_source_form %}
+
+{% block pageTitle %}Add data source{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Add data source</h1>
+
+      <form method="POST" action="{{ url_for('cms.create_data_source' )}}">
+
+        {{ render_data_source_form(data_source_form=data_source_form, organisations_by_type=organisations_by_type, form_disabled=False, diffs=[]) }}
+
+        <button class="govuk-button">Save</button>
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/application/templates/error/400.html
+++ b/application/templates/error/400.html
@@ -12,8 +12,8 @@
         </div>
         {% if message %}
             <div class="govuk-grid-row">
-                <div class="column-two-thirds">
-                    <p>{{ message }}</p>
+                <div class="govuk-grid-column-two-thirds">
+                    <p class="govuk-body">{{ message }}</p>
                 </div>
             </div>
         {% endif %}

--- a/tests/application/cms/views/test_add_data_source.py
+++ b/tests/application/cms/views/test_add_data_source.py
@@ -1,46 +1,100 @@
 from bs4 import BeautifulSoup
 
-from tests.models import DataSourceFactory
+import re
+
+from application.cms.models import DataSource, MeasureVersion
+
+from tests.models import DataSourceFactory, MeasureVersionFactory
 
 from tests.utils import find_input_for_label_with_text
 
 
 class TestAddDataSourceView:
-    def __get_page(self, test_app_client):
+    def __get_page(self, measure_version_id, test_app_client):
 
-        response = test_app_client.get("/cms/data-sources/new")
+        response = test_app_client.get(f"/cms/data-sources/new?measure_version_id={measure_version_id}")
 
         return (response, BeautifulSoup(response.data.decode("utf-8"), "html.parser"))
 
-    def test_returns_200(self, test_app_client, logged_in_rdu_user):
+    def test_returns_200_if_measure_version_set(self, test_app_client, logged_in_rdu_user):
 
-        response, _ = self.__get_page(test_app_client)
+        measure_version = MeasureVersionFactory.create()
+
+        response, _ = self.__get_page(measure_version.id, test_app_client)
         assert response.status_code == 200
 
-    def test_page_title(self, test_app_client, logged_in_rdu_user):
+    def test_page_title_if_measure_version_set(self, test_app_client, logged_in_rdu_user):
 
-        response, page = self.__get_page(test_app_client)
+        measure_version = MeasureVersionFactory.create()
+
+        response, page = self.__get_page(measure_version.id, test_app_client)
         assert "Add data source" == page.find("h1").text
         assert "Add data source" == page.find("title").text
 
+    def test_returns_400_if_measure_version_no_set(self, test_app_client, logged_in_rdu_user):
+
+        response = test_app_client.get("/cms/data-sources/new")
+        assert response.status_code == 400
+
+    def test_returns_400_if_measure_version_is_invalid(self, test_app_client, logged_in_rdu_user):
+
+        response = test_app_client.get("/cms/data-sources/new?measure_version_id=999999999")
+        assert response.status_code == 400
+
 
 class TestCreateDataSource:
-    def test_post_with_a_title(self, test_app_client, logged_in_rdu_user):
+    def test_post_with_a_title(self, test_app_client, logged_in_rdu_user, db_session):
 
-        response = test_app_client.post("/cms/data-sources", data={"title": "Test"})
+        measure_version = MeasureVersionFactory.create(data_sources=[])
+
+        response = test_app_client.post(
+            "/cms/data-sources", data={"measure_version_id": measure_version.id, "title": "Test"}
+        )
 
         assert response.status_code == 302
 
-        # TODO: this should probably check that there is an ID (any number) at the end?
-        assert "/cms/data-sources/" in response.headers["Location"]
+        redirected_to_location = response.headers["Location"]
+
+        match = re.search(r"/cms/data-sources/(\d+)$", redirected_to_location)
+
+        assert match, f"Expected {redirected_to_location} to match /cms/data-sources/(\\d+)"
+
+        data_source_id = match.group(1)
+
+        data_source = DataSource.query.get(data_source_id)
+
+        assert data_source, f"Expected to be able to find a data source with id {data_source_id}"
+        assert data_source.title == "Test"
+
+        measure_version = MeasureVersion.query.get(measure_version.id)
+
+        assert measure_version.data_sources == [
+            data_source
+        ], "Expected data source to have been associated with the measure version"
 
     def test_post_with_no_title(self, test_app_client, logged_in_rdu_user):
 
-        response = test_app_client.post("/cms/data-sources", data={"title": ""})
+        measure_version = MeasureVersionFactory.create()
+
+        response = test_app_client.post(
+            "/cms/data-sources", data={"measure_version_id": measure_version.id, "title": ""}
+        )
         page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
         assert response.status_code == 200
         assert "Error: Add data source" == page.find("title").text
+
+    def test_post_with_no_measure_version_id(self, test_app_client, logged_in_rdu_user):
+
+        response = test_app_client.post("/cms/data-sources", data={"title": "Test"})
+
+        assert response.status_code == 400
+
+    def test_post_with_invalid_measure_version_id(self, test_app_client, logged_in_rdu_user):
+
+        response = test_app_client.post("/cms/data-sources", data={"measure_version_id": "999999999", "title": "Test"})
+
+        assert response.status_code == 400
 
 
 class TestEditDataSourceView:
@@ -84,7 +138,15 @@ class TestUpdateDataSource:
         response = test_app_client.post(f"/cms/data-sources/{data_source.id}", data={"title": "Police statistics 2019"})
 
         assert response.status_code == 302
-        assert f"/cms/data-sources/{data_source.id}" in response.headers["Location"]
+
+        redirected_to_location = response.headers["Location"]
+        match = re.search(f"/cms/data-sources/{data_source.id}$", redirected_to_location)
+        assert match, f"Expected {redirected_to_location} to match /cms/data-sources/{data_source.id}"
+
+        # Re-fetch the model from the database to be sure that it has been saved.
+        data_source = DataSource.query.get(data_source.id)
+
+        assert data_source.title == "Police statistics 2019", "Expected title to have been updated"
 
     def test_post_with_no_title(self, test_app_client, logged_in_rdu_user):
 

--- a/tests/application/cms/views/test_add_data_source.py
+++ b/tests/application/cms/views/test_add_data_source.py
@@ -1,0 +1,96 @@
+from bs4 import BeautifulSoup
+
+from tests.models import DataSourceFactory
+
+from tests.utils import find_input_for_label_with_text
+
+
+class TestAddDataSourceView:
+    def __get_page(self, test_app_client):
+
+        response = test_app_client.get("/data-sources/new")
+
+        return (response, BeautifulSoup(response.data.decode("utf-8"), "html.parser"))
+
+    def test_returns_200(self, test_app_client):
+
+        response, _ = self.__get_page(test_app_client)
+        assert response.status_code == 200
+
+    def test_page_title(self, test_app_client):
+
+        response, page = self.__get_page(test_app_client)
+        assert "Add data source" == page.find("h1").text
+        assert "Add data source" == page.find("title").text
+
+
+class TestCreateDataSource:
+    def test_post_with_a_title(self, test_app_client):
+
+        response = test_app_client.post("/data-sources/new", data={"title": "Test"})
+
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/data-sources/1"
+
+    def test_post_with_no_title(self, test_app_client):
+
+        response = test_app_client.post("/data-sources/new", data={"title": ""})
+        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+        assert response.status_code == 200
+        assert "Error: Add data source" == page.find("title").text
+
+
+class TestEditDataSourceView:
+    def __get_page(self, test_app_client, data_source):
+
+        response = test_app_client.get(f"/data-sources/{data_source.id}")
+
+        return (response, BeautifulSoup(response.data.decode("utf-8"), "html.parser"))
+
+    def test_returns_200(self, test_app_client):
+
+        data_source = DataSourceFactory.create()
+
+        response, _ = self.__get_page(test_app_client, data_source)
+        assert response.status_code == 200
+
+    def test_page_title(self, test_app_client):
+
+        data_source = DataSourceFactory.create()
+
+        response, page = self.__get_page(test_app_client, data_source)
+        assert "Edit data source" == page.find("h1").text
+        assert "Edit data source" == page.find("title").text
+
+    def test_edit_form(self, test_app_client):
+
+        data_source = DataSourceFactory.create(title="Police statistics 2019")
+
+        response, page = self.__get_page(test_app_client, data_source)
+
+        title_input = find_input_for_label_with_text(page, "Title")
+
+        assert "Police statistics 2019" == title_input["value"]
+
+
+class TestUpdateDataSource:
+    def test_post_with_an_updated_title(self, test_app_client):
+
+        data_source = DataSourceFactory.create(title="Police stats 2019")
+
+        response = test_app_client.post(f"/data-sources/{data_source.id}", data={"title": "Police statistics 2019"})
+
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/data-sources/1"
+
+    def test_post_with_no_title(self, test_app_client):
+
+        data_source = DataSourceFactory.create(title="Police stats 2019")
+
+        response = test_app_client.post(f"/data-sources/{data_source.id}", data={"title": ""})
+
+        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+        assert response.status_code == 200
+        assert "Error: Edit data source" == page.find("title").text

--- a/tests/application/cms/views/test_add_data_source.py
+++ b/tests/application/cms/views/test_add_data_source.py
@@ -8,16 +8,16 @@ from tests.utils import find_input_for_label_with_text
 class TestAddDataSourceView:
     def __get_page(self, test_app_client):
 
-        response = test_app_client.get("/data-sources/new")
+        response = test_app_client.get("/cms/data-sources/new")
 
         return (response, BeautifulSoup(response.data.decode("utf-8"), "html.parser"))
 
-    def test_returns_200(self, test_app_client):
+    def test_returns_200(self, test_app_client, logged_in_rdu_user):
 
         response, _ = self.__get_page(test_app_client)
         assert response.status_code == 200
 
-    def test_page_title(self, test_app_client):
+    def test_page_title(self, test_app_client, logged_in_rdu_user):
 
         response, page = self.__get_page(test_app_client)
         assert "Add data source" == page.find("h1").text
@@ -25,16 +25,18 @@ class TestAddDataSourceView:
 
 
 class TestCreateDataSource:
-    def test_post_with_a_title(self, test_app_client):
+    def test_post_with_a_title(self, test_app_client, logged_in_rdu_user):
 
-        response = test_app_client.post("/data-sources/new", data={"title": "Test"})
+        response = test_app_client.post("/cms/data-sources", data={"title": "Test"})
 
         assert response.status_code == 302
-        assert response.headers["Location"] == "/data-sources/1"
 
-    def test_post_with_no_title(self, test_app_client):
+        # TODO: this should probably check that there is an ID (any number) at the end?
+        assert "/cms/data-sources/" in response.headers["Location"]
 
-        response = test_app_client.post("/data-sources/new", data={"title": ""})
+    def test_post_with_no_title(self, test_app_client, logged_in_rdu_user):
+
+        response = test_app_client.post("/cms/data-sources", data={"title": ""})
         page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
         assert response.status_code == 200
@@ -44,18 +46,18 @@ class TestCreateDataSource:
 class TestEditDataSourceView:
     def __get_page(self, test_app_client, data_source):
 
-        response = test_app_client.get(f"/data-sources/{data_source.id}")
+        response = test_app_client.get(f"/cms/data-sources/{data_source.id}")
 
         return (response, BeautifulSoup(response.data.decode("utf-8"), "html.parser"))
 
-    def test_returns_200(self, test_app_client):
+    def test_returns_200(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create()
 
         response, _ = self.__get_page(test_app_client, data_source)
         assert response.status_code == 200
 
-    def test_page_title(self, test_app_client):
+    def test_page_title(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create()
 
@@ -63,32 +65,32 @@ class TestEditDataSourceView:
         assert "Edit data source" == page.find("h1").text
         assert "Edit data source" == page.find("title").text
 
-    def test_edit_form(self, test_app_client):
+    def test_edit_form(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police statistics 2019")
 
         response, page = self.__get_page(test_app_client, data_source)
 
-        title_input = find_input_for_label_with_text(page, "Title")
+        title_input = find_input_for_label_with_text(page, "Title of data source")
 
         assert "Police statistics 2019" == title_input["value"]
 
 
 class TestUpdateDataSource:
-    def test_post_with_an_updated_title(self, test_app_client):
+    def test_post_with_an_updated_title(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police stats 2019")
 
-        response = test_app_client.post(f"/data-sources/{data_source.id}", data={"title": "Police statistics 2019"})
+        response = test_app_client.post(f"/cms/data-sources/{data_source.id}", data={"title": "Police statistics 2019"})
 
         assert response.status_code == 302
-        assert response.headers["Location"] == "/data-sources/1"
+        assert f"/cms/data-sources/{data_source.id}" in response.headers["Location"]
 
-    def test_post_with_no_title(self, test_app_client):
+    def test_post_with_no_title(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police stats 2019")
 
-        response = test_app_client.post(f"/data-sources/{data_source.id}", data={"title": ""})
+        response = test_app_client.post(f"/cms/data-sources/{data_source.id}", data={"title": ""})
 
         page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 

--- a/tests/application/cms/views/test_add_data_source.py
+++ b/tests/application/cms/views/test_add_data_source.py
@@ -82,7 +82,7 @@ class TestCreateDataSource:
 
         return f"{edit_measure_url}/data-sources"
 
-    def test_post_with_a_title(self, test_app_client, logged_in_rdu_user, db_session):
+    def test_post_with_a_title_redirects_to_edit_measure(self, test_app_client, logged_in_rdu_user, db_session):
 
         measure_version = MeasureVersionFactory.create(data_sources=[])
         url = self.__create_data_source_for_measure_url(measure_version)
@@ -167,7 +167,7 @@ class TestEditDataSourceView:
         response, _ = self.__get_page(test_app_client, data_source, measure_version)
         assert response.status_code == 200
 
-    def test_page_title(self, test_app_client, logged_in_rdu_user):
+    def test_page_title_is_set(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create()
         measure_version = MeasureVersionFactory.create(data_sources=[data_source])
@@ -176,7 +176,7 @@ class TestEditDataSourceView:
         assert "Edit data source" == page.find("h1").text
         assert "Edit data source" == page.find("title").text
 
-    def test_edit_form(self, test_app_client, logged_in_rdu_user):
+    def test_edit_form_fields_populate_from_existing_data(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police statistics 2019")
         measure_version = MeasureVersionFactory.create(data_sources=[data_source])
@@ -232,7 +232,7 @@ class TestUpdateDataSource:
 
         return f"/cms/{topic_slug}/{subtopic_slug}/{measure_slug}/{measure_version.version}/edit"
 
-    def test_post_with_an_updated_title(self, test_app_client, logged_in_rdu_user):
+    def test_post_with_an_updated_title_redirects_to_edit_measure(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police stats 2019")
         measure_version = MeasureVersionFactory.create(data_sources=[data_source])
@@ -256,7 +256,7 @@ class TestUpdateDataSource:
 
         assert data_source.title == "Police statistics 2019", "Expected title to have been updated"
 
-    def test_post_with_no_title(self, test_app_client, logged_in_rdu_user):
+    def test_post_with_no_title_redisplays_form_with_error(self, test_app_client, logged_in_rdu_user):
 
         data_source = DataSourceFactory.create(title="Police stats 2019")
         measure_version = MeasureVersionFactory.create(data_sources=[data_source])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,8 +83,16 @@ def find_input_for_label_with_text(dom_node, label_text):
 
     label_tags_with_matching_text = list(filter(lambda x: x.get_text().strip() == label_text, label_tags))
 
-    if len(label_tags_with_matching_text) > 0:
+    if len(label_tags_with_matching_text) == 1:
 
-        return dom_node.select('input[for="' + label_tags_with_matching_text[0]["id"] + '"]')
+        id_label_is_for = label_tags_with_matching_text[0]["for"]
+
+        input_element = dom_node.select('input[id="' + id_label_is_for + '"]')
+
+        if len(input_element) == 1:
+            return input_element[0]
+        else:
+            raise Exception(f"No input found with the id '{id_label_is_for}'")
+
     else:
-        return None
+        raise Exception(f"Label not found with the text '{label_text}'")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,3 +75,16 @@ def details_tag_with_summary(dom_node, summary_text):
 def find_link_with_text(dom_node, link_text):
 
     return dom_node.find("a", string=link_text)
+
+
+def find_input_for_label_with_text(dom_node, label_text):
+
+    label_tags = dom_node.find_all("label")
+
+    label_tags_with_matching_text = list(filter(lambda x: x.get_text().strip() == label_text, label_tags))
+
+    if len(label_tags_with_matching_text) > 0:
+
+        return dom_node.select('input[for="' + label_tags_with_matching_text[0]["id"] + '"]')
+    else:
+        return None


### PR DESCRIPTION
This adds the ability to direct create, edit and update data sources, in preparation for moving this out from the Edit Measure form.

See https://trello.com/c/iFVg7tRu/1591-create-new-data-source-form-fields-page-5