### PR TITLE
Add context to example labels

### DIFF
--- a/application/templates/forms/extended_hints/_description.html
+++ b/application/templates/forms/extended_hints/_description.html
@@ -1,7 +1,11 @@
 {% from "_macros/_details.html" import govukDetails %}
 
+{% set summaryHtml %}
+  Example <span class="govuk-visually-hidden">search engine description</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Example",
+  summaryHtml=summaryHtml,
   text="As at 31 March 2018, 93.4% of police officers were White, and 6.6% came from all other ethnic groups.",
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_dimension_summary.html
+++ b/application/templates/forms/extended_hints/_dimension_summary.html
@@ -9,8 +9,12 @@
   </ul>
 {% endset %}
 
+{% set summaryHtml %}
+  Examples <span class="govuk-visually-hidden">for summary</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Examples",
+  summaryText=summaryHtml,
   html=html,
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_methodology.html
+++ b/application/templates/forms/extended_hints/_methodology.html
@@ -13,8 +13,12 @@
   <p class="govuk-body">Find example wording in the <a href="https://guide.ethnicity-facts-figures.service.gov.uk/a-z" target="_blank" class="govuk-link">style guide</a> (this will open a new page).</p>
 {% endset %}
 
+{% set summaryHtml %}
+  Examples <span class="govuk-visually-hidden">for methodology</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Examples",
+  summaryText=summaryHtml,
   html=html,
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_related_publications.html
+++ b/application/templates/forms/extended_hints/_related_publications.html
@@ -8,8 +8,12 @@
   </ul>
 {% endset %}
 
+{% set summaryHtml %}
+  Examples <span class="govuk-visually-hidden">for related publications</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Example",
+  summaryText=summaryHtml,
   html=html,
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_summary.html
+++ b/application/templates/forms/extended_hints/_summary.html
@@ -9,8 +9,12 @@
   </ul>
 {% endset %}
 
+{% set summaryHtml %}
+  Examples <span class="govuk-visually-hidden">for summary</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Examples",
+  summaryText=summaryHtml,
   html=html,
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_suppression_and_disclosure.html
+++ b/application/templates/forms/extended_hints/_suppression_and_disclosure.html
@@ -1,7 +1,11 @@
 {% from "_macros/_details.html" import govukDetails %}
 
+{% set summaryHtml %}
+  Example <span class="govuk-visually-hidden">suppression rules and disclosure control</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="Examples",
+  summaryText=summaryHtml,
   text="Estimates based on fewer than 30 households have not been included in these statistics, because small numbers of households make it impossible to draw meaningful conclusions.",
   classes="govuk-!-margin-bottom-4"
 ) }}

--- a/application/templates/forms/extended_hints/_things_you_need_to_know.html
+++ b/application/templates/forms/extended_hints/_things_you_need_to_know.html
@@ -10,8 +10,12 @@
   </ul>
 {% endset %}
 
+{% set summaryHtml %}
+  What to include <span class="govuk-visually-hidden">within ‘things you need to know’</span>
+{% endset %}
+
 {{ govukDetails(
-  summaryText="What to include",
+  summaryText=summaryHtml,
   html=html,
   classes="govuk-!-margin-bottom-4"
 ) }}


### PR DESCRIPTION
This adds visually-hidden text adding context to the `<summary>` elements within the Details components that give examples for some of our form fields.

This assists screen readers users, who may hear the text read out out-of-context.

https://trello.com/c/ptiYWWq3/1687-ensure-all-buttons-are-unique-and-descriptive