### PR TITLE
Update homepage title tag

### DIFF
--- a/application/templates/static_site/index.html
+++ b/application/templates/static_site/index.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs = none %}
 
-{% block pageTitle %}GOV.UK Ethnicity facts and figures{% endblock %}
+{% block pageTitle %}Ethnicity facts and figures – GOV.UK{% endblock %}
 {% block socialTitle %}Ethnicity facts and figures{% endblock %}
 {% block googleAnalytics %}ga('set','contentGroup1','Home');{% endblock %}
 


### PR DESCRIPTION
This changes the homepage title tag from

> GOV.UK Ethnicity facts and figures

to

> Ethnicity facts and figures – GOV.UK

This is based on feedback from our accessibility audit which said:

> I found that the page title was not front loaded since company information was displayed before the purpose of the page was described. For the benefit of users navigating multiple tabs it would be helpful if the purpose of the page were presented first.