### PR TITLE
3984-update-newsletter-page

### DIFF
--- a/application/templates/static_site/static_pages/newsletter.html
+++ b/application/templates/static_site/static_pages/newsletter.html
@@ -65,6 +65,9 @@
 
 <ul class="govuk-list govuk-list--bullet">
   
+   <li><a class="govuk-link" rel="external"
+       href="https://mailchi.mp/5236c036e326/news-from-the-rdu-new-and-updated-pages-inclusive-britain-updates">September 2022</a></li>
+
   <li><a class="govuk-link" rel="external"
        href="https://mailchi.mp/53a0fd43e4d1/news-from-the-rdu-inclusive-britain-updatesfamily-review-part-1-published">August 2022</a></li>
 
@@ -79,9 +82,6 @@
   
 <li><a class="govuk-link" rel="external"
        href="https://us17.campaign-archive.com/?u=d3d03c697590f8350546553f6&id=8625833081">April 2022</a></li>
-
-<li><a class="govuk-link" rel="external"
-           href="https://us17.campaign-archive.com/?u=d3d03c697590f8350546553f6&id=8d8ca391e4">March 2022</a></li>
        
     </ul>
 
@@ -90,25 +90,18 @@
     <p class="govuk-body">You can also:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>read our <a class="govuk-link"
-           href="{{ url_for('static_site.blog_posts') }}">blog posts</a></li>
-      <li>see the <a class="govuk-link"
-           href="{{ url_for('dashboards.whats_new') }}">new and updated pages</a> we’ve published recently</li>
-      <li>go to the <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/government/organisations/race-disparity-unit">Race Disparity Unit</a> page and
-        sign up to <a class="govuk-link" rel="external"
+            <li>see the <a class="govuk-link"
+           href="{{ url_for('dashboards.whats_new') }}">new and updated pages</a> we have published on Ethnicity facts and figures</li>
+      <li>visit the <a class="govuk-link" rel="external"
+           href="https://www.gov.uk/government/organisations/race-disparity-unit">Race Disparity Unit page on GOV.UK</a> and
+        sign up for <a class="govuk-link" rel="external"
            href="https://www.gov.uk/email-signup?link=/government/organisations/race-disparity-unit">email updates</a>
       </li>
-    </ul>
+       <li>see updates on the government's <a class="govuk-link" rel="external"
+           href="https://www.gov.uk/guidance/inclusive-britain-action-plan-updates">Inclusive Britain action plan</a></li>
+            <li>see our <a class="govuk-link" rel="external"
+           href="https://www.gov.uk/government/collections/ethnicity-data-methods-and-quality-reports">data quality resources for ethnicity data</a> (including methods and quality reports, and blog posts)</li>
 
-    <p class="govuk-body">You might also be interested in:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Inclusive Britain: <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/government/publications/inclusive-britain-action-plan-government-response-to-the-commission-on-race-and-ethnic-disparities">government response to the Commission on Race and Ethnic Disparities</a></li>
-      <li>the <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/government/collections/windrush-cross-government-working-group">Windrush
-          cross-government working group</a></li>
     </ul>
 
   </div>

--- a/application/templates/static_site/static_pages/newsletter.html
+++ b/application/templates/static_site/static_pages/newsletter.html
@@ -19,7 +19,7 @@
 
     <h1 class="govuk-heading-xl">Newsletter</h1>
 
-    <p class="govuk-body">The Race Disparity Unit sends an email to subscribers at the start of every month.</p>
+    <p class="govuk-body">The Race Disparity Unit (RDU) sends an email to subscribers at the start of every month.</p>
 
     <p class="govuk-body">The newsletter includes details of:</p>
 
@@ -87,20 +87,18 @@
 
     <h2 class="govuk-heading-m">Get other updates</h2>
 
-    <p class="govuk-body">You can also:</p>
+    <p class="govuk-body">You can also see:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-            <li>see the <a class="govuk-link"
-           href="{{ url_for('dashboards.whats_new') }}">new and updated pages</a> we have published on Ethnicity facts and figures</li>
-      <li>visit the <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/government/organisations/race-disparity-unit">Race Disparity Unit page on GOV.UK</a> and
-        sign up for <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/email-signup?link=/government/organisations/race-disparity-unit">email updates</a>
+            <li><a class="govuk-link"
+           href="{{ url_for('dashboards.whats_new') }}">new and updated pages</a> on Ethnicity facts and figures</li>
+      <li>the <a class="govuk-link" rel="external"
+           href="https://www.gov.uk/government/organisations/race-disparity-unit">RDU's page on GOV.UK</a>
       </li>
-       <li>see updates on the government's <a class="govuk-link" rel="external"
+       <li>updates on the government's <a class="govuk-link" rel="external"
            href="https://www.gov.uk/guidance/inclusive-britain-action-plan-updates">Inclusive Britain action plan</a></li>
-            <li>see our <a class="govuk-link" rel="external"
-           href="https://www.gov.uk/government/collections/ethnicity-data-methods-and-quality-reports">data quality resources for ethnicity data</a> (including methods and quality reports, and blog posts)</li>
+            <li>our <a class="govuk-link" rel="external"
+           href="https://www.gov.uk/government/collections/ethnicity-data-methods-and-quality-reports">blog posts and methods and quality reports</a></li>
 
     </ul>
 


### PR DESCRIPTION
[https://trello.com/c/N5wrHrAW](https://trello.com/c/N5wrHrAW).

Added link to latest newsletter.
Removed March newsletter.
Added link to Inclusive Britain action plan updates page on GOV.UK.