### PR TITLE
Allow custom labels for radio/checkbox items

### DIFF
--- a/application/form_fields.py
+++ b/application/form_fields.py
@@ -155,7 +155,9 @@ class _RDUChoiceInput(_FormFieldTemplateRenderer):
         super().__init__(*args, **kwargs)
         self.field_type = field_type
 
-    def __call__(self, field, class_="", diffs=None, disabled=False, conditional_question=None, **kwargs):
+    def __call__(
+        self, field, class_="", diffs=None, disabled=False, conditional_question=None, label_class=None, **kwargs
+    ):
         if getattr(field, "checked", field.data):
             kwargs["checked"] = True
 
@@ -170,6 +172,7 @@ class _RDUChoiceInput(_FormFieldTemplateRenderer):
                 "value": field.data,
                 "field_type": self.field_type.value,
                 "conditional_question": conditional_question,
+                "label_class": label_class,
             },
             field_params={**kwargs},
         )
@@ -190,6 +193,7 @@ class _FormGroup(_FormFieldTemplateRenderer):
         fieldset_class="",
         legend_class="",
         field_class="",
+        label_class="",
         diffs=None,
         disabled=False,
         inline=False,
@@ -211,6 +215,7 @@ class _FormGroup(_FormFieldTemplateRenderer):
                 "fieldset_class": fieldset_class,
                 "legend_class": legend_class,
                 "field_class": field_class,
+                "label_class": label_class,
                 "field_type": self.field_type.value,
                 "inline": inline,
                 "conditional_questions": conditional_questions,

--- a/application/templates/forms/_choice_input.html
+++ b/application/templates/forms/_choice_input.html
@@ -9,7 +9,7 @@
          {{ field_params }}
          {% if conditional_question %} data-aria-controls="{{ conditionalId }}"{% endif %}
   >
-  <label class="govuk-label {{ govukBaseClass }}__label {{ label_class | default('') }}" for="{{ field.id }}">{{ field.label.text }}</label>
+  <label class="govuk-label {{ govukBaseClass }}__label {{ label_class }}" for="{{ field.id }}">{{ field.label.text }}</label>
   {% if field.description %}
   <span id="{{ field.id }}-hint" class="govuk-hint {{ govukBaseClass }}__hint">{{ field.description }}</span>
   {% endif %}

--- a/application/templates/forms/_choice_input.html
+++ b/application/templates/forms/_choice_input.html
@@ -1,4 +1,4 @@
-{# Required parameters: field, id_, name, class, value, field_params #}
+{# Required parameters: field, id_, name, class_, value, field_params, label_class #}
 
 {% set govukBaseClass = 'govuk-' + ('checkboxes' if field_type == 'checkbox' else 'radios') %}
 {% set conditionalId = 'conditional-' + field.id %}
@@ -9,7 +9,7 @@
          {{ field_params }}
          {% if conditional_question %} data-aria-controls="{{ conditionalId }}"{% endif %}
   >
-  <label class="govuk-label {{ govukBaseClass }}__label" for="{{ field.id }}">{{ field.label.text }}</label>
+  <label class="govuk-label {{ govukBaseClass }}__label {{ label_class | default('') }}" for="{{ field.id }}">{{ field.label.text }}</label>
   {% if field.description %}
   <span id="{{ field.id }}-hint" class="govuk-hint {{ govukBaseClass }}__hint">{{ field.description }}</span>
   {% endif %}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -1,4 +1,4 @@
-{# Required parameters: id_, name, class_, fieldset_class, field_class, field_type, legend, fields, errors, label_class, disabled, inline #}
+{# Required parameters: id_, name, class_, fieldset_class, field_class, field_type, fields, errors, legend_class, disabled, inline, label_class #}
 
 {% set baseFieldType = ('checkboxes' if field_type == 'checkbox' else 'radios') %}
 {% set govukBaseClass = 'govuk-' + baseFieldType %}
@@ -19,7 +19,7 @@
            {% if conditional_questions %} data-module="{{ baseFieldType }}"{% endif %}
       >
         {% for subfield in fields %}
-            {% set field_options = {"disabled": disabled, "class_": field_class} %}
+            {% set field_options = {"disabled": disabled, "class_": field_class, "label_class": label_class | default('')} %}
             {% if loop.last and other_field %}
               {% do field_options.update({"aria-controls": other_field.id + "-wrapper", "aria-expanded": "false"}) %}
             {% endif %}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -19,7 +19,7 @@
            {% if conditional_questions %} data-module="{{ baseFieldType }}"{% endif %}
       >
         {% for subfield in fields %}
-            {% set field_options = {"disabled": disabled, "class_": field_class, "label_class": label_class | default('')} %}
+            {% set field_options = {"disabled": disabled, "class_": field_class, "label_class": label_class} %}
             {% if loop.last and other_field %}
               {% do field_options.update({"aria-controls": other_field.id + "-wrapper", "aria-expanded": "false"}) %}
             {% endif %}

--- a/tests/application/test_form_fields.py
+++ b/tests/application/test_form_fields.py
@@ -132,6 +132,12 @@ class TestRDUCheckboxField:
         assert len(doc.xpath("//input[@type='checkbox']")) == 3
         assert doc.xpath("//input[@type='checkbox']/following-sibling::label/text()") == ["one", "two", "three"]
 
+    def test_label_class_is_rendered(self):
+        doc = html.fromstring(self.form.checkbox_field(label_class="govuk-!-font-weight-bold"))
+
+        assert doc.xpath("//label")
+        assert "govuk-!-font-weight-bold" in doc.xpath("//label/@class")[0].split()
+
     def test_checkbox_enum_choices_have_correct_values(self):
         doc = html.fromstring(self.form.checkbox_field_enum())
 
@@ -209,6 +215,12 @@ class TestRDURadioField:
 
         assert doc.xpath("//legend")
         assert doc.xpath("//legend/@class")[0] == "govuk-fieldset__legend govuk-!-font-weight-bold"
+
+    def test_label_class_is_rendered(self):
+        doc = html.fromstring(self.form.radio_field(label_class="govuk-!-font-weight-bold"))
+
+        assert doc.xpath("//label")
+        assert "govuk-!-font-weight-bold" in doc.xpath("//label/@class")[0].split()
 
     def test_radio_choices_are_rendered(self):
         doc = html.fromstring(self.form.radio_field())


### PR DESCRIPTION
Sometimes we want to style the labels for each radio/checkbox item
individually, for example where they also have hint text and we need to
make the actual choice label stand out more clearly. This adds support
for it.

Example for calling in a template:
`form.radios(label_class='govuk-!-font-weight-bold')`