### PR TITLE
Bring back the old series dimming behavior

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -160,6 +160,9 @@ function barchartHighchartObject(chartObject) {
         states: {
           hover: {
             enabled: false
+          },
+          inactive: {
+            opacity: 1
           }
         }
       }
@@ -548,6 +551,9 @@ function smallBarchart(container_id, chartObject, max) {
         states: {
           hover: {
             enabled: false
+          },
+          inactive: {
+            opacity: 1
           }
         }
       }


### PR DESCRIPTION
Highcharts introduced dimming behaviour on version "Highcharts Basic v7.1.0 (2019-04-01)" and a setting to bring back the old series dimming behavior.

@see https://www.highcharts.com/blog/changelog/