### PR TITLE
Add basic client-side validation for data source

### DIFF
--- a/application/src/js/chartbuilder/chartbuilder.js
+++ b/application/src/js/chartbuilder/chartbuilder.js
@@ -44,15 +44,34 @@ $(document).ready(function () {
     Events from the DATA ENTRY PANEL
     */
     function setChartData(evt) {
-        handleNewData(function () {
-            if (current_settings) {
-                setupChartbuilderWithSettings(current_settings)
-            }
-            preview()
-        });
-        document.getElementById('data-panel').classList.add('hidden')
-        document.getElementById('edit-panel').classList.remove('hidden')
-        document.getElementById('builder-title').textContent = 'Format and view chart'
+
+        var data_text_area = document.getElementById('data_text_area')
+        var data_error_message = document.getElementById('data-error')
+        var data_form_group = document.getElementById('data-form-group')
+
+        if (data_text_area.value != '') {
+
+            handleNewData(function () {
+                if (current_settings) {
+                    setupChartbuilderWithSettings(current_settings)
+                }
+                preview()
+            });
+            document.getElementById('data-panel').classList.add('hidden')
+            document.getElementById('edit-panel').classList.remove('hidden')
+            document.getElementById('builder-title').textContent = 'Format and view chart'
+
+            data_text_area.classList.remove('govuk-textarea--error')
+            data_form_group.classList.remove('govuk-form-group--error')
+            data_error_message.textContent = ''
+
+        } else {
+            data_text_area.classList.add('govuk-textarea--error')
+            data_form_group.classList.add('govuk-form-group--error')
+            data_error_message.textContent = 'Enter some data'
+        }
+
+
     }
 
     function editChartData(evt) {

--- a/application/src/js/tablebuilder/tablebuilder.js
+++ b/application/src/js/tablebuilder/tablebuilder.js
@@ -74,16 +74,35 @@ document.addEventListener('DOMContentLoaded', function() {
      */
 
     function setTableData(evt) {
-        handleNewData(function () {
-            if (current_settings) {
-                setupTablebuilderWithSettings(current_settings)
-            }
-            preview()
-        });
 
-        document.getElementById('data-panel').classList.add('hidden')
-        document.getElementById('edit-panel').classList.remove('hidden')
-        document.getElementById('builder-title').innerHTML = 'Format and view table';
+        var data_text_area = document.getElementById('data_text_area')
+        var data_error_message = document.getElementById('data-error')
+        var data_form_group = document.getElementById('data-form-group')
+
+        if (data_text_area.value != '') {
+
+            handleNewData(function () {
+                if (current_settings) {
+                    setupTablebuilderWithSettings(current_settings)
+                }
+                preview()
+            });
+
+            document.getElementById('data-panel').classList.add('hidden')
+            document.getElementById('edit-panel').classList.remove('hidden')
+            document.getElementById('builder-title').innerHTML = 'Format and view table';
+
+            data_text_area.classList.remove('govuk-textarea--error')
+            data_form_group.classList.remove('govuk-form-group--error')
+            data_error_message.textContent = ''
+
+        } else {
+            data_text_area.classList.add('govuk-textarea--error')
+            data_form_group.classList.add('govuk-form-group--error')
+            data_error_message.textContent = 'Enter some data'
+        }
+
+
     }
 
     function editTableData(evt) {

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -48,8 +48,12 @@
 
                 <div class="govuk-form-group">
                   <form onsubmit="return false;">
-                          <textarea class="govuk-textarea" id="data_text_area" rows="10"
+
+                        <div class="govuk-form-group" id="data-form-group">
+                            <span id="data-error" class="govuk-error-message"></span>
+                            <textarea class="govuk-textarea" id="data_text_area" rows="10"
                                     {% if form_disabled %}disabled="disabled"{% endif %}></textarea>
+                        </div>
                       <button class="btn govuk-button btn-primary" id="confirm-data">Next</button>
                   </form>
                 </div>

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -48,8 +48,11 @@
 
                 <div class="govuk-form-group">
                   <form onsubmit="return false;">
+                      <div class="govuk-form-group" id="data-form-group">
+                          <span id="data-error" class="govuk-error-message"></span>
                           <textarea class="govuk-textarea" id="data_text_area" rows="10"
                                     {% if form_disabled %}disabled="disabled"{% endif %}></textarea>
+                      </div>
                       <button type="button" class="govuk-button" id="confirm-data">Next</button>
                   </form>
                 </div>


### PR DESCRIPTION
Show an error if you try to create a chart or table without first entering some data:

<img width="1012" alt="Screenshot 2019-08-30 at 11 51 31" src="https://user-images.githubusercontent.com/30665/64015477-89a00800-cb1c-11e9-9462-a7ccf8fe93b4.png">

This is a bit of a short-term fix, pending a rewrite of this code to use a server-side round-trip and server-side validation.

Fixes https://trello.com/c/KNnidAFq/1684-error-validation-missing-when-creating-a-table-in-the-publisher-2