### PR TITLE
Fix contrast ratio on legends

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -104,7 +104,10 @@ function barchartHighchartObject(chartObject) {
             enabled: false
         },
         legend: {
-            enabled: (chartObject.series.length > 1)
+            enabled: (chartObject.series.length > 1),
+            itemHiddenStyle: {
+                color: '#767676'
+            }
         },
         plotOptions: {
             bar: {
@@ -275,7 +278,10 @@ function componentChart(container_id, chartObject) {
             max: 100
         },
         legend: {
-            reversed: true
+            reversed: true,
+            itemHiddenStyle: {
+                color: '#767676'
+            }
         },
         plotOptions: {
             series: {
@@ -436,7 +442,10 @@ function smallBarchart(container_id, chartObject, max) {
                 enabled: false
             },
             legend: {
-                enabled: (chartObject.series.length > 1)
+                enabled: (chartObject.series.length > 1),
+                itemHiddenStyle: {
+                    color: '#767676'
+                }
             },
             plotOptions: {
                 bar: {
@@ -597,7 +606,10 @@ function smallLinechart(container_id, chartObject, max, min) {
             useHTML: true
         },
         legend: {
-            enabled: false
+            enabled: false,
+            itemHiddenStyle: {
+                color: '#767676'
+            }
         },
         xAxis: {
             categories: chartObject.xAxis.categories,


### PR DESCRIPTION
Applied grey colour with  4.5:1 ratio (minimal for AAA)

**Before:**
<img width="1128" alt="Screenshot 2020-02-26 at 17 33 41" src="https://user-images.githubusercontent.com/6704411/75372590-ae551c80-58c0-11ea-8daf-b8f8c201160c.png">

**After:**
<img width="1061" alt="Screenshot 2020-02-26 at 17 52 04" src="https://user-images.githubusercontent.com/6704411/75372645-bc0aa200-58c0-11ea-8a11-8dd8b09411a3.png">

