### PR TITLE
Request build if updating a data source

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -187,8 +187,13 @@ class DataSource(db.Model, CopyableModel):
         "FrequencyOfRelease", foreign_keys=[frequency_of_release_id], back_populates="data_sources"
     )
     measure_versions = db.relationship(
-        "MeasureVersion", secondary="data_source_in_measure_version", back_populates="data_sources"
+        "MeasureVersion", secondary="data_source_in_measure_version", back_populates="data_sources", lazy="dynamic"
     )
+
+    @property
+    def associated_with_published_measure_versions(self):
+
+        return self.measure_versions.filter(MeasureVersion.status == "APPROVED").count() > 0
 
     @staticmethod
     def search(query, limit=False, exclude_data_sources=None):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1325,6 +1325,9 @@ def update_data_source(topic_slug, subtopic_slug, measure_slug, version, data_so
         message = "Saved"
         flash(message, "info")
 
+        if data_source.associated_with_published_measure_versions:
+            build_service.request_build()
+
         return redirect(
             url_for(
                 "cms.edit_data_source",

--- a/tests/application/cms/models/test_data_source_model.py
+++ b/tests/application/cms/models/test_data_source_model.py
@@ -87,3 +87,14 @@ class TestDataSourceModel:
         assert (
             data_source_associated_with_1_measure_version == search[1]
         ), "Expected data source associated with 1 measure version to be second"
+
+    def test_data_source_associated_with_published_measure_versions(self):
+
+        data_source_1 = DataSourceFactory.create()
+        MeasureVersionFactory.create(data_sources=[data_source_1], status="APPROVED")
+
+        data_source_2 = DataSourceFactory.create()
+        MeasureVersionFactory.create(data_sources=[data_source_2], status="DRAFT")
+
+        assert data_source_1.associated_with_published_measure_versions is True
+        assert data_source_2.associated_with_published_measure_versions is False


### PR DESCRIPTION
(only if it's associated with at least one published measure version)

See https://trello.com/c/3RePBUVF/1749-8-make-data-source-updates-affecting-published-measures-log-a-build-request-1