### PR TITLE
Javascript links in Markdown sanitised

### DIFF
--- a/application/cms/markdown.py
+++ b/application/cms/markdown.py
@@ -21,7 +21,7 @@ class DesignSystemMarkdownProcessor(Treeprocessor):
 class MarkdownCleanerProcessor(Treeprocessor):
     def run(self, root):
         for a in root.iter("a"):
-            if "javascript" in a.get("href"):
+            if "javascript:" in a.get("href"):
                 a.set("href", "#")
 
 

--- a/application/cms/markdown.py
+++ b/application/cms/markdown.py
@@ -18,9 +18,17 @@ class DesignSystemMarkdownProcessor(Treeprocessor):
             ol.set("class", "govuk-list govuk-list--number eff-list--sparse")
 
 
+class MarkdownCleanerProcessor(Treeprocessor):
+    def run(self, root):
+        for a in root.iter("a"):
+            if "javascript" in a.get("href"):
+                a.set("href", "#")
+
+
 class DesignSystemMarkdownExtension(Extension):
     def extendMarkdown(self, md):
         md.treeprocessors.register(item=DesignSystemMarkdownProcessor(md), name="design-system-markdown", priority=0)
+        md.treeprocessors.register(item=MarkdownCleanerProcessor(md), name="cleaner-markdown", priority=0)
 
 
 def markdown(text):

--- a/tests/application/static_site/test_filters.py
+++ b/tests/application/static_site/test_filters.py
@@ -23,6 +23,18 @@ class TestRenderMarkdown:
     def test_html_is_escaped(self, input_text, expected_output):
         assert render_markdown(input_text) == expected_output
 
+    @pytest.mark.parametrize(
+        "input_text, expected_output",
+        (
+            (
+                "[text to display](javascript:alert(1))",
+                '<p class="govuk-body"><a class="govuk-link" href="#">text to display</a></p>',
+            ),
+        ),
+    )
+    def test_js_links_stripped(self, input_text, expected_output):
+        assert render_markdown(input_text) == expected_output
+
 
 class TestHtmlParams:
     """

--- a/tests/application/static_site/test_filters.py
+++ b/tests/application/static_site/test_filters.py
@@ -30,6 +30,14 @@ class TestRenderMarkdown:
                 "[text to display](javascript:alert(1))",
                 '<p class="govuk-body"><a class="govuk-link" href="#">text to display</a></p>',
             ),
+            (
+                "[text to display](https://gov.uk)",
+                '<p class="govuk-body"><a class="govuk-link" href="https://gov.uk">text to display</a></p>',
+            ),
+            (
+                "[text to display](https://javascript.co.uk)",
+                '<p class="govuk-body"><a class="govuk-link" href="https://javascript.co.uk">text to display</a></p>',
+            ),
         ),
     )
     def test_js_links_stripped(self, input_text, expected_output):


### PR DESCRIPTION
In Markdown, if a malicious user adds a JavaScript link, we replace it with a
`#` from now on