### PR TITLE
Style flash messages for errors

### DIFF
--- a/application/src/sass/components/_flash_message.scss
+++ b/application/src/sass/components/_flash_message.scss
@@ -8,6 +8,7 @@
 @import "node_modules/govuk-frontend/core/lists";
 
 $eff-flash-colour: #00833F;
+$eff-flash-error-colour: govuk-colour('red');
 
 .eff-flash-message {
   @include govuk-text-colour;
@@ -19,6 +20,14 @@ $eff-flash-colour: #00833F;
 
   @include govuk-media-query($from: tablet) {
     border: $govuk-border-width solid $eff-flash-colour;
+  }
+}
+
+.eff-flash-message--error {
+  border: $govuk-border-width-mobile solid $eff-flash-error-colour;
+
+  @include govuk-media-query($from: tablet) {
+    border: $govuk-border-width solid $eff-flash-error-colour;
   }
 }
 

--- a/application/templates/_shared/_flash_messages.html
+++ b/application/templates/_shared/_flash_messages.html
@@ -2,13 +2,13 @@
   {% if messages %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-          <div class="eff-flash-message govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
-            {% for category, message in messages %}
+          {% for category, message in messages %}
+          <div class="eff-flash-message govuk-!-margin-bottom-0 govuk-!-padding-bottom-0{% if category == "error" %} eff-flash-message--error{% endif %}">
             <div class="eff-flash-message__body">
               {{ message|render_markdown }}
             </div>
-            {% endfor %}
           </div>
+          {% endfor %}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Introduces additional visual indicator (red colouring) to flash messages
that are displaying errors, to highlight to the user that something
untoward has occurred.

## Example
![Screen Shot 2019-07-10 at 14 23 55](https://user-images.githubusercontent.com/2920760/60972537-61ffa100-a31e-11e9-9eca-e45aa78d180f.png)
