### PR TITLE
Move update label down

### DIFF
--- a/application/templates/dashboards/graphs.html
+++ b/application/templates/dashboards/graphs.html
@@ -59,7 +59,7 @@
 
       {{ render_value_circles(data.total_major_updates_count_each_week, x_scale, y_scale, graph_height, colour='#28A197', start_index=data.total_major_updates_count_each_week|index_of_last_initial_zero) }}
 
-      {{ render_value_label(data.total_major_updates_count_each_week|last, (data.total_major_updates_count_each_week|length - 1), x_scale, y_scale, graph_height, text_anchor='end', vertical_offset=-13, unit='updates')  }}
+      {{ render_value_label(data.total_major_updates_count_each_week|last, (data.total_major_updates_count_each_week|length - 1), x_scale, y_scale, graph_height, text_anchor='end', vertical_offset=50, unit='updates')  }}
 
     </g>
 

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -88,7 +88,7 @@
                                                             subtopic_slug=page.measure.subtopic.slug,
                                                             measure_slug=page.measure.slug,
                                                             version='latest') }}">{{ page.title }}</a>
-                                        <span class="source">{{ page.primary_data_source.publisher.name }}</span>{{ page.published_at | format_friendly_short_date}}</li>
+                                        <span class="source">{% if page.primary_data_source.publisher %}{{ page.primary_data_source.publisher.name }}{% endif %}</span>{{ page.published_at | format_friendly_short_date}}</li>
                                 {% endfor %}
                               </ul>
                           {% endif %}

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -88,7 +88,7 @@
                                                             subtopic_slug=page.measure.subtopic.slug,
                                                             measure_slug=page.measure.slug,
                                                             version='latest') }}">{{ page.title }}</a>
-                                        <span class="source">{% if page.primary_data_source.publisher %}{{ page.primary_data_source.publisher.name }}{% endif %}</span>{{ page.published_at | format_friendly_short_date}}</li>
+                                        <span class="source">{% if page.primary_data_source and page.primary_data_source.publisher %}{{ page.primary_data_source.publisher.name }}{% endif %}</span>{{ page.published_at | format_friendly_short_date}}</li>
                                 {% endfor %}
                               </ul>
                           {% endif %}

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -75,7 +75,7 @@
                                                             subtopic_slug=page.measure.subtopic.slug,
                                                             measure_slug=page.measure.slug,
                                                             version='latest') }}">{{ page.title }}</a>
-                                        <span class="source">{{ page.primary_data_source.publisher.name }}</span>{{ page.published_at | format_friendly_short_date}}</li>
+                                        {% if page.primary_data_source and page.primary_data_source.publisher %}<span class="source">{{ page.primary_data_source.publisher.name }}</span>{% endif %}{{ page.published_at | format_friendly_short_date}}</li>
                                 {% endfor %}
                               </ul>
                           {% endif %}
@@ -88,7 +88,7 @@
                                                             subtopic_slug=page.measure.subtopic.slug,
                                                             measure_slug=page.measure.slug,
                                                             version='latest') }}">{{ page.title }}</a>
-                                        <span class="source">{% if page.primary_data_source and page.primary_data_source.publisher %}{{ page.primary_data_source.publisher.name }}{% endif %}</span>{{ page.published_at | format_friendly_short_date}}</li>
+                                        {% if page.primary_data_source and page.primary_data_source.publisher %}<span class="source">{{ page.primary_data_source.publisher.name }}</span>{% endif %}{{ page.published_at | format_friendly_short_date}}</li>
                                 {% endfor %}
                               </ul>
                           {% endif %}


### PR DESCRIPTION
Fix for https://trello.com/c/81qbbvvK/1772-fix-overlapping-copy-on-the-published-pages-dashboard