### PR TITLE
Add visually-hidden text to make link clearer

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -657,7 +657,7 @@
                             topic_slug=topic_slug,
                             subtopic_slug=subtopic_slug,
                             measure_slug=page_version.measure.slug,
-                            version=page_version.version) }}">{{ page_version.published_at|format_friendly_date }}</a>
+                            version=page_version.version) }}"><span class="govuk-visually-hidden">Edition published on </span>{{ page_version.published_at|format_friendly_date }}</a>
                     </li>
                 {% endfor %}
               </ol>

--- a/tests/application/static_site/test_views.py
+++ b/tests/application/static_site/test_views.py
@@ -916,7 +916,7 @@ class TestMeasurePage:
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
         measure_1_1_links = page.find_all("a", attrs={"href": measure_1_1_url})
         assert len(measure_1_1_links) == 1
-        assert measure_1_1_links[0].text == "29 March 2019"
+        assert measure_1_1_links[0].text == "Edition published on 29 March 2019"
 
         # AND should not contain a link to the superseded earlier version
         measure_1_0_links = page.find_all("a", attrs={"href": measure_1_0_url})


### PR DESCRIPTION
This updates the links to previous editions from:

> Previous edition:
> [2 March 2018]

to

> Previous edition:
> [{Edition published on} 2 March 2018]

...where the text in `{}` is visually-hidden, and so only used by screen readers.

This allows the links to make sense when read out of of context.