### PR TITLE
Add aria-hidden to graphs

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -702,6 +702,7 @@
             link.id = 'download-' + chartDownloadLinkContainer.getAttribute('data-chart-guid');
             link.href = '#';
             link.className = 'govuk-link download-png';
+            link.setAttribute('aria-hidden', 'true');
             link.setAttribute('data-on', 'click');
             link.setAttribute('data-event-category', 'Image downloaded');
             link.setAttribute('data-event-action', "Image of the chart");

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -247,7 +247,7 @@
               {% set chart_and_downloadable = (dimension.dimension_chart.chart_object.type not in ['panel_bar_chart', 'panel_line_chart']) %}
               <div class="chart-and-footer hidden">
                 <div class="govuk-grid-row">
-                  <div class="rd_chart" id="chart_{{ dimension.guid }}" style="clear: both; overflow: hidden"></div>
+                  <div class="rd_chart" aria-hidden="true" id="chart_{{ dimension.guid }}" style="clear: both; overflow: hidden"></div>
                 </div>
 
                 <div class="govuk-grid-row">


### PR DESCRIPTION
This helps improve accessibility by hiding the graphs from screen-readers, as these are confusing, and there is a more accessible alternative in the form of the summary and the table.

https://trello.com/c/6ITRqpX1/1674-add-aria-hidden-attribute-to-graphs-1