### PR TITLE
Remove links to dashboard

### DIFF
--- a/application/templates/static_site/index.html
+++ b/application/templates/static_site/index.html
@@ -128,28 +128,6 @@ outcomes for people in the UK, produced by the Race Disparity Audit{% endblock %
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-4" />
 
-    <h2 class="govuk-heading-m">Updates</h2>
-
-    <ul class="govuk-list">
-      <div class="govuk-grid-row">
-        <li>
-          <div class="govuk-grid-column-one-third">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link"
-                 href="{{ url_for('dashboards.whats_new') }}">New and updated pages</a></h3>
-            <p class="govuk-body">Recent updates to the website</p>
-          </div>
-        </li>
-
-        <li>
-          <div class="govuk-grid-column-one-third">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link"
-                 href="{{ url_for('dashboards.planned_pages') }}">Planned pages</a></h3>
-            <p class="govuk-body">What’s being worked on and coming up next</p>
-          </div>
-        </li>
-      </div>
-    </ul>
-
     {% include 'static_site/_newsletter-sign-up.html' %}
 
   </div>


### PR DESCRIPTION
Resolves: https://trello.com/c/zn55DnBr/2430-remove-links-to-dashboards-on-homepage