### PR TITLE
Update warning guidance when deleting a draft version of a measure

### DIFF
--- a/application/templates/cms/delete_page.html
+++ b/application/templates/cms/delete_page.html
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
         Delete
-        ‘{{ measure_version.title }}’?
+        ‘{{ measure_version.title }}’ draft version {{ measure_version.version }}?
       </h1>
 
       <form method="POST" action="{{ url_for('cms.delete_measure_version', topic_slug=topic.slug, subtopic_slug=subtopic.slug, measure_slug=measure_version.measure.slug, version=measure_version.version) }}">

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ black==18.9b0         # Automatic code formatting (must also update `.pre-commit
 coverage==4.5.1       # Required by pytest-cov
 coveralls==1.5.1
 factory-boy==2.11.1
-Faker==0.9.2
+Faker==4.0.2
 flake8==3.6.0
 glob2==0.6
 pluggy==0.6.0         # Required by pytest


### PR DESCRIPTION
**Before:**
<img width="585" alt="Screenshot 2020-03-16 at 13 42 24" src="https://user-images.githubusercontent.com/6704411/76764081-2d38c900-678c-11ea-9f99-523e876793a6.png">

**After:**
<img width="559" alt="Screenshot 2020-03-16 at 13 42 06" src="https://user-images.githubusercontent.com/6704411/76764037-172b0880-678c-11ea-86b3-6fcb07e44b6c.png">
