### PR TITLE
Remove nulls from dimension positions

### DIFF
--- a/scripts/data_migrations/2019-08-29_remove-nulls-from-dimension-positions.sql
+++ b/scripts/data_migrations/2019-08-29_remove-nulls-from-dimension-positions.sql
@@ -1,0 +1,1 @@
+UPDATE dimension SET position = 0 WHERE position IS NULL;


### PR DESCRIPTION
These can cause ordering to break, as Python doesn’t know how to compare a number to `null`.