### PR TITLE
Fix Non-descriptive-headings and back home link

### DIFF
--- a/application/templates/_shared/_breadcrumb.html
+++ b/application/templates/_shared/_breadcrumb.html
@@ -1,25 +1,38 @@
 {% macro render_breadcrumbs(breadcrumbs) %}
-  {% if breadcrumbs is not defined or breadcrumbs %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
+{% if breadcrumbs is not defined or breadcrumbs %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
 
-        <div id="breadcrumb" class="govuk-breadcrumbs">
-          <ol class="govuk-breadcrumbs__list">
-            {% if breadcrumbs is defined %}
-              {% for breadcrumb in breadcrumbs %}
-              <li class="govuk-breadcrumbs__list-item">
-                  <a class="govuk-breadcrumbs__link" href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
-              </li>
-              {% endfor %}
-            {% else %}
-            <li>
-              <a class="govuk-breadcrumbs__list-item" href="{{ url_for('static_site.index') }}">Ethnicity facts and figures</a>
-            </li>
-            {% endif %}
-          </ol>
-        </div>
+    <div id="breadcrumb"
+         class="govuk-breadcrumbs">
+      <ol class="govuk-breadcrumbs__list">
+        {% if breadcrumbs is defined %}
+        {% for breadcrumb in breadcrumbs %}
+        <li class="govuk-breadcrumbs__list-item">
 
-      </div>
+          {% if breadcrumb.text == "Home" %}
+          <a class="govuk-breadcrumbs__link"
+             href="{{ breadcrumb.url }}">
+             <span class="sr-only">Ethnicity facts and figures homepage</span> Home
+          </a>
+          {% else %}
+          <a class="govuk-breadcrumbs__link"
+             href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
+          {% endif %}
+        </li>
+        {% endfor %}
+        {% else %}
+        <li>
+          <a class="govuk-breadcrumbs__list-item"
+             href="{{ url_for('static_site.index') }}">
+            <span class="sr-only">Ethnicity facts and figures homepage</span> Home
+          </a>
+        </li>
+        {% endif %}
+      </ol>
     </div>
-  {% endif %}
+
+  </div>
+</div>
+{% endif %}
 {% endmacro %}

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('admin.index'), "text": "Admin"},
     {"url": url_for('admin.users'), "text": "Users"},
   ]

--- a/application/templates/admin/data_sources.html
+++ b/application/templates/admin/data_sources.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('admin.index'), "text": "Admin"},
   ]
 %}

--- a/application/templates/admin/index.html
+++ b/application/templates/admin/index.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/admin/merge_data_sources.html
+++ b/application/templates/admin/merge_data_sources.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('admin.index'), "text": "Admin"}
   ]
 %}

--- a/application/templates/admin/site_build.html
+++ b/application/templates/admin/site_build.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for("admin.index"), "text": "Admin"},
   ]
 %}

--- a/application/templates/admin/user.html
+++ b/application/templates/admin/user.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('admin.index'), "text": "Admin"},
     {"url": url_for('admin.users'), "text": "Users"},
   ]

--- a/application/templates/admin/users.html
+++ b/application/templates/admin/users.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('admin.index'), "text": "Admin"},
   ]
 %}

--- a/application/templates/cms/measure_versions.html
+++ b/application/templates/cms/measure_versions.html
@@ -4,7 +4,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('static_site.topic', topic_slug=topic.slug), "text": topic.title},
   ]
 %}

--- a/application/templates/dashboards/ethnic_group.html
+++ b/application/templates/dashboards/ethnic_group.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
     {"url": url_for('dashboards.ethnic_groups'), "text": "Ethnic groups"},
   ]

--- a/application/templates/dashboards/ethnic_groups.html
+++ b/application/templates/dashboards/ethnic_groups.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/dashboards/ethnicity_classification.html
+++ b/application/templates/dashboards/ethnicity_classification.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index').rstrip('/'), "text": "Dashboards"},
     {"url": url_for('dashboards.ethnicity_classifications'), "text": "Ethnicity classifications"},
   ]

--- a/application/templates/dashboards/ethnicity_classifications.html
+++ b/application/templates/dashboards/ethnicity_classifications.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index').rstrip('/'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/dashboards/geographic-breakdown.html
+++ b/application/templates/dashboards/geographic-breakdown.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/dashboards/index.html
+++ b/application/templates/dashboards/index.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/dashboards/lowest-level-of-geography.html
+++ b/application/templates/dashboards/lowest-level-of-geography.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
     {"url": url_for('dashboards.locations'), "text": "Geographic areas"},
   ]

--- a/application/templates/dashboards/measures.html
+++ b/application/templates/dashboards/measures.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/dashboards/planned_pages.html
+++ b/application/templates/dashboards/planned_pages.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -3,7 +3,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/dashboards/whats_new.html
+++ b/application/templates/dashboards/whats_new.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for('dashboards.index'), "text": "Dashboards"},
   ]
 %}

--- a/application/templates/static_site/corrections.html
+++ b/application/templates/static_site/corrections.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -5,7 +5,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
     {"url": url_for("static_site.topic", topic_slug=topic_slug), "text": measure_version.measure.subtopic.topic.title},
   ]
   if preview | default(true) else
@@ -340,7 +340,7 @@
 
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
-                  <h3 class="govuk-heading-s">Summary</h3>
+                  <h3 class="govuk-heading-s"><span class="sr-only">Summary of {{ measure_version.title }} {{dimension.title}} </span> Summary </h3>
                   <div class="govuk-!-margin-bottom-8 eff-summary--with-bullets-spaced-out">
                     {{ dimension.summary | render_markdown }}
                   </div>

--- a/application/templates/static_site/static_pages/background.html
+++ b/application/templates/static_site/static_pages/background.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 
@@ -27,11 +27,11 @@
       Former Prime Minister Theresa May <a class="govuk-link" href="https://www.gov.uk/government/news/prime-minister-orders-government-audit-to-tackle-racial-disparities-in-public-service-outcomes" data-on="click" data-event-category="External link clicked" data-event-action="Background link" data-event-label="Prime Minister announcement">announced the Race Disparity Audit</a> in August 2016.</p>
 
       <p class="govuk-body">The aim of the project was to gather and publish data collected by government about the different experiences of the UK’s ethnic groups.</p>
-      
+
        <p class="govuk-body">The <a class="govuk-link" href="https://www.gov.uk/government/publications/race-disparity-audit" data-on="click" data-event-category="External link clicked" data-event-action="Background link" data-event-label="Race Disparity Audit page">Race Disparity Audit</a> was published in October 2017. Data from the audit is continually updated on the <a class="govuk-link" href="https://www.ethnicity-facts-figures.service.gov.uk/" data-on="click" data-event-category="External link clicked" data-event-action="Background link" data-event-label="Ethnicity facts and figures">Ethnicity facts and figures</a> website.</p>
 
       <p class="govuk-body">Below, we explain:</p>
-      
+
       <ul class="govuk-list govuk-list--bullet">
         <li>who our users are</li>
         <li>how the project was carried out</li>

--- a/application/templates/static_site/static_pages/cookies.html
+++ b/application/templates/static_site/static_pages/cookies.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/static_pages/ethnic_groups.html
+++ b/application/templates/static_site/static_pages/ethnic_groups.html
@@ -4,7 +4,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 
@@ -23,7 +23,7 @@
       </h1>
 
       <div class="govuk-inset-text">If you’re in a government service team, there’s a design pattern for <a href="https://design-system.service.gov.uk/patterns/ethnic-group/">asking users for their ethnic group</a>.</div>
-      
+
       <p class="govuk-body">In England and Wales, there are 18 ethnic groups recommended for use by government when they ask for someone’s ethnicity. These are grouped into 5 broad ethnic groups, each with an ‘Any other’ option where respondents can write in their ethnicity using their own words.</p>
 
       <p class="govuk-body">The recommended ethnic groups are:</p>

--- a/application/templates/static_site/static_pages/ethnicity_in_the_uk/ethnic_groups_by_sexual_identity.html
+++ b/application/templates/static_site/static_pages/ethnicity_in_the_uk/ethnic_groups_by_sexual_identity.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"}
+    {"url": url_for("static_site.index"), "text": "Home"}
   ]
 %}
 

--- a/application/templates/static_site/static_pages/privacy-policy.html
+++ b/application/templates/static_site/static_pages/privacy-policy.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/static_pages/search.html
+++ b/application/templates/static_site/static_pages/search.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/static_pages/understanding_our_data.html
+++ b/application/templates/static_site/static_pages/understanding_our_data.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/static_pages/understanding_our_data/how_to_read_survey_data.html
+++ b/application/templates/static_site/static_pages/understanding_our_data/how_to_read_survey_data.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
+    {"url": url_for("static_site.index"), "text": "Home"},
   ]
 %}
 

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -22,7 +22,7 @@ class FooterLinkLocators:
 
 
 class PageLinkLocators:
-    HOME_BREADCRUMB = (By.LINK_TEXT, "Ethnicity facts and figures")
+    HOME_BREADCRUMB = (By.LINK_TEXT, "Home")
     NEW_MEASURE = (By.LINK_TEXT, "Add a measure")
 
     @staticmethod


### PR DESCRIPTION
**Resolves:**  
- https://trello.com/c/cOnUGUHK/1698-summary-headings-arent-currently-descriptive-1
- https://trello.com/c/SeKclda4/1743-explore-how-to-help-users-navigate-back-to-the-ethnicity-facts-and-figures-homepage

**Before:**
<img width="464" alt="Screenshot 2020-04-03 at 14 04 32" src="https://user-images.githubusercontent.com/6704411/78365026-60fe5600-75b6-11ea-8565-0838353b0a5b.png">
**After:**
<img width="347" alt="Screenshot 2020-04-03 at 14 04 18" src="https://user-images.githubusercontent.com/6704411/78365067-6fe50880-75b6-11ea-9493-53f36e1f819f.png">
<img width="792" alt="Screenshot 2020-04-03 at 14 18 34" src="https://user-images.githubusercontent.com/6704411/78365071-72476280-75b6-11ea-8a7f-4805f2f28742.png">
