### PR TITLE
Add back to contents link beneath each section

### DIFF
--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -7,6 +7,7 @@ $govuk-assets-path: '/static/assets/';
 @import "node_modules/govuk-frontend/all";
 
 /* Components unique to our service */
+@import 'components/back_to_top';
 @import 'components/badge';
 @import 'components/buttons';
 @import 'components/cookie_banner';

--- a/application/src/sass/components/_back_to_top.scss
+++ b/application/src/sass/components/_back_to_top.scss
@@ -1,0 +1,13 @@
+.app-back-to-top {
+  margin-top: govuk-spacing(4);
+  margin-bottom: govuk-spacing(8);
+}
+
+.app-back-to-top__icon {
+  display: inline-block;
+  width: .8em;
+  height: 1em;
+  margin-top: -(govuk-spacing(1));
+  margin-right: govuk-spacing(2);
+  vertical-align: middle;
+}

--- a/application/templates/_macros/_back_to_top.html
+++ b/application/templates/_macros/_back_to_top.html
@@ -1,0 +1,18 @@
+{# Adapted from https://github.com/alphagov/govuk-design-system/blob/master/views/partials/_back-to-top.njk #}
+
+{% macro appBackToTop(anchor=None, text=None) %}
+  {# Safari on OSX with `position: -webkit-sticky` requires a block level element.
+  To avoid a large focus area we use a wrapper element. #}
+  <div class="app-back-to-top app-back-to-top--hidden app-back-to-top--fixedxx" data-module="app-back-to-top">
+    <div class="app-back-to-top__container">
+      <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#{{ anchor }}">
+        {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+           treat it as an interactive element - without this it will be 'focusable'
+           when using the keyboard to navigate. #}
+        <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+          <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+        </svg>{{ text }}
+      </a>
+    </div>
+  </div>
+{% endmacro %}

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -332,7 +332,7 @@
                     {{ dimension.summary | render_markdown }}
                   </div>
 
-                  {{ appBackToTop(anchor="toc",text="Contents") }}
+                  {{ appBackToTop(anchor="toc",text="Back to Contents") }}
               </div>
 
 
@@ -377,7 +377,7 @@
               {{ measure_version.further_technical_information | render_markdown }}
             {% endif %}
 
-        {{ appBackToTop(anchor="toc",text="Contents") }}
+        {{ appBackToTop(anchor="toc",text="Back to Contents") }}
 
         <div itemscope itemtype="http://schema.org/Dataset">
           <meta itemprop="version" content=" {{ measure_version.version }}">
@@ -488,7 +488,7 @@
 
             {% endif %}
 
-            {{ appBackToTop(anchor="toc",text="Contents") }}
+            {{ appBackToTop(anchor="toc",text="Back to Contents") }}
 
 
             <h2 class="govuk-heading-l" id="download-the-data">
@@ -658,7 +658,7 @@
 
       </div>
 
-      {{ appBackToTop(anchor="toc",text="Contents") }}
+      {{ appBackToTop(anchor="toc",text="Back to Contents") }}
 
       {% include "static_site/_share.html" %}
 

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from "_shared/_status_banner_macro.html" import status_banner %}
 {% from "_macros/_details.html" import govukDetails %}
+{% from "_macros/_back_to_top.html" import appBackToTop %}
 
 {% set breadcrumbs =
   [
@@ -123,7 +124,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <div class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</div>
+      <div class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5" id="toc">Contents</div>
       <ol class="eff-table-of-contents">
         <li><a class="govuk-link" href="#main-facts-and-figures" data-on="click" data-event-category="Table of contents link clicked" data-event-action="Main facts and figures" data-event-label=""><span class="eff-table-of-contents__number">1. </span><span class="eff-table-of-contents__content">Main facts and figures</span></a></li>
 
@@ -330,7 +331,11 @@
                   <div class="govuk-!-margin-bottom-8 eff-summary--with-bullets-spaced-out">
                     {{ dimension.summary | render_markdown }}
                   </div>
+
+                  {{ appBackToTop(anchor="toc",text="Contents") }}
               </div>
+
+
           {% endfor %}
       {% endif %}
   </div>
@@ -371,6 +376,8 @@
 
               {{ measure_version.further_technical_information | render_markdown }}
             {% endif %}
+
+        {{ appBackToTop(anchor="toc",text="Contents") }}
 
         <div itemscope itemtype="http://schema.org/Dataset">
           <meta itemprop="version" content=" {{ measure_version.version }}">
@@ -481,6 +488,7 @@
 
             {% endif %}
 
+            {{ appBackToTop(anchor="toc",text="Contents") }}
 
 
             <h2 class="govuk-heading-l" id="download-the-data">
@@ -649,6 +657,8 @@
         </div>
 
       </div>
+
+      {{ appBackToTop(anchor="toc",text="Contents") }}
 
       {% include "static_site/_share.html" %}
 


### PR DESCRIPTION
Alternative implementation from https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/pull/1129

See https://trello.com/c/xidjrkqa/1589-prototype-back-to-contents-jump-link-for-measure-pages-2