### PR TITLE
3929-newsletter-page-update

### DIFF
--- a/application/templates/static_site/static_pages/newsletter.html
+++ b/application/templates/static_site/static_pages/newsletter.html
@@ -66,6 +66,9 @@
 <ul class="govuk-list govuk-list--bullet">
   
   <li><a class="govuk-link" rel="external"
+       href="https://mailchi.mp/53a0fd43e4d1/news-from-the-rdu-inclusive-britain-updatesfamily-review-part-1-published">August 2022</a></li>
+
+  <li><a class="govuk-link" rel="external"
        href="https://mailchi.mp/4cb226231cab/news-from-the-rdu-ethnicity-data-standards-consultation-more-inclusive-britain-updates">July 2022</a></li>
           
 <li><a class="govuk-link" rel="external"
@@ -79,10 +82,6 @@
 
 <li><a class="govuk-link" rel="external"
            href="https://us17.campaign-archive.com/?u=d3d03c697590f8350546553f6&id=8d8ca391e4">March 2022</a></li>
-
-<li><a class="govuk-link" rel="external"
-        href="https://us17.campaign-archive.com/?u=d3d03c697590f8350546553f6&id=747e409eb9">February 2022</a></li>
-
        
     </ul>
 


### PR DESCRIPTION
Added a link to the August 2022 newsletter, and removed the link to the February 2022 newsletter.

Trello card: https://trello.com/c/3yGsJzVK