### PR TITLE
 Update information on merge data source page

### DIFF
--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -77,4 +77,4 @@ def html_line_breaks(string):
 
 
 def url_with_line_breaks(string):
-    return string.replace("/", "/\N{ZERO WIDTH SPACE}").replace("&", "&\N{ZERO WIDTH SPACE}")
+    return string.replace("/", "/\N{ZERO WIDTH SPACE}").replace("&", "&\N{ZERO WIDTH SPACE}") if string else string

--- a/application/templates/forms/labels/_merge_data_source_choice_hint.html
+++ b/application/templates/forms/labels/_merge_data_source_choice_hint.html
@@ -1,11 +1,14 @@
 <div class="govuk-body">
-  {% set plural = data_source.measure_versions.count() != 1 %}
+  {% set published_measure_versions_count = data_source.measure_versions.all() | map(attribute='status') | select('equalto', 'APPROVED') | list | length  %}
+  {% set plural = published_measure_versions_count != 1 %}
+  {% set unique_time_covered = data_source.measure_versions.all() | map(attribute='time_covered') | unique | reject("none") %}
+  {% set formatted_time_covered = (unique_time_covered | join(', ')) if unique_time_covered else '123' %}
 
   <div class="govuk-body">{{ data_source.publisher.name }}</div>
 
   <div class="govuk-body">{% if data_source.publication_date %}Published on {{ data_source.publication_date }}{% else %}No publication date{% endif %}</div>
 
-  <div class="govuk-body">Linked to {{ data_source.measure_versions.count() }} measure version{% if plural %}s{% endif %} ({{ data_source.measure_versions.all() | map(attribute='time_covered') | unique | join(', ') }})</div>
+  <div class="govuk-body">Linked to {{ published_measure_versions_count }} published measure version{% if plural %}s{% endif %}{% if formatted_time_covered %} from {{ formatted_time_covered }}{% endif %}</div>
 
   <div class="govuk-body"><a class="govuk-link" href="{{ data_source.source_url }}">{{ data_source.source_url | url_with_line_breaks }}</a></div>
 

--- a/application/templates/forms/labels/_merge_data_source_choice_hint.html
+++ b/application/templates/forms/labels/_merge_data_source_choice_hint.html
@@ -8,7 +8,7 @@
 
   <div class="govuk-body">{% if data_source.publication_date %}Published on {{ data_source.publication_date }}{% else %}No publication date{% endif %}</div>
 
-  <div class="govuk-body">Linked to {{ published_measure_versions_count }} published measure version{% if plural %}s{% endif %}{% if formatted_time_covered %} from {{ formatted_time_covered }}{% endif %}</div>
+  <div class="govuk-body">Linked to {{ published_measure_versions_count }} published measure version{% if plural %}s{% endif %}{% if formatted_time_covered %} for {{ formatted_time_covered }}{% endif %}</div>
 
   <div class="govuk-body"><a class="govuk-link" href="{{ data_source.source_url }}">{{ data_source.source_url | url_with_line_breaks }}</a></div>
 


### PR DESCRIPTION
It's useful for analysts to know which data sources are associated to
published measures, as this implies they've already been "signed off".
This will give weight to preferring these as canonical data sources and
reduce the risk of accepting a data source from the testing space, or
that otherwise isn't finished yet.

## Example
<img width="694" alt="Screen Shot 2019-07-16 at 14 15 39" src="https://user-images.githubusercontent.com/2920760/61297466-35430200-a7d4-11e9-9559-20ed0d4f3588.png">
