### PR TITLE
Add checkboxes to admin data source search

### DIFF
--- a/application/admin/views.py
+++ b/application/admin/views.py
@@ -7,6 +7,7 @@ from application import db
 from application.admin import admin_blueprint
 from application.admin.forms import AddUserForm
 from application.auth.models import User, TypeOfUser, CAPABILITIES, MANAGE_SYSTEM, MANAGE_USERS, MANAGE_DATA_SOURCES
+from application.cms.forms import SelectMultipleDataSourcesForm
 from application.cms.models import user_measure, DataSource
 from application.cms.page_service import page_service
 from application.utils import create_and_send_activation_email, user_can
@@ -208,5 +209,6 @@ def site_build():
 def data_sources():
 
     data_sources = DataSource.query.order_by(DataSource.title).all()
+    form = SelectMultipleDataSourcesForm(data_sources=data_sources)
 
-    return render_template("admin/data_sources.html", data_sources=data_sources)
+    return render_template("admin/data_sources.html", data_sources=data_sources, form=form)

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -415,12 +415,13 @@ class NewVersionForm(FlaskForm):
 class SelectMultipleDataSourcesForm(FlaskForm):
     data_sources = RDUCheckboxField(label="Choose data source to merge")
 
-    def _build_data_source_label(self, data_source):
+    def _build_data_source_hint(self, data_source):
         return Markup(render_template("forms/labels/_data_source_choice_label.html", data_source=data_source))
 
     def __init__(self, data_sources: Sequence[DataSource], *args, **kwargs):
         super(SelectMultipleDataSourcesForm, self).__init__(*args, **kwargs)
 
-        self.data_sources.choices = [
-            (data_source.id, self._build_data_source_label(data_source)) for data_source in data_sources
-        ]
+        self.data_sources.choices = [(data_source.id, data_source.title) for data_source in data_sources]
+
+        hints = {data_source.id: self._build_data_source_hint(data_source) for data_source in data_sources}
+        self.data_sources.choices_hints = hints

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -1,5 +1,7 @@
+from typing import Sequence
+
 from flask_wtf import FlaskForm
-from flask import abort
+from flask import abort, render_template
 from markupsafe import Markup
 from wtforms import StringField, TextAreaField, FileField, IntegerField
 from wtforms.fields.html5 import DateField
@@ -16,6 +18,7 @@ from application.cms.models import (
     LowestLevelOfGeography,
     FrequencyOfRelease,
     TypeOfStatistic,
+    DataSource,
 )
 from application.utils import get_bool
 
@@ -406,4 +409,18 @@ class NewVersionForm(FlaskForm):
                     f"{next_major_version}</strong>Create new edition (eg after new data becomes available)"
                 ),
             ),
+        ]
+
+
+class SelectMultipleDataSourcesForm(FlaskForm):
+    data_sources = RDUCheckboxField(label="Choose data source to merge")
+
+    def _build_data_source_label(self, data_source):
+        return Markup(render_template("forms/labels/_data_source_choice_label.html", data_source=data_source))
+
+    def __init__(self, data_sources: Sequence[DataSource], *args, **kwargs):
+        super(SelectMultipleDataSourcesForm, self).__init__(*args, **kwargs)
+
+        self.data_sources.choices = [
+            (data_source.id, self._build_data_source_label(data_source)) for data_source in data_sources
         ]

--- a/application/cms/forms.py
+++ b/application/cms/forms.py
@@ -413,7 +413,7 @@ class NewVersionForm(FlaskForm):
 
 
 class SelectMultipleDataSourcesForm(FlaskForm):
-    data_sources = RDUCheckboxField(label="Choose data source to merge")
+    data_sources = RDUCheckboxField(label="Select all options that represent the same data source")
 
     def _build_data_source_hint(self, data_source):
         return Markup(render_template("forms/labels/_data_source_choice_label.html", data_source=data_source))

--- a/application/form_fields.py
+++ b/application/form_fields.py
@@ -222,7 +222,26 @@ class _FormGroup(_FormFieldTemplateRenderer):
         self.other_field = other_field
 
 
-class RDUCheckboxField(SelectMultipleField):
+class _RDUSelectWithHintsMixin:
+    """Mixin for checkbox/radio fields to provide support for supplementary hint text alongside the labels.
+
+    WTForm checkbox/radio fields are populated from a `choices` variable on the field. This class wraps the provided
+    field and extends it with a `choices_hints` variable that maps choice values to hint text for that choice.
+
+    This utilises the `description` attribute on WTForm's interface for checkbox/radio fields.
+    """
+
+    def __init__(self, *args, choices_hints=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.choices_hints = choices_hints or {}
+
+    def __iter__(self):
+        for opt in super().__iter__():
+            opt.description = self.choices_hints.get(opt.data, "")
+            yield opt
+
+
+class RDUCheckboxField(_RDUSelectWithHintsMixin, SelectMultipleField):
     widget = _FormGroup(field_type=_ChoiceInputs.CHECKBOX)
     option_widget = _RDUChoiceInput(field_type=widget.field_type)
 
@@ -239,7 +258,7 @@ class RDUCheckboxField(SelectMultipleField):
         super().__init__(label, validators, **kwargs)
 
 
-class RDURadioField(RadioField):
+class RDURadioField(_RDUSelectWithHintsMixin, RadioField):
     """
     A radio-button field that supports showing/hiding a different field based on whether the last radio has been
     selected - the current limitation/expectation being that the last field is an "other" selection.

--- a/application/templates/admin/data_sources.html
+++ b/application/templates/admin/data_sources.html
@@ -16,22 +16,11 @@
       <h1 class="govuk-heading-xl">Data sources</h1>
 
           <ul class="govuk-list">
-            {% for data_source in data_sources %}
+            <form method="GET" action="{{ url_for('admin.data_sources') }}">  {# TODO: Update to `merge_data_sources` URL when it's added #}
+              {{ form.data_sources }}
 
-              <li>
-                <div class="govuk-heading-s govuk-!-margin-bottom-2">{{ data_source.title }}</div>
-                <div class="govuk-body">
-                  {% if data_source.publication_date %}
-                    <span class="eff-!-grey-1">Published on {{ data_source.publication_date }}</span>
-                  {% endif %}
-                  {% if data_source.source_url %}
-                    <a class="govuk-link" href="{{ data_source.source_url }}">View publication</a>
-                  {% endif %}
-                </div>
-
-              </li>
-
-            {% endfor %}
+              <button type="submit" class="govuk-button">Submit</button>
+            </form>
           </ul>
 
     </div>

--- a/application/templates/admin/data_sources.html
+++ b/application/templates/admin/data_sources.html
@@ -15,25 +15,38 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Data sources</h1>
 
-
       <form method="GET" action="{{ url_for('admin.data_sources' )}}">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            {{ data_source_search_form.q }}
+          </div>
 
-        {{ data_source_search_form.q() }}
-
-        <button class="govuk-button">Search</button>
-
+          <div class="govuk-grid-column-one-third">
+            <button class="govuk-button govuk-button--secondary">Filter</button>
+          </div>
+        </div>
       </form>
 
-      <p class="govuk-body">{% if data_sources|length == 1 %}1 result{% else %}{{ '{:,}'.format(data_sources|length) }} results{% endif %}</p>
+      <p class="govuk-body">
+        Showing
+        {% if data_source_search_form.q.data == "" %}
+          all data sources.
+        {% elif data_sources|length == 1 %}
+          1 result
+        {% else %}
+          {{ '{:,}'.format(data_sources|length) }} results
+        {% endif %}
+      </p>
 
-          <ul class="govuk-list">
-            <form method="GET" action="{{ url_for('admin.data_sources') }}">  {# TODO: Update to `merge_data_sources` URL when it's added #}
-              {{ data_source_selection_form.data_sources }}
+      {% if data_source_selection_form.data_sources.choices|length > 0 %}
+        <ul class="govuk-list">
+          <form method="GET" action="{{ url_for('admin.data_sources') }}">  {# TODO: Update to `merge_data_sources` URL when it's added #}
+            {{ data_source_selection_form.data_sources }}
 
-              <button type="submit" class="govuk-button">Submit</button>
-            </form>
-          </ul>
-
+            <button type="submit" class="govuk-button">Continue</button>
+          </form>
+        </ul>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/application/templates/forms/_choice_input.html
+++ b/application/templates/forms/_choice_input.html
@@ -10,6 +10,9 @@
          {% if conditional_question %} data-aria-controls="{{ conditionalId }}"{% endif %}
   >
   <label class="govuk-label {{ govukBaseClass }}__label" for="{{ field.id }}">{{ field.label.text }}</label>
+  {% if field.description %}
+  <span id="{{ field.id }}-hint" class="govuk-hint {{ govukBaseClass }}__hint">{{ field.description }}</span>
+  {% endif %}
 </div>
 
 {% if conditional_question %}

--- a/application/templates/forms/labels/_data_source_choice_label.html
+++ b/application/templates/forms/labels/_data_source_choice_label.html
@@ -1,0 +1,9 @@
+<div class="govuk-heading-s govuk-!-margin-bottom-2">{{ data_source.title }}</div>
+<div class="govuk-body">
+  {% if data_source.publication_date %}
+    <span class="eff-!-grey-1">Published on {{ data_source.publication_date }}</span>
+  {% endif %}
+  {% if data_source.source_url %}
+    <a class="govuk-link" href="{{ data_source.source_url }}">View publication</a>
+  {% endif %}
+</div>

--- a/application/templates/forms/labels/_data_source_choice_label.html
+++ b/application/templates/forms/labels/_data_source_choice_label.html
@@ -1,4 +1,3 @@
-<div class="govuk-heading-s govuk-!-margin-bottom-2">{{ data_source.title }}</div>
 <div class="govuk-body">
   {% if data_source.publication_date %}
     <span class="eff-!-grey-1">Published on {{ data_source.publication_date }}</span>

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -430,7 +430,8 @@ class TestDataSourcesView:
         response = test_app_client.get("/admin/data-sources")
         page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
-        form = page.find("form", action=url_for("admin.data_sources"))  # TODO: Update to `admin.merge_data_sources`
+        # TODO: Update to `admin.merge_data_sources`
+        form = page.find_all("form", action=url_for("admin.data_sources"))[1]
         assert form
 
         checkboxes = form.find_all("input", type="checkbox")

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -392,3 +392,26 @@ class TestDataSourcesView:
 
         assert "Police statistics 2019" in page.text
         assert "2011 Census of England and Wales" in page.text
+
+    def test_data_sources_ordered_lexicographically_by_title(self, test_app_client, logged_in_admin_user):
+        DataSourceFactory.create(title="Police statistics 2019")
+        DataSourceFactory.create(title="2011 Census of England and Wales")
+
+        response = test_app_client.get("/admin/data-sources")
+        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+        main = page.find("main")
+        assert main.text.index("2011 Census of England and Wales") < main.text.index("Police statistics 2019")
+
+    def test_form_has_checkbox_for_each_data_source(self, test_app_client, logged_in_admin_user):
+        ds1 = DataSourceFactory.create(title="Police statistics 2019")
+        ds2 = DataSourceFactory.create(title="2011 Census of England and Wales")
+
+        response = test_app_client.get("/admin/data-sources")
+        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+        form = page.find("form", action=url_for("admin.data_sources"))  # TODO: Update to `admin.merge_data_sources`
+        assert form
+
+        checkboxes = form.find_all("input", type="checkbox")
+        assert {int(c.get("value")) for c in checkboxes} == {ds1.id, ds2.id}

--- a/tests/application/admin/test_views.py
+++ b/tests/application/admin/test_views.py
@@ -434,5 +434,5 @@ class TestDataSourcesView:
         form = page.find_all("form", action=url_for("admin.data_sources"))[1]
         assert form
 
-        checkboxes = form.find_all("input", type="checkbox")
-        assert {int(c.get("value")) for c in checkboxes} == {ds1.id, ds2.id}
+        assert find_input_for_label_with_text(form, "Police statistics 2019").get("value") == str(ds1.id)
+        assert find_input_for_label_with_text(form, "2011 Census of England and Wales").get("value") == str(ds2.id)

--- a/tests/application/test_form_fields.py
+++ b/tests/application/test_form_fields.py
@@ -96,6 +96,11 @@ class TestRDUCheckboxField:
         )
         checkbox_field_enum = RDUCheckboxField(label="checkbox_field", enum=EnumForTest)
         other_field = RDUStringField(label="other_field")
+        checkbox_field_with_hints = RDUCheckboxField(
+            label="checkbox_field_with_hints",
+            choices=[(1, 1), (2, 2), (3, 3)],
+            choices_hints={1: "Hint 1", 2: "Hint 2"},
+        )
 
     def setup(self):
         self.form = self.FormForTest()
@@ -160,6 +165,18 @@ class TestRDUCheckboxField:
         checkboxes_div = doc.xpath("//div[contains(@class, 'govuk-checkboxes')]")[0]
         assert "govuk-checkboxes--inline" in checkboxes_div.attrib["class"]
 
+    def test_can_render_hints_for_each_choice(self):
+        doc = html.fromstring(self.form.checkbox_field_with_hints())
+
+        assert len(doc.xpath("//input[@type='checkbox']")) == 3
+
+        radios_with_hints = doc.xpath(
+            "//input[@type='checkbox']/following-sibling::span[@class='govuk-hint govuk-checkboxes__hint']"
+        )
+        assert len(radios_with_hints) == 2
+        assert radios_with_hints[0].text == "Hint 1"
+        assert radios_with_hints[1].text == "Hint 2"
+
 
 class TestRDURadioField:
     class FormForTest(FlaskForm):
@@ -170,6 +187,9 @@ class TestRDURadioField:
             validators=[DataRequired(message="failed validation")],
         )
         other_field = RDUStringField(label="other_field")
+        radio_field_with_hints = RDURadioField(
+            label="radio_field_with_hints", choices=[(1, 1), (2, 2), (3, 3)], choices_hints={1: "Hint 1", 2: "Hint 2"}
+        )
 
     def setup(self):
         self.form = self.FormForTest()
@@ -238,6 +258,18 @@ class TestRDURadioField:
         doc = html.fromstring(self.form.radio_field(inline=True))
         radios_div = doc.xpath("//div[contains(@class, 'govuk-radios')]")[0]
         assert "govuk-radios--inline" in radios_div.attrib["class"]
+
+    def test_can_render_hints_for_each_choice(self):
+        doc = html.fromstring(self.form.radio_field_with_hints())
+
+        assert len(doc.xpath("//input[@type='radio']")) == 3
+
+        radios_with_hints = doc.xpath(
+            "//input[@type='radio']/following-sibling::span[@class='govuk-hint govuk-radios__hint']"
+        )
+        assert len(radios_with_hints) == 2
+        assert radios_with_hints[0].text == "Hint 1"
+        assert radios_with_hints[1].text == "Hint 2"
 
 
 class TestRDUStringField:


### PR DESCRIPTION
We currently have a page that allows an admin to see all data sources
entered into the system. We want the user to be able to manage the list
of data sources (by combining multiple ones into a single authoritative
source), so we need a way for users to select which data sources they
wish to combine.

This patch adds checkboxes to each data source in the list, allowing the
user to select which they wish to manage. The form currently does a GET
back to its own URL, but will soon be updated to point at the "merge
data sources" page, when it becomes available.

 ## Ticket
https://trello.com/c/w471ZapE