### PR TITLE
Fix focus on elements and page titles

### DIFF
--- a/application/src/js/chartbuilder/chartbuilder.js
+++ b/application/src/js/chartbuilder/chartbuilder.js
@@ -60,6 +60,7 @@ $(document).ready(function () {
             document.getElementById('data-panel').classList.add('hidden')
             document.getElementById('edit-panel').classList.remove('hidden')
             document.getElementById('builder-title').textContent = 'Format and view chart'
+            document.title = 'Format and view chart'
 
             data_text_area.classList.remove('govuk-textarea--error')
             data_form_group.classList.remove('govuk-form-group--error')
@@ -84,6 +85,7 @@ $(document).ready(function () {
         document.getElementById('data-panel').classList.remove('hidden')
         document.getElementById('edit-panel').classList.add('hidden')
         document.getElementById('builder-title').textContent = 'Create a chart'
+        document.title = 'Create a chart'
     }
 
     function cancelEditData(evt) {
@@ -91,6 +93,7 @@ $(document).ready(function () {
         document.getElementById('data-panel').classList.add('hidden')
         document.getElementById('edit-panel').classList.remove('hidden')
         document.getElementById('builder-title').textContent = 'Format and view chart'
+        document.title = 'Format and view chart'
         document.getElementById('errors_container').classList.add('hidden');
         document.getElementById('data-missing').classList.add('hidden');
     }

--- a/application/src/js/tablebuilder/tablebuilder.js
+++ b/application/src/js/tablebuilder/tablebuilder.js
@@ -91,6 +91,7 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('data-panel').classList.add('hidden')
             document.getElementById('edit-panel').classList.remove('hidden')
             document.getElementById('builder-title').innerHTML = 'Format and view table';
+            document.title = 'Format and view table';
 
             data_text_area.classList.remove('govuk-textarea--error')
             data_form_group.classList.remove('govuk-form-group--error')
@@ -117,6 +118,7 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('data_text_area').focus()
         document.getElementById('edit-panel').classList.add('hidden')
         document.getElementById('builder-title').innerHTML = 'Create a table';
+        document.title = 'Create a table';
     }
 
     function cancelEditData(evt) {
@@ -124,6 +126,7 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('data-panel').classList.add('hidden')
         document.getElementById('edit-panel').classList.remove('hidden')
         document.getElementById('builder-title').innerHTML = 'Format and view table';
+        document.title = 'Format and view table';
         document.getElementById('errors_container').classList.add('hidden');
         document.getElementById('data-missing').classList.add('hidden');
     }

--- a/application/src/sass/components/_header_search_box.scss
+++ b/application/src/sass/components/_header_search_box.scss
@@ -145,7 +145,10 @@ https://github.com/alphagov/static/blob/99f41342b66cde279f231fdc0834fac493260158
 
   &.focus,
   &:focus {
-    outline-offset: -3px;
+      border-width: 0;
+      box-shadow: inset 0 0 0 4px #ffdd00;
+      outline: 3px solid #ffdd00;
+      outline-offset: 0;
   }
 }
 
@@ -182,6 +185,9 @@ https://github.com/alphagov/static/blob/99f41342b66cde279f231fdc0834fac493260158
 
   &.focus,
   &:focus {
-    outline-offset: -3px;
+    border-width: 0;
+    box-shadow: inset 0 0 0 4px #ffdd00;
+    outline: 3px solid #ffdd00;
+    outline-offset: 0;
   }
 }

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -35,8 +35,7 @@
 {% endblock %}
 
 
-{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} chart –
-{{ measure_version.title }}: {{ dimension.title }}{% endblock %}
+{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} chart{% endblock %}
 
 
 {% block content %}

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -11,7 +11,7 @@
   ]
 %}
 
-{% block pageTitle %}Create dimension{% endblock %}
+{% block pageTitle %}Create new dimension{% endblock %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -20,7 +20,7 @@
   </script>
 {% endblock %}
 
-{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} table – {{ measure_version.title }}: {{ dimension.title }}{% endblock %}
+{% block pageTitle %}{% if settings_and_source_data %}Edit{% else %}Create a{% endif %} table{% endblock %}
 
 <!-- On save success display back to link -->
 {% block displayNavigationLinkOnMessage %}

--- a/application/templates/cms/edit_measure_version.html
+++ b/application/templates/cms/edit_measure_version.html
@@ -11,7 +11,7 @@
 {% set form_disabled = false if (new is defined and new) else measure_version.status != 'DRAFT' %}
 
 {% block bodyClasses %}rd_cms{% endblock %}
-{% block pageTitle %}{{ measure_version.title if measure_version.title is defined and measure_version.title else "Create a measure" }}{% endblock %}
+{% block pageTitle %}{{ measure_version.title if measure_version.title is defined and measure_version.title else "Create page" }}{% endblock %}
 
 {% block content %}
 <form method="POST"
@@ -139,7 +139,13 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">{% if new %}Create{% else %}Edit{% endif %} page</h1>
+            {% if new %}
+            <h1 class="govuk-heading-xl">Create page</h1>
+
+            {% else %}
+                <h1 class="govuk-heading-xl">{{ measure_version.title }}</h1>
+                <h2 id="edit_page_title" class="govuk-heading-l">Edit page</h2>
+            {% endif %}
 
             <!-- Select template version -->
             <div class="govuk-form-group">

--- a/application/templates/dashboards/whats_new.html
+++ b/application/templates/dashboards/whats_new.html
@@ -19,7 +19,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">All pages published on Ethnicity facts and figures, starting with the most recent. You can also find out what we have <a href="{{ url_for('dashboards.planned_pages') }}">planned and in
+    <p class="govuk-body">All pages published on Ethnicity facts and figures, starting with the most recent. You can also find out what we have <a class="govuk-link" href="{{ url_for('dashboards.planned_pages') }}">planned and in
       progress</a>.</p>
   </div>
 </div>

--- a/tests/application/cms/test_models.py
+++ b/tests/application/cms/test_models.py
@@ -61,7 +61,7 @@ class TestDimensionModel:
         resp = test_app_client.post(url, follow_redirects=False)
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
-        assert page.find("title").string == "Error: Create dimension"
+        assert page.find("title").string == "Error: Create new dimension"
 
     @flaky(max_runs=10, min_passes=1)
     def test_update_dimension_with_valid_data(self, test_app_client, logged_in_rdu_user):

--- a/tests/application/cms/test_views.py
+++ b/tests/application/cms/test_views.py
@@ -388,7 +388,8 @@ def test_view_edit_measure_page(test_app_client, logged_in_rdu_user, stub_measur
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
-    assert page.h1.text.strip() == "Edit page"
+    edit_page_title = page.find("h2", attrs={"id": "edit_page_title"})
+    assert edit_page_title.text.strip() == "Edit page"
 
     title = page.find("input", attrs={"id": "title"})
     assert title
@@ -485,7 +486,8 @@ def test_view_edit_measure_page_for_minor_update_shows_data_correction_radio(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
-    assert page.h1.text.strip() == "Edit page"
+    edit_page_title = page.find("h2", attrs={"id": "edit_page_title"})
+    assert edit_page_title.text.strip() == "Edit page"
 
     update_corrects_data_mistake = page.find("div", id="update_corrects_data_mistake")
     if should_show_data_correction_radio:
@@ -868,7 +870,8 @@ def test_copy_measure_page(test_app_client, logged_in_dev_user):
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
-    assert page.find("h1").text == "Edit page"
+    edit_page_title = page.find("h2", attrs={"id": "edit_page_title"})
+    assert edit_page_title.text.strip() == "Edit page"
     assert page.find("input", attrs={"name": "title"})["value"] == "COPY OF Test Measure Page"
 
 


### PR DESCRIPTION
Resolves:
- https://trello.com/c/iOnd9Z3E/2466-dac-focus-indicator
- https://trello.com/c/mg2AzEp8/2468-dac-page-titles-issue2

After:
<img width="632" alt="Screenshot 2020-07-24 at 12 19 38" src="https://user-images.githubusercontent.com/6704411/88388157-d8493700-cdab-11ea-8c7c-0ddf24ec37ee.png">
<img width="367" alt="Screenshot 2020-07-24 at 12 21 23" src="https://user-images.githubusercontent.com/6704411/88388159-d8e1cd80-cdab-11ea-81f7-1c4f23eeb394.png">
