### PR TITLE
Update source description for downloaded charts

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -718,7 +718,7 @@
         var subtitle = 'Title:' +  chartTitle
                                 + '. Location: ' + '{{ measure_version.format_area_covered() }}'
                                 + '. Time period: '  + dimension.time_period
-                                + '. Source:  {{ measure_version.primary_data_source.publisher.name if measure_version.primary_data_source and measure_version.primary_data_source.publisher else "" }}'
+                                + '. Source:  {{ measure_version.primary_data_source.title if measure_version.primary_data_source else "" }}'
                                 + '| Ethnicity Facts and Figures GOV.UK';
 
         chart.highcharts().options.subtitle.text = subtitle;


### PR DESCRIPTION
On the main measure page, next to each chart's source, we show the
primary data source's title. However, in the downloaded version of the
chart, we currently just show the data source publisher's name. We
should be consistent about what we show. Let's show the data source
title in both cases.