### PR TITLE
Remove the "order by" dropdown on search results

### DIFF
--- a/application/src/sass/_search_results.scss
+++ b/application/src/sass/_search_results.scss
@@ -52,6 +52,11 @@ main#main-content {
     display: none;
   }
 
+  /* Order by dropdown */
+  .gsc-orderby-container {
+    display: none;
+  }
+
   /* Table containing each result snippet */
   .gsc-table-result {
     padding-left: 0;


### PR DESCRIPTION
This isn't that useful, and is inaccessible.

https://trello.com/c/3TmBUU4p/1673-remove-search-sort-dropdown-on-search-results-page-2