### PR TITLE
Add the dimension title as visually-hidden text

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -297,14 +297,14 @@
                                    measure_slug=measure_version.measure.slug,
                                    version=version,
                                    filename=dimension.static_table_file_name) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}"
-                                 download="{{ dimension.static_table_file_name }}">Download table data (CSV)</a>
+                                 download="{{ dimension.static_table_file_name }}">Download table data <span class="govuk-visually-hidden">for ‘{{ dimension.title }}’</span> (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_table_download',
                                    topic_slug=topic_slug,
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}">Download table data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.dimension_table.table_object.header}}">Download table data <span class="govuk-visually-hidden">for ‘{{ dimension.title }}’</span> (CSV)</a>
                           {% endif %}
 
                           {% if static_mode %}
@@ -313,14 +313,14 @@
                                    measure_slug=measure_version.measure.slug,
                                    version=version,
                                    filename=dimension.static_file_name) }}" data-on="click"
-                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data (CSV)</a>
+                                 data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data <span class="govuk-visually-hidden">for ‘{{ dimension.title }}’</span> (CSV)</a>
                           {% else %}
                               <a class="govuk-link" href="{{ url_for('static_site.dimension_file_download',
                                    topic_slug=topic_slug,
                                    subtopic_slug=subtopic_slug,
                                    measure_slug=measure_version.measure.slug,
                                    version=measure_version.version,
-                                   dimension_guid=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.dimension_table.table_object.header}}">Source data <span class="govuk-visually-hidden">for ‘{{ dimension.title }}’</span> (CSV)</a>
                           {% endif %}
                       </p>
               </div>

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -808,9 +808,8 @@ class TestMeasurePage:
         resp = test_app_client.get(f"/topic/subtopic/measure/latest?static_mode={static_mode}", follow_redirects=False)
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
-        data_links = page.findAll("a", href=True, text="Download table data (CSV)")
+        data_links = page.findAll("a", href=expected_url)
         assert len(data_links) == 1
-        assert data_links[0].attrs["href"] == expected_url
 
     @pytest.mark.parametrize(
         "static_mode, expected_url",
@@ -839,9 +838,8 @@ class TestMeasurePage:
         resp = test_app_client.get(f"/topic/subtopic/measure/latest?static_mode={static_mode}", follow_redirects=False)
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
-        data_links = page.findAll("a", href=True, text="Source data (CSV)")
+        data_links = page.findAll("a", href=expected_url)
         assert len(data_links) == 1
-        assert data_links[0].attrs["href"] == expected_url
 
     @pytest.mark.parametrize(
         "static_mode, expected_url",


### PR DESCRIPTION
This changes the download CSV links from:

> Download table data (CSV)

to

> Download table data for ‘By ethnicity and gender’ CSV

(Where [for ‘dimension title’] is visually-hidden)

This helps screen reader users to understand what the links do when they are read out out-of-context.

https://trello.com/c/b4z9VJZc/1677-multiple-download-table-data-links-on-the-page-will-be-ambiguous-for-screen-reader-users-1