### PR TITLE
Fix issue with decimal numbers on charts

### DIFF
--- a/application/src/js/charts/rd-graph.js
+++ b/application/src/js/charts/rd-graph.js
@@ -330,12 +330,16 @@ function componentChart(container_id, chartObject) {
 }
 
 function componentChartTooltip(chartObject) {
+  // in components manually set decimal places to be equal 2 if not set
+  // @see https://trello.com/c/VyspZX5I/1741-when-you-hover-over-some-charts-the-figures-that-appear-have-6-decimal-places-after-them
+  var decimalPlaces = chartObject.decimalPlaces ? chartObject.decimalPlaces : 2;
+
   if (chartObject.series.length > 1) {
     return {
       pointFormat:
         '<span style="color:{point.color}">\u25CF</span> {series.name}: <b>' +
         chartObject.number_format.prefix +
-        decimalPointFormat('point.y', chartObject.decimalPlaces) +
+        decimalPointFormat('point.y', decimalPlaces) +
         chartObject.number_format.suffix +
         '</b><br/>'
     };
@@ -344,7 +348,7 @@ function componentChartTooltip(chartObject) {
       pointFormat:
         '<span style="color:{point.color}">\u25CF</span><b>' +
         chartObject.number_format.prefix +
-        decimalPointFormat('point.y', chartObject.decimalPlaces) +
+        decimalPointFormat('point.y', decimalPlaces) +
         chartObject.number_format.suffix +
         '</b><br/>'
     };


### PR DESCRIPTION
Set decimal places to be 2 when not defined in component charts

**Resolves:** https://trello.com/c/VyspZX5I/1741-when-you-hover-over-some-charts-the-figures-that-appear-have-6-decimal-places-after-them

**Before:**
<img width="651" alt="Screenshot 2020-04-07 at 12 23 24" src="https://user-images.githubusercontent.com/6704411/78663957-f9ece400-78ca-11ea-9f4b-db5fd0b8bd7e.png">

**After:**
<img width="407" alt="Screenshot 2020-04-07 at 13 22 32" src="https://user-images.githubusercontent.com/6704411/78668627-e5ace500-78d2-11ea-90c1-3b12798adb01.png">
