### PR TITLE
Add page title to action buttons

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -65,7 +65,7 @@
              topic_slug=topic_slug,
              subtopic_slug=subtopic_slug,
              measure_slug=measure_version.measure.slug,
-             version=measure_version.version) }}" class="govuk-link">Export <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+             version=measure_version.version) }}" class="govuk-link">Export page: <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
         </span>
 
         <span class="info">
@@ -74,7 +74,7 @@
             {% if measure_version.status == 'APPROVED' %}
               {% if current_user.is_authenticated and current_user.can(CREATE_VERSION) %}
                 <a class="govuk-button" href="{{ url_for('cms.new_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">
-                  Update <span class="govuk-visually-hidden">{{ measure_version.title }}
+                  Update page: <span class="govuk-visually-hidden">{{ measure_version.title }}
                 </a>
               {% endif %}
             {% else %}
@@ -82,7 +82,7 @@
            topic_slug=topic_slug,
            subtopic_slug=subtopic_slug,
            measure_slug=measure_version.measure.slug,
-           version=measure_version.version) }}" class="govuk-button">Edit  <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+           version=measure_version.version) }}" class="govuk-button">Edit page:  <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
             {% endif %}
           {% endif %}
         </span>
@@ -90,7 +90,7 @@
         {% if measure_version.status == 'DRAFT' %}
 
 
-          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete page: <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
 
         {% endif %}
       </div>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -65,7 +65,7 @@
              topic_slug=topic_slug,
              subtopic_slug=subtopic_slug,
              measure_slug=measure_version.measure.slug,
-             version=measure_version.version) }}" class="govuk-link">Export</a>
+             version=measure_version.version) }}" class="govuk-link">Export <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
         </span>
 
         <span class="info">
@@ -74,7 +74,7 @@
             {% if measure_version.status == 'APPROVED' %}
               {% if current_user.is_authenticated and current_user.can(CREATE_VERSION) %}
                 <a class="govuk-button" href="{{ url_for('cms.new_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">
-                  Update
+                  Update <span class="govuk-visually-hidden">{{ measure_version.title }}
                 </a>
               {% endif %}
             {% else %}
@@ -82,7 +82,7 @@
            topic_slug=topic_slug,
            subtopic_slug=subtopic_slug,
            measure_slug=measure_version.measure.slug,
-           version=measure_version.version) }}" class="govuk-button">Edit</a>
+           version=measure_version.version) }}" class="govuk-button">Edit  <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
             {% endif %}
           {% endif %}
         </span>
@@ -90,7 +90,7 @@
         {% if measure_version.status == 'DRAFT' %}
 
 
-          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete</a>
+          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
 
         {% endif %}
       </div>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -65,7 +65,7 @@
              topic_slug=topic_slug,
              subtopic_slug=subtopic_slug,
              measure_slug=measure_version.measure.slug,
-             version=measure_version.version) }}" class="govuk-link">Export page: <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+             version=measure_version.version) }}" class="govuk-link">Export <span class="govuk-visually-hidden">page: {{ measure_version.title }}</a>
         </span>
 
         <span class="info">
@@ -74,7 +74,7 @@
             {% if measure_version.status == 'APPROVED' %}
               {% if current_user.is_authenticated and current_user.can(CREATE_VERSION) %}
                 <a class="govuk-button" href="{{ url_for('cms.new_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">
-                  Update page: <span class="govuk-visually-hidden">{{ measure_version.title }}
+                  Update<span class="govuk-visually-hidden"> page: {{ measure_version.title }}
                 </a>
               {% endif %}
             {% else %}
@@ -82,7 +82,7 @@
            topic_slug=topic_slug,
            subtopic_slug=subtopic_slug,
            measure_slug=measure_version.measure.slug,
-           version=measure_version.version) }}" class="govuk-button">Edit page:  <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+           version=measure_version.version) }}" class="govuk-button">Edit<span class="govuk-visually-hidden"> page: {{ measure_version.title }}</a>
             {% endif %}
           {% endif %}
         </span>
@@ -90,7 +90,7 @@
         {% if measure_version.status == 'DRAFT' %}
 
 
-          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete page: <span class="govuk-visually-hidden">{{ measure_version.title }}</a>
+          <a class="govuk-button eff-button--warning" href="{{ url_for('cms.confirm_delete_measure_version', topic_slug=topic_slug, subtopic_slug=subtopic_slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">Delete<span class="govuk-visually-hidden"> page: {{ measure_version.title }}</a>
 
         {% endif %}
       </div>

--- a/tests/functional/test_cms_delete_v1_measure.py
+++ b/tests/functional/test_cms_delete_v1_measure.py
@@ -42,7 +42,7 @@ def test_delete_a_draft_1_0_measure(driver, live_server):
     driver.find_element_by_link_text(measure.title).click()
 
     # WHEN we walk through the delete process
-    driver.find_element_by_xpath(f"//a[contains(., 'Delete {measure.title}')]").click()
+    driver.find_element_by_xpath(f"//a[contains(., 'Delete page: {measure.title}')]").click()
 
     driver.find_element_by_xpath('//button[text()="Yes, delete"]').click()
 

--- a/tests/functional/test_cms_delete_v1_measure.py
+++ b/tests/functional/test_cms_delete_v1_measure.py
@@ -42,7 +42,7 @@ def test_delete_a_draft_1_0_measure(driver, live_server):
     driver.find_element_by_link_text(measure.title).click()
 
     # WHEN we walk through the delete process
-    driver.find_element_by_link_text("Delete").click()
+    driver.find_element_by_xpath(f"//a[contains(., 'Delete {measure.title}')]").click()
 
     driver.find_element_by_xpath('//button[text()="Yes, delete"]').click()
 

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -141,7 +141,8 @@ def navigate_to_edit_page(driver, live_server, topic, subtopic, measure):
         driver.find_element_by_xpath(f"//button[normalize-space(text())='{subtopic.title}']").click()
         driver.find_element_by_link_text(measure.title).click()
 
-    driver.find_element_by_link_text("Edit").click()
+    driver.find_element_by_xpath(f"//a[contains(., 'Edit')]").click()
+    # driver.find_element_by_link_text("Edit").click()
 
 
 def navigate_to_view_form(driver, live_server, topic, subtopic, measure):

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -142,7 +142,6 @@ def navigate_to_edit_page(driver, live_server, topic, subtopic, measure):
         driver.find_element_by_link_text(measure.title).click()
 
     driver.find_element_by_xpath(f"//a[contains(., 'Edit')]").click()
-    # driver.find_element_by_link_text("Edit").click()
 
 
 def navigate_to_view_form(driver, live_server, topic, subtopic, measure):


### PR DESCRIPTION
This updates the text on buttons such as "Edit", "Update" and "Delete" to include the page title, eg

> Edit Stop and search

...where the page title is visually-hidden.

This helps provide more context to screen-reader users.

https://trello.com/c/nhSsBCr8/1680-address-ambiguous-links-in-the-publisher-for-edit-delete-etc-button-links-1