### PR TITLE
Pentest adding security headers and testing

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -268,6 +268,7 @@ def harden_app(response):
     response.headers.add(
         "Content-Security-Policy", get_content_security_policy(allow_google_custom_search=allow_google_custom_search)
     )
+    response.headers.add("X-Permitted-Cross-Domain-Policies", "none")
 
     return response
 

--- a/tests/application/test_factory.py
+++ b/tests/application/test_factory.py
@@ -1,4 +1,5 @@
 from flask import render_template_string
+from werkzeug.test import EnvironBuilder, run_wsgi_app
 
 
 class TestTemplateGlobals:
@@ -17,3 +18,16 @@ class TestTemplateGlobals:
 
         assert client.get("/test-globals?static_mode=no").get_data(as_text=True) == "False"
         assert client.get("/test-globals?static_mode=yes").get_data(as_text=True) == "True"
+
+
+class TestHeaders:
+    def test_http_headers(self, single_use_app):
+        builder = EnvironBuilder(path="/", method="GET")
+        env = builder.get_environ()
+
+        (app_iter, status, headers) = run_wsgi_app(single_use_app, env)
+        assert headers.get("X-Frame-Options") == "deny"
+        assert headers.get("X-Content-Type-Options") == "nosniff"
+        assert headers.get("X-XSS-Protection") == "1; mode=block"
+        assert headers.get("X-Permitted-Cross-Domain-Policies") == "none"
+        assert headers.get("Content-Security-Policy")


### PR DESCRIPTION
https://trello.com/c/v44ObDqp/1831-implement-missing-security-headers
https://trello.com/c/C0Nx1IqN/1830-use-strict-transport-security-header-and-preload

The following headers were added:
```
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000 ; includeSubDomains;
Content-Security-Policy: frame-ancestors 'none'
X-Permitted-Cross-Domain-Policies: none
```
