### PR TITLE
Combine published dashboards

### DIFF
--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -30,8 +30,9 @@ def index():
 @dashboard_blueprint.route("/whats-new")
 @login_required
 def whats_new():
+    data = get_published_dashboard_data()
     pages_by_years_and_months = get_published_measures_by_years_and_months()
-    return render_template("dashboards/whats_new.html", pages_by_years_and_months=pages_by_years_and_months)
+    return render_template("dashboards/whats_new.html", pages_by_years_and_months=pages_by_years_and_months, data=data)
 
 
 @dashboard_blueprint.route("/published")

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -275,8 +275,11 @@ def build_dashboards(build_dir):
     write_html(file_path, content)
 
     # New and updated pages
+    data = get_published_dashboard_data()
     pages_by_years_and_months = get_published_measures_by_years_and_months()
-    content = render_template("dashboards/whats_new.html", pages_by_years_and_months=pages_by_years_and_months)
+    content = render_template(
+        "dashboards/whats_new.html", pages_by_years_and_months=pages_by_years_and_months, data=data
+    )
     file_path = os.path.join(dashboards_dir, "whats-new/index.html")
     write_html(file_path, content)
 

--- a/application/templates/dashboards/index.html
+++ b/application/templates/dashboards/index.html
@@ -34,11 +34,6 @@
       <p class="govuk-body govuk-!-font-size-16">What’s being worked on and coming up next</p>
     </div>
 
-    <div class="govuk-grid-column-one-third">
-      <h2><a href="{{ url_for('dashboards.published') }}" class="govuk-link govuk-heading-s govuk-!-margin-bottom-1">Pages published by week</a></h2>
-      <p class="govuk-body govuk-!-font-size-16">A week-by-week count of new and updated pages</p>
-    </div>
-
   </div>
 
   <div class="govuk-grid-row govuk-!-margin-bottom-5">

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -8,7 +8,13 @@
   ]
 %}
 
+
 {% block pageTitle %}Published pages{% endblock %}
+
+{% block headEnd %}
+    {{ super() }}
+    <meta name="robots" content="noindex">
+{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/application/templates/dashboards/whats_new.html
+++ b/application/templates/dashboards/whats_new.html
@@ -10,21 +10,44 @@
 {% block pageTitle %}New and updated pages for Ethnicity facts and figures - GOV.UK{% endblock %}
 
 {% block content %}
-    <h1 class="govuk-heading-xl">New and updated pages</h1>
+<h1 class="govuk-heading-xl">New and updated pages</h1>
 
-    <p class="govuk-body">All pages published on Ethnicity facts and figures, starting with the most recent.</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">All pages published on Ethnicity facts and figures, starting with the most recent. You can also find out what we have <a href="{{ url_for('dashboards.planned_pages') }}">planned and in
+      progress</a>.</p>
+  </div>
+</div>
 
-    {% for year, months in pages_by_years_and_months|dictsort(reverse=True) %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <div class="eff-stat eff-!-background-light-blue">
+      <span class="eff-stat__figure">{{ data.number_of_publications }}</span>
+      <span class="eff-stat__description">{% if data.number_of_publications == 1 %}Page{% else %}Pages{% endif %}</span>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="eff-stat eff-!-background-turquoise">
+      <span class="eff-stat__figure">{{ data.number_of_major_updates }}</span>
+      <span
+            class="eff-stat__description">{% if data.number_of_major_updates == 1 %}Update{% else %}Updates{% endif %}</span>
+    </div>
+  </div>
+</div>
 
-      <h2 class="govuk-heading-l">{{ year }}</h2>
 
-      {% for month, pages in months|dictsort(reverse=True) %}
+{% for year, months in pages_by_years_and_months|dictsort(reverse=True) %}
 
-        <h3 class="govuk-heading-m">{{ month.strftime("%B") }}</h3>
+<h2 class="govuk-heading-l">{{ year }}</h2>
 
-        <ol class="govuk-!-margin-bottom-5 govuk-list">
-          {% for page in pages %}
-            <li><a class="govuk-link" href="{{ url_for(
+{% for month, pages in months|dictsort(reverse=True) %}
+
+<h3 class="govuk-heading-m">{{ month.strftime("%B") }}</h3>
+
+<ol class="govuk-!-margin-bottom-5 govuk-list">
+  {% for page in pages %}
+  <li><a class="govuk-link"
+       href="{{ url_for(
               'static_site.measure_version',
               topic_slug=page.measure.subtopic.topic.slug,
               subtopic_slug=page.measure.subtopic.slug,
@@ -32,19 +55,20 @@
               version='latest'
             ) }}">
 
-              {{ page.title }}</a>
+      {{ page.title }}</a>
 
-              <span class="govuk-!-font-size-16">
-              {% if page.version == '1.0' %}
-                <strong class="new-tag govuk-!-margin-left-2">New</strong>
-              {% endif %}
+    <span class="govuk-!-font-size-16">
+      {% if page.version == '1.0' %}
+      <strong class="new-tag govuk-!-margin-left-2">New</strong>
+      {% endif %}
 
-              <span class="item-date govuk-!-margin-left-2 eff-!-grey-1">{{ page.published_at | format_friendly_short_date }}</span>
-              </span>
-            </li>
-          {% endfor %}
-          </ol>
+      <span
+            class="item-date govuk-!-margin-left-2 eff-!-grey-1">{{ page.published_at | format_friendly_short_date }}</span>
+    </span>
+  </li>
+  {% endfor %}
+</ol>
 
-      {% endfor %}
-    {% endfor %}
+{% endfor %}
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
**Resolves:** https://trello.com/c/ydHS5gKv/2284-combine-whats-new-and-published-dashboards-3


**Before:**
--------------------------------------------------------------------------------------

<img width="980" alt="Screenshot 2020-04-27 at 12 50 01" src="https://user-images.githubusercontent.com/6704411/80369137-ac3e1880-8885-11ea-974a-9316dfcc904c.png">
<img width="708" alt="Screenshot 2020-04-27 at 12 49 42" src="https://user-images.githubusercontent.com/6704411/80369141-ad6f4580-8885-11ea-9da3-2d6c40caf2c4.png">



**After**
--------------------------------------------------------------------------------------
<img width="1008" alt="Screenshot 2020-04-27 at 12 50 12" src="https://user-images.githubusercontent.com/6704411/80369157-b5c78080-8885-11ea-9781-0fb75bf69a83.png">
<img width="756" alt="Screenshot 2020-04-27 at 12 49 35" src="https://user-images.githubusercontent.com/6704411/80369161-b7914400-8885-11ea-919a-267df9d67290.png">
