### PR TITLE
Link "back to contents" to title instead

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -101,7 +101,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4  govuk-!-margin-top-2" itemprop="headline">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4  govuk-!-margin-top-2" itemprop="headline" id="title">
         {{ measure_version.title }}
       </h1>
 
@@ -653,7 +653,7 @@
 
       </div>
 
-      {{ appBackToTop(anchor="toc",text="Contents") }}
+      {{ appBackToTop(anchor="title",text="Contents") }}
 
       {% include "static_site/_share.html" %}
 


### PR DESCRIPTION
Potentially this is more helpful, as a reminder of the context of which page you are looking at, especially as the table of contents includes things like "By ethnicity" which only make sense within the context of the title.

https://trello.com/c/s6fkBj5t/1836-back-to-contents-should-anchor-to-the-measure-title-discuss