### PR TITLE
Survey copy updated for accessibility

### DIFF
--- a/application/templates/_shared/_phase_banner.html
+++ b/application/templates/_shared/_phase_banner.html
@@ -4,7 +4,7 @@
     <div class="{% if reversed%}eff-phase-banner{% else %}govuk-phase-banner{% endif %}">
       <p class="{% if reversed%}eff-phase-banner__content{% else %}govuk-phase-banner__content{% endif %}">
         {% if config.SURVEY_ENABLED %}
-          <span>Help us improve this website – <a class="govuk-link" href="https://www.surveymonkey.co.uk/r/B2CBF6Z" data-on="click" data-event-category="Survey" data-event-action="Link clicked" data-event-label="Page header">answer 4 short questions</a>.</span>
+          <span>Answer 4 short questions to <a class="govuk-link" href="https://www.surveymonkey.co.uk/r/B2CBF6Z" data-on="click" data-event-category="Survey" data-event-action="Link clicked" data-event-label="Page header">help us improve this website</a>.</span>
         {% else %}
           <span>This is a new service – please send your feedback to <a class="govuk-link" data-on="click" data-event-category="E-mail link clicked" data-event-action="Contact e-mail" data-event-label="Header" href="mailto:ethnicity@cabinetoffice.gov.uk">ethnicity@cabinetoffice.gov.uk</a></span>
         {% endif %}


### PR DESCRIPTION
The previous copy only had 'answer 4 short questions' out of context and it
didn't make sense for screenreader users. We updated the copy and made the link
text 'help us improve this website'.