### PR TITLE
Set page titles for Chart and Table editors

### DIFF
--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -20,6 +20,9 @@
   </script>
 {% endblock %}
 
+{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} chart – {{ measure_version.title }}: {{ dimension.title }}{% endblock %}
+
+
 {% block content %}
     <div class="govuk-grid-row eff-numbered-sections">
         <div class="govuk-grid-column-full">

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -20,6 +20,8 @@
   </script>
 {% endblock %}
 
+{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} table – {{ measure_version.title }}: {{ dimension.title }}{% endblock %}
+
 {% block content %}
     <div class="govuk-grid-row eff-numbered-sections">
         <div class="govuk-grid-column-full">

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -8,7 +8,7 @@
   ]
 %}
 
-{% block pageTitle %}Edit dimension – {{ measure_version.title }}{% endblock %}
+{% block pageTitle %}Edit dimension – {{ measure_version.title }}: {{ dimension.title }}{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -8,7 +8,7 @@
   ]
 %}
 
-{% block pageTitle %}Edit dimension{% endblock %}
+{% block pageTitle %}Edit dimension – {{ measure_version.title }}{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -86,7 +86,7 @@ class TestDimensionModel:
 
     def test_update_dimension_with_invalid_data(self, test_app_client, logged_in_rdu_user):
 
-        measure_version = MeasureVersionWithDimensionFactory()
+        measure_version = MeasureVersionWithDimensionFactory(title="Stop and search", dimensions__title="By ethnicity")
 
         data = {"title": ""}
 
@@ -102,7 +102,7 @@ class TestDimensionModel:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         assert resp.status_code == 400
-        assert page.find("title").string == "Error: Edit dimension"
+        assert page.find("title").string == "Error: Edit dimension – Stop and search: By ethnicity"
 
     def test_classification_source_string_is_none_if_no_dimension_classification(self):
         measure_version = MeasureVersionWithDimensionFactory(dimensions__classification_links=[])


### PR DESCRIPTION
These pages were missing a descriptive page `<title>`

https://trello.com/c/5oqwyM6A/1683-make-page-title-descriptive-in-create-chart-page