### PR TITLE
Add aria-describedby attributes

### DIFF
--- a/application/templates/forms/_text_input.html
+++ b/application/templates/forms/_text_input.html
@@ -9,7 +9,7 @@
 {{ field.label(id=field.id + '-label', class_='govuk-label ' + label_class) }}
 
 {% if field.hint or hint | default(false) %}
-  <span class="govuk-hint">{{ field.hint or hint }}</span>
+  <span class="govuk-hint" id="{{ id_ }}-hint">{{ field.hint or hint }}</span>
 {% endif %}
 
 {% if field.errors %}
@@ -32,9 +32,9 @@
 {{ field.extended_hint if field.extended_hint is defined and field.extended_hint else '' }}
 
 {% if textarea %}
-  <textarea id="{{ id_ }}" name="{{ name }}" class="govuk-textarea {{ class_ }}{% if field.errors %} govuk-textarea--error{% endif %}{% if field.character_count_limit %} js-character-count{% endif %}" {{ field_params }}>{{ value or "" }}</textarea>
+  <textarea id="{{ id_ }}" name="{{ name }}" class="govuk-textarea {{ class_ }}{% if field.errors %} govuk-textarea--error{% endif %}{% if field.character_count_limit %} js-character-count{% endif %}" {% if field.hint or hint | default(false) %}aria-describedby="{{ id_ }}-hint"{% endif %} {{ field_params }} >{{ value or "" }}</textarea>
 {% else %}
-  <input id="{{ id_ }}" name="{{ name }}" class="govuk-input {{ class_ }}{% if field.errors %} govuk-input--error{% endif %}" value="{{ value }}" {{ field_params }}>
+  <input id="{{ id_ }}" name="{{ name }}" class="govuk-input {{ class_ }}{% if field.errors %} govuk-input--error{% endif %}" value="{{ value }}" {% if field.hint or hint | default(false) %}aria-describedby="{{ id_ }}-hint"{% endif %} {{ field_params }}>
 {% endif %}
 
 {% if field.character_count_limit %}


### PR DESCRIPTION
This helps to associate hint text with the fields for users of assistive technology.

Fixes https://trello.com/c/oo8n1Tvx/1697-aria-describedby