### PR TITLE
Upgrade govuk-frontend

### DIFF
--- a/application/src/sass/_overrides.scss
+++ b/application/src/sass/_overrides.scss
@@ -16,7 +16,7 @@ Naming convention follows https://design-system.service.gov.uk/styles/spacing/
 }
 
 .eff-\!-grey-1 {
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -4,7 +4,7 @@
 $govuk-assets-path: '/static/assets/';
 
 /* GOV.UK Frontend, for the Design System. Installed via npm */
-@import "node_modules/govuk-frontend/all";
+@import "node_modules/govuk-frontend/govuk/all";
 
 /* Components unique to our service */
 @import 'components/back_to_top';

--- a/application/src/sass/components/_back_to_top.scss
+++ b/application/src/sass/components/_back_to_top.scss
@@ -15,7 +15,7 @@
   margin: 0;
   padding: 0;
   width: 100%;
-  background-color: govuk-colour("grey-3");
+  background-color: govuk-colour("light-grey");
   z-index: 1;
 }
 

--- a/application/src/sass/components/_badge.scss
+++ b/application/src/sass/components/_badge.scss
@@ -1,5 +1,5 @@
 .eff-badge {
-  background-color: govuk-colour("grey-1");
+  background-color: govuk-colour("dark-grey");
   color: govuk-colour("white");
   padding: 2px 6px;
 }

--- a/application/src/sass/components/_buttons.scss
+++ b/application/src/sass/components/_buttons.scss
@@ -35,7 +35,7 @@ $govuk-button-delete-shadow-colour: mix($black, $govuk-error-colour, 50%);
    Borrowed from https://github.com/UKGovernmentBEIS/beis-mspsds/blob/master/mspsds-web/app/assets/application/stylesheets/buttons.scss
 */
 $black: #000000;
-$eff-button-neutral-colour: govuk-colour("grey-3");
+$eff-button-neutral-colour: govuk-colour("light-grey");
 $eff-button-neutral-hover-colour: mix($black, $eff-button-neutral-colour, 15%);
 $eff-button-neutral-shadow-colour: mix($black, $eff-button-neutral-colour, 50%);
 
@@ -68,7 +68,7 @@ $eff-button-neutral-shadow-colour: mix($black, $eff-button-neutral-colour, 50%);
    Adapted from styles at https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_button.scss#L69-L99
 */
 $black: #000000;
-$eff-quiet-button-colour: govuk-colour("grey-1");
+$eff-quiet-button-colour: govuk-colour("dark-grey");
 $eff-quiet-button-hover-colour: mix($black, $eff-quiet-button-colour, 15%);
 
 

--- a/application/src/sass/components/_flash_message.scss
+++ b/application/src/sass/components/_flash_message.scss
@@ -1,11 +1,11 @@
 // Minimal adapted copy of the GOV.UK Frontend error-summary component:
 // https://github.com/alphagov/govuk-frontend/blob/master/src/components/error-summary/_error-summary.scss
 
-@import "node_modules/govuk-frontend/settings/all";
-@import "node_modules/govuk-frontend/tools/all";
-@import "node_modules/govuk-frontend/helpers/all";
+@import "node_modules/govuk-frontend/govuk/settings/all";
+@import "node_modules/govuk-frontend/govuk/tools/all";
+@import "node_modules/govuk-frontend/govuk/helpers/all";
 
-@import "node_modules/govuk-frontend/core/lists";
+@import "node_modules/govuk-frontend/govuk/core/lists";
 
 $eff-flash-colour: #00833F;
 $eff-flash-error-colour: govuk-colour('red');
@@ -14,17 +14,20 @@ $eff-flash-error-colour: govuk-colour('red');
   @include govuk-text-colour;
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(8, "bottom");
-  @include govuk-focusable;
 
-  border: $govuk-border-width-mobile solid $eff-flash-colour;
+  border: $govuk-border-width-narrow solid $eff-flash-colour;
 
   @include govuk-media-query($from: tablet) {
     border: $govuk-border-width solid $eff-flash-colour;
   }
 }
 
+.eff-flash-message:focus {
+  @include govuk-focused-text;
+}
+
 .eff-flash-message--error {
-  border: $govuk-border-width-mobile solid $eff-flash-error-colour;
+  border: $govuk-border-width-narrow solid $eff-flash-error-colour;
 
   @include govuk-media-query($from: tablet) {
     border: $govuk-border-width solid $eff-flash-error-colour;

--- a/application/src/sass/components/_list.scss
+++ b/application/src/sass/components/_list.scss
@@ -2,7 +2,7 @@
  */
 
 .eff-list--hint {
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 .eff-list--sparse > li {

--- a/application/src/sass/components/_missing_data_explanation.scss
+++ b/application/src/sass/components/_missing_data_explanation.scss
@@ -5,7 +5,7 @@
 .missing-data-explanation,
 .missing-data-explanation {
   @include govuk-font(16);
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 .missing-data-explanation .explanation {
@@ -15,7 +15,7 @@
 
 /* Used for showing N/A in tables */
 .not-applicable {
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 /* Asterisk – positioned as inline-block with negative margin

--- a/application/src/sass/components/_table.scss
+++ b/application/src/sass/components/_table.scss
@@ -128,7 +128,7 @@
 
 .table-footer .missing-data-explanation,
 .chart-footer .missing-data-explanation {
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 .missing-data-explanation .explanation {
@@ -138,7 +138,7 @@
 
 /* Used for showing N/A in tables */
 .not-applicable {
-  color: govuk-colour("grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 
@@ -180,7 +180,7 @@
     right: 10px;
     font-size: 19px;
     font-weight: bold;
-    color: govuk-colour("grey-1");
+    color: govuk-colour("dark-grey");
   }
 
   tbody .week.empty td:last-child:after {

--- a/application/templates/_macros/_accordion.html
+++ b/application/templates/_macros/_accordion.html
@@ -3,7 +3,7 @@
 
   {% set headingLevel = headingLevel | default(2) %}
 
-  <div class="govuk-accordion {%- if classes %} {{ classes }}{% endif %}" data-module="accordion" {%- if id %} id="{{id}}"{% endif %} {{ attributes | html_params | safe }}>
+  <div class="govuk-accordion {%- if classes %} {{ classes }}{% endif %}" data-module="govuk-accordion" {%- if id %} id="{{id}}"{% endif %} {{ attributes | html_params | safe }}>
 
     {% for item in items %}
 

--- a/application/templates/_macros/_details.html
+++ b/application/templates/_macros/_details.html
@@ -1,6 +1,6 @@
-{# Adapted from https://github.com/alphagov/govuk-frontend/blob/master/src/components/details/template.njk #}
+{# Adapted from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/details/template.njk #}
 {% macro govukDetails(summaryHtml=None,summaryText=None,text=None,html=None,id=None,attributes={},open=False,classes=None) %}
-  <details {%- if id %} id="{{id}}"{% endif %} class="govuk-details {%- if classes %} {{ classes }}{% endif %}" {{ attributes | html_params | safe }} {{- " open" if open else "" }}>
+  <details {%- if id %} id="{{id}}"{% endif %} class="govuk-details {%- if classes %} {{ classes }}{% endif %}" data-module="govuk-details" {{ attributes | html_params | safe }} {{- " open" if open else "" }}>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       {{ summaryHtml if summaryHtml else summaryText }}

--- a/application/templates/forms/_form_group.html
+++ b/application/templates/forms/_form_group.html
@@ -17,7 +17,7 @@
     <span class="govuk-hint">{{ field.hint or hint }}</span>
     {% endif %}
       <div class="{{ govukBaseClass }}{% if inline %} {{ govukBaseClass }}--inline{% endif %}{% if conditional_questions %} {{ govukBaseClass }}--conditional{% endif %}"
-           {% if conditional_questions %} data-module="{{ baseFieldType }}"{% endif %}
+           {% if conditional_questions %} data-module="govuk-{{ baseFieldType }}"{% endif %}
       >
         {% for subfield in fields %}
             {% set field_options = {"disabled": disabled, "class_": field_class, "label_class": label_class} %}

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -31,7 +31,7 @@
 
             <div class="govuk-grid-column-two-thirds">
 
-                <div class="govuk-accordion" data-module="accordion" id="accordion-{{ topic.slug }}">
+                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-{{ topic.slug }}">
                         {% for subtopic in (subtopics|selectattr('has_published_measures') if static_mode else subtopics) %}
                             {% if measures_by_subtopic[subtopic.id]|length > 0 or (current_user.is_authenticated and current_user.can(CREATE_MEASURE)) %}
                                 <div class="govuk-accordion__section">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ gulp.task('copy-static', function () {
 
 // Copy assets from GOV.UK Frontend
 gulp.task('copy-govuk-frontend-assets', function () {
-  return gulp.src(['./node_modules/govuk-frontend/assets/**'])
+  return gulp.src(['./node_modules/govuk-frontend/govuk/assets/**'])
     .pipe(gulp.dest('./application/static/assets'))
 })
 
@@ -32,7 +32,7 @@ gulp.task('compile-css', function () {
 
 gulp.task('compile-js-all', function () {
   return gulp.src([
-    './node_modules/govuk-frontend/all.js',
+    './node_modules/govuk-frontend/govuk/all.js',
     './application/src/js/all/vendor/jquery.min.js',
     './application/src/js/all/vendor/polyfills/*.js',
     './application/src/js/all/vendor/govuk-template.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,9 +2244,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
-      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.1.0.tgz",
+      "integrity": "sha512-ozyG6ulmawzg3rsf9Efxcgj81mk4yzea3tfl0hgmXWILGC0/uEGj6A+g9pJ2ETgk78rgNlRLXDv0WvlaHd/LnA=="
     },
     "graceful-fs": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "govuk-frontend": "^2.13.0",
+    "govuk-frontend": "^3.1.0",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-if": "^3.0.0",


### PR DESCRIPTION
This updates govuk-frontend from 2.13.0 to 3.1.0.

See release notes:

* [3.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0) – update to colours and focus styles, amongst other features
* [3.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.1.0) – accessibility improvements and fixes.

See background blog posts:

* [We’ve updated the GOV.UK colours and font](https://designnotes.blog.gov.uk/2019/07/29/weve-updated-the-gov-uk-colours-and-font/)
* [We’ve made the GOV.UK Design System more accessible](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/)