### PR TITLE
Require Google Chromedriver version

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
     "DEPLOY_SITE": {
       "required": true
     },
+    "CHROMEDRIVER_VERSION": {
+      "required": true
+    },
     "ENVIRONMENT": {
       "required": true
     },


### PR DESCRIPTION
This will allow us to pin to a specific Google Chromedriver version. This is required in the short term to resolve a discrepancy between the 'latest' Google Chromedriver version and the 'stable' version of Google Chrome.