### PR TITLE
Use latest highcharts version

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -91,6 +91,7 @@ function barchartHighchartObject(chartObject) {
         text: chartObject.xAxis.title.text
       },
       labels: {
+        staggerLines: 1,
         autoRotation: 'off',
         style: { color: 'black' },
         overflow: 'justify',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,10 +50,10 @@ gulp.task('compile-js-charts', function (cb) {
   pump([
     gulp.src([
       './application/src/js/charts/vendor/underscore-min.js',
-      './application/src/js/charts/vendor/highcharts/v5/highcharts.js',
-      './application/src/js/charts/vendor/highcharts/v5/exporting.js',
-      './application/src/js/charts/vendor/highcharts/v5/export-data.js',
-      './application/src/js/charts/vendor/highcharts/v5/accessibility.js',
+      './application/src/js/charts/vendor/highcharts/v8/highcharts.js',
+      './application/src/js/charts/vendor/highcharts/v8/exporting.js',
+      './application/src/js/charts/vendor/highcharts/v8/export-data.js',
+      './application/src/js/charts/vendor/highcharts/v8/accessibility.js',
       './application/src/js/charts/rd-graph.js',
       './application/src/js/charts/rd-data-tools.js'
     ]),


### PR DESCRIPTION
**Relates to:** https://trello.com/c/5eRqr8gi/1740-fix-when-voiceover-reads-table-it-reads-black-and-caribbean-as-two-separate-words-because-its-split-over-2-lines